### PR TITLE
Sort - Chapters/topics/tests, Maintain tests dropdown state, API timeout

### DIFF
--- a/internal/dto/chapter_dto.go
+++ b/internal/dto/chapter_dto.go
@@ -1,15 +1,5 @@
 package dto
 
-import (
-	"github.com/avantifellows/nex-gen-cms/internal/constants"
-)
-
-type SortState struct {
-	Column string
-	Order  constants.SortOrder
-}
-
 type TopicsData struct {
-	ChapterId       string
-	TopicsSortState SortState
+	ChapterId string
 }

--- a/internal/dto/home_dto.go
+++ b/internal/dto/home_dto.go
@@ -3,14 +3,13 @@ package dto
 import "github.com/avantifellows/nex-gen-cms/internal/models"
 
 type HomeData struct {
-	CurriculumID     int16
-	GradeID          int8
-	SubjectID        int8
-	ChapterPtr       *models.Chapter
-	ChapterSortState SortState
-	TestPtr          *models.Test
-	ProblemPtr       *models.Problem
-	Problems         map[int]*models.Problem // key = Problem ID
-	TopicPtr         *models.Topic
-	TestRule         *models.TestRule
+	CurriculumID int16
+	GradeID      int8
+	SubjectID    int8
+	ChapterPtr   *models.Chapter
+	TestPtr      *models.Test
+	ProblemPtr   *models.Problem
+	Problems     map[int]*models.Problem // key = Problem ID
+	TopicPtr     *models.Topic
+	TestRule     *models.TestRule
 }

--- a/internal/handlers/topic_handler.go
+++ b/internal/handlers/topic_handler.go
@@ -127,10 +127,10 @@ func (h *TopicsHandler) UpdateTopic(responseWriter http.ResponseWriter, request 
 	local_repo.ExecuteTemplate(updateSuccessTemplate, responseWriter, "Topic", nil)
 }
 
-func sortTopics(topics []*models.Topic) {
+func sortTopics(topics []*models.Topic, sortColumn string, sortOrder string) {
 	slices.SortStableFunc(topics, func(t1, t2 *models.Topic) int {
 		var sortResult int
-		switch topicSortState.Column {
+		switch sortColumn {
 		case "1":
 			t1Suffix := utils.ExtractNumericSuffix(t1.Code)
 			t2Suffix := utils.ExtractNumericSuffix(t2.Code)
@@ -147,7 +147,7 @@ func sortTopics(topics []*models.Topic) {
 			sortResult = 0
 		}
 
-		if topicSortState.Order == constants.SortOrderDesc {
+		if constants.SortOrder(sortOrder) == constants.SortOrderDesc {
 			sortResult = -sortResult
 		}
 		return sortResult

--- a/internal/repositories/remote/api_repository.go
+++ b/internal/repositories/remote/api_repository.go
@@ -22,7 +22,7 @@ func NewAPIRepository() *APIRepository {
 func (r *APIRepository) CallAPI(urlEndPoint string, method string, body any) ([]byte, error) {
 	// Create an HTTP client
 	client := &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: time.Second * 30,
 	}
 
 	var reqBody io.Reader

--- a/web/html/chapters.html
+++ b/web/html/chapters.html
@@ -1,34 +1,25 @@
 {{ define "content" }}
 <div>
-    <div class="shadow-md my-6 overflow-x-auto">
+    <div class="shadow-md my-6 overflow-x-auto" hx-ext="table-sort" data-sort-scope="chapters">
         <table class="min-w-full bg-white">
             <thead>
                 <tr class="bg-gray-200 text-gray-600 text-sm">
                     <th class="py-4 px-6 text-left">
-                        <a href="#" hx-get="/chapters?sortColumn=1" hx-target="body"
+                        <a href="#" hx-get="/chapters" hx-target="body" hx-on:click="updateTableSortState('1', 'chapters');"
                             hx-on::before-request="sessionStorage.removeItem(window.CHAPTERS_LOADED_KEY)">
-                            Code <i class="fas 
-                            {{ if eq .ChapterSortState.Column "1" }} {{ if eq .ChapterSortState.Order "asc" }}
-                                fa-sort-up {{ else if eq .ChapterSortState.Order "desc" }} fa-sort-down {{ else }}
-                                fa-sort {{ end }} {{ else }} fa-sort {{ end }}"></i>
+                            Code <i class="fas fa-sort"></i>
                         </a>
                     </th>
                     <th class="px-6 text-left">
-                        <a href="#" hx-get="/chapters?sortColumn=2" hx-target="body"
+                        <a href="#" hx-get="/chapters" hx-target="body" hx-on:click="updateTableSortState('2', 'chapters');"
                             hx-on::before-request="sessionStorage.removeItem(window.CHAPTERS_LOADED_KEY)">
-                            Name <i class="fas 
-                            {{ if eq .ChapterSortState.Column "2" }} {{ if eq .ChapterSortState.Order "asc" }}
-                                fa-sort-up {{ else if eq .ChapterSortState.Order "desc" }} fa-sort-down {{ else }}
-                                fa-sort {{ end }} {{ else }} fa-sort {{ end }}"></i>
+                            Name <i class="fas fa-sort"></i>
                         </a>
                     </th>
                     <th class="px-6 text-center">
-                        <a href="#" hx-get="/chapters?sortColumn=3" hx-target="body"
+                        <a href="#" hx-get="/chapters" hx-target="body" hx-on:click="updateTableSortState('3', 'chapters');"
                             hx-on::before-request="sessionStorage.removeItem(window.CHAPTERS_LOADED_KEY)">
-                            Topics <i class="fas
-                            {{ if eq .ChapterSortState.Column "3" }} {{ if eq .ChapterSortState.Order "asc" }}
-                                fa-sort-up {{ else if eq .ChapterSortState.Order "desc" }} fa-sort-down {{ else }}
-                                fa-sort {{ end }} {{ else }} fa-sort {{ end }}"></i>
+                            Topics <i class="fas fa-sort"></i>
                         </a>
                     </th>
                     <th class="px-6 text-center">Chapter Tests</th>

--- a/web/html/home.html
+++ b/web/html/home.html
@@ -16,6 +16,7 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
     </script>
     <script src="/web/static/js/constants.js"></script>
+    <script src="/web/static/js/table-sort.js"></script>
     <script>
         function afterDropdownReq(dropdown, selectedValue) {
             /* 

--- a/web/html/tests.html
+++ b/web/html/tests.html
@@ -1,5 +1,5 @@
 {{ define "content" }}
-<div>
+<div hx-ext="table-sort" data-sort-scope="tests">
     <div class="flex justify-between items-center mb-4">
 
         <!-- hx-trigger="onLoaded from:(#curriculum-dropdown, #grade-dropdown)" is added to load tests on 
@@ -30,32 +30,32 @@
                 <thead>
                     <tr class="bg-gray-200 text-gray-600 text-sm">
                         <th class="py-4 px-6 text-left">
-                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateSortState(event, '1');">
+                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateTableSortState('1', 'tests');">
                                 Code <i class="fas fa-sort"></i>
                             </a>
                         </th>
                         <th class="px-6 text-left">
-                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateSortState(event, '2');">
+                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateTableSortState('2', 'tests');">
                                 Name <i class="fas fa-sort"></i>
                             </a>
                         </th>
                         <th class="px-6 text-center">
-                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateSortState(event, '3');">
+                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateTableSortState('3', 'tests');">
                                 # of questions <i class="fas fa-sort"></i>
                             </a>
                         </th>
                         <th class="px-6 text-center">
-                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateSortState(event, '4');">
+                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateTableSortState('4', 'tests');">
                                 Marks <i class="fas fa-sort"></i>
                             </a>
                         </th>
                         <th class="px-6 text-center">
-                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateSortState(event, '5');">
+                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateTableSortState('5', 'tests');">
                                 Duration <i class="fas fa-sort"></i>
                             </a>
                         </th>
                         <th class="px-6 text-center">
-                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateSortState(event, '6');">
+                            <a href="#" hx-get="/tests" hx-target="body" hx-on:click="updateTableSortState('6', 'tests');">
                                 Set <i class="fas fa-sort"></i>
                             </a>
                         </th>
@@ -72,120 +72,60 @@
 </div>
 
 <script>
+    (function () {
+        htmx.defineExtension('testsLoader', {
+            onEvent: function (name, event) {
+                if (name === "htmx:afterProcessNode") {
+                    restoreState();
 
-    // Ensure the script is executed only once (event listener is attached and constants are declared only once)
-    if (!window.scriptExecutedOnce) {
-        window.scriptExecutedOnce = true;
+                } else if (name === "htmx:beforeRequest") {
+                    const requestPath = event.detail.elt.getAttribute("hx-get");
 
-        document.body.addEventListener('htmx:load', function () {
-
-            // Function to restore tests tab state (testtype dropdown, sort) and trigger HTMX request
-            function restoreState() {
-                const dropdown = document.getElementById('testtype-dropdown');
-                if (!dropdown) return;
-
-                const storedTesttype = sessionStorage.getItem('selectedTesttype');
-
-                if (storedTesttype && dropdown.value !== storedTesttype) {
-                    // Set the dropdown value
-                    dropdown.value = storedTesttype;
-                    updateSortIcons(sessionStorage.getItem(TESTS_SORT_COLUMN), sessionStorage.getItem(TESTS_SORT_ORDER));
-
-                    // Trigger native change event which should activate HTMX
-                    htmx.trigger(dropdown, 'change');
-                }
-            }
-
-            restoreState();
-        });
-
-        const TESTS_SORT_COLUMN = "testsSortColumn";
-        const TESTS_SORT_ORDER = "testsSortOrder";
-
-        function updateSortState(event, column) {
-            // Retrieve previous sort state from sessionStorage
-            let previousColumn = sessionStorage.getItem(TESTS_SORT_COLUMN);
-            let previousOrder = sessionStorage.getItem(TESTS_SORT_ORDER);
-
-            let newOrder = "asc"; // Default to ascending order
-            if (previousColumn === column) {
-                newOrder = previousOrder === "asc" ? "desc" : "asc";
-            }
-
-            // Store new state
-            sessionStorage.setItem(TESTS_SORT_COLUMN, column);
-            sessionStorage.setItem(TESTS_SORT_ORDER, newOrder);
-        }
-
-        function updateSortIcons(column, order) {
-            // Reset all icons
-            document.querySelectorAll("th i.fas").forEach(icon => {
-                icon.classList.remove("fa-sort-up", "fa-sort-down");
-                icon.classList.add("fa-sort");
-            });
-
-            // Find the correct header and update its icon
-            document.querySelectorAll("th").forEach(th => {
-                let link = th.querySelector("a");
-                if (link && link.getAttribute("hx-on:click")?.includes(column)) {
-                    let icon = th.querySelector("i.fas");
-                    if (icon) {
-                        icon.classList.remove("fa-sort");
-                        icon.classList.add(order === "asc" ? "fa-sort-up" : "fa-sort-down");
-                    }
-                }
-            });
-        }
-
-        document.body.addEventListener('htmx:configRequest', function (event) {
-            if (event.detail.path === "/api/tests") {
-                // Get sessionStorage values
-                let sortColumn = sessionStorage.getItem(TESTS_SORT_COLUMN);
-                let sortOrder = sessionStorage.getItem(TESTS_SORT_ORDER);
-                if (sortColumn) {
-                    // Add them to the request parameters
-                    event.detail.parameters.sortColumn = sortColumn;
-                    event.detail.parameters.sortOrder = sortOrder;
-                }
-            }
-        });
-    }
-
-    htmx.defineExtension('testsLoader', {
-        onEvent: function (name, event) {
-            if (name === "htmx:beforeRequest") {
-                const requestPath = event.detail.elt.getAttribute("hx-get");
-
-                if (requestPath === "/api/tests") {
-                    if (sessionStorage.getItem(window.TESTS_LOADED_KEY) === "true") {
-                        console.log("Skipping /api/tests request because tests are already loaded.");
-                        event.preventDefault();
-
-                    } else {
-                        const params = event.detail.requestConfig.parameters;
-                        const curriculum = params["curriculum-dropdown"];
-                        const grade = params["grade-dropdown"];
-
-                        // if dropdown values are showing default value like "Loading...", then don't execute request
-                        if (!isInt(curriculum) || !isInt(grade)) {
-                            console.log("Skipping /api/tests request because dropdowns are not loaded yet.");
+                    if (requestPath === "/api/tests") {
+                        if (sessionStorage.getItem(window.TESTS_LOADED_KEY) === "true") {
+                            console.log("Skipping /api/tests request because tests are already loaded.");
                             event.preventDefault();
 
                         } else {
-                            const storedCurriculum = sessionStorage.getItem("selectedCurriculum");
-                            const storedGrade = sessionStorage.getItem("selectedGrade");
+                            const params = event.detail.requestConfig.parameters;
+                            const curriculum = params["curriculum-dropdown"];
+                            const grade = params["grade-dropdown"];
 
-                            if ((storedCurriculum && storedCurriculum !== curriculum) ||
-                                (storedGrade && storedGrade !== grade)) {
-                                // at least 1 dropdown value is 1 (1st item value) and its correct value is yet to be retained from sessionStorage
-                                console.log("Skipping /api/tests request because dropdowns values are not yet retained.");
+                            // if dropdown values are showing default value like "Loading...", then don't execute request
+                            if (!isInt(curriculum) || !isInt(grade)) {
+                                console.log("Skipping /api/tests request because dropdowns are not loaded yet.");
                                 event.preventDefault();
+
+                            } else {
+                                const storedCurriculum = sessionStorage.getItem("selectedCurriculum");
+                                const storedGrade = sessionStorage.getItem("selectedGrade");
+
+                                if ((storedCurriculum && storedCurriculum !== curriculum) ||
+                                    (storedGrade && storedGrade !== grade)) {
+                                    // at least 1 dropdown value is 1 (1st item value) and its correct value is yet to be retained from sessionStorage
+                                    console.log("Skipping /api/tests request because dropdowns values are not yet retained.");
+                                    event.preventDefault();
+                                }
                             }
                         }
                     }
                 }
             }
+        });
+
+        function restoreState() {
+            const dropdown = document.getElementById('testtype-dropdown');
+            if (!dropdown) return;
+
+            const storedTesttype = sessionStorage.getItem('selectedTesttype');
+
+            if (storedTesttype && dropdown.value !== storedTesttype) {
+                dropdown.value = storedTesttype;
+
+                // Trigger native change event so HTMX picks it up
+                htmx.trigger(dropdown, 'change');
+            }
         }
-    });
+    })();
 </script>
 {{ end }}

--- a/web/html/topics.html
+++ b/web/html/topics.html
@@ -1,26 +1,18 @@
 <div>
-    <div class="shadow-md overflow-x-auto">
+    <div class="shadow-md overflow-x-auto" hx-ext="table-sort" data-sort-scope="topics">
         <table class="min-w-full bg-white">
             <thead>
                 <tr class="bg-gray-200 text-gray-600 text-sm">
                     <th class="py-4 px-6 text-left">
-                        <a href="#" hx-get="/topics?id={{.ChapterId}}&sortColumn=1" hx-target="#subContent">
-                            Code <i class="fas 
-                            {{ if eq .TopicsSortState.Column "1" }}
-                                {{ if eq .TopicsSortState.Order "asc" }} fa-sort-up
-                                {{ else if eq .TopicsSortState.Order "desc" }} fa-sort-down
-                                {{ else }} fa-sort {{ end }}
-                            {{ else }} fa-sort {{ end }}"></i>
+                        <a href="#" hx-get="/topics?id={{.ChapterId}}" hx-target="#subContent"
+                            hx-on:click="updateTableSortState('1', 'topics');">
+                            Code <i class="fas fa-sort"></i>
                         </a>
                     </th>
                     <th class="px-6 text-left">
-                        <a href="#" hx-get="/topics?id={{.ChapterId}}&sortColumn=2" hx-target="#subContent">
-                            Name <i class="fas 
-                            {{ if eq .TopicsSortState.Column "2" }}
-                                {{ if eq .TopicsSortState.Order "asc" }} fa-sort-up
-                                {{ else if eq .TopicsSortState.Order "desc" }} fa-sort-down
-                                {{ else }} fa-sort {{ end }}
-                            {{ else }} fa-sort {{ end }}"></i>
+                        <a href="#" hx-get="/topics?id={{.ChapterId}}" hx-target="#subContent"
+                            hx-on:click="updateTableSortState('2', 'topics');">
+                            Name <i class="fas fa-sort"></i>
                         </a>
                     </th>
                     <th class="px-6 text-center">ICTs</th>

--- a/web/static/js/table-sort.js
+++ b/web/static/js/table-sort.js
@@ -1,0 +1,89 @@
+(function() {
+    htmx.defineExtension('table-sort', {
+        onEvent: function(name, evt) {
+            if (name === "htmx:afterProcessNode") {
+                let scope = evt.target.getAttribute("data-sort-scope");
+                if (!scope) return;
+
+                const SORT_COLUMN = scope + "SortColumn";
+                const SORT_ORDER = scope + "SortOrder";
+
+                restoreState(scope, SORT_COLUMN, SORT_ORDER);
+
+            } else if (name === "htmx:configRequest") {
+                // find the closest parent having data-sort-scope attribute
+                let scopeElement = evt.target.closest("[data-sort-scope]");
+                if (!scopeElement) return;
+
+                let scope = scopeElement.getAttribute("data-sort-scope");
+                if (!scope) return;
+
+                const SORT_COLUMN = scope + "SortColumn";
+                const SORT_ORDER = scope + "SortOrder";
+
+                if (evt.detail.path.startsWith("/api/" + scope)) {
+                    // Get sessionStorage values
+                    let sortColumn = sessionStorage.getItem(SORT_COLUMN);
+                    let sortOrder = sessionStorage.getItem(SORT_ORDER);
+                    if (sortColumn) {
+                        // Add them to the request parameters
+                        evt.detail.parameters.sortColumn = sortColumn;
+                        evt.detail.parameters.sortOrder = sortOrder;
+                    }
+                }
+            }
+        }
+    });
+
+    function restoreState(scope, colKey, orderKey) {
+        updateSortIcons(
+            sessionStorage.getItem(colKey),
+            sessionStorage.getItem(orderKey),
+            scope
+        );
+    }
+
+    function updateSortState(column, scope) {
+        const colKey = scope + "SortColumn";
+        const orderKey = scope + "SortOrder";
+
+        let previousColumn = sessionStorage.getItem(colKey);
+        let previousOrder = sessionStorage.getItem(orderKey);
+
+        let newOrder = "asc";
+        if (previousColumn === column) {
+            newOrder = previousOrder === "asc" ? "desc" : "asc";
+        }
+
+        sessionStorage.setItem(colKey, column);
+        sessionStorage.setItem(orderKey, newOrder);
+    }
+
+    function updateSortIcons(column, order, scope) {
+        if (!column || !order) return;
+
+        const table = document.querySelector(`[data-sort-scope="${scope}"]`);
+        if (!table) return;
+
+        // Reset icons inside this scope
+        table.querySelectorAll("th i.fas").forEach(icon => {
+            icon.classList.remove("fa-sort-up", "fa-sort-down");
+            icon.classList.add("fa-sort");
+        });
+
+        // Highlight active column
+        table.querySelectorAll("th").forEach(th => {
+            let link = th.querySelector("a");
+            if (link && link.getAttribute("hx-on:click")?.includes(column)) {
+                let icon = th.querySelector("i.fas");
+                if (icon) {
+                    icon.classList.remove("fa-sort");
+                    icon.classList.add(order === "asc" ? "fa-sort-up" : "fa-sort-down");
+                }
+            }
+        });
+    }
+
+    // Expose globally so HTMX can call it via hx-on:click
+    window.updateTableSortState = updateSortState;
+})();


### PR DESCRIPTION
1. Issue - Same chapter & topic sorting was visible on multiple windows/sessions, hence unable to sort differently on different browsers/sessions - Fixed by maintaining sort state on client side instead of server
2. Keep sorting code in separate js file which is used by chapters, topics and tests
3. Replaced htmx:load event listening for sort icon setting by htmx:afterProcessNode, because load is called as many times as there are number of rows, whereas sort icon setting is required only once per table reload
4. Listener To maintain test type dropdown state is called so many times & also it stays registered forever - Fixed by replacing a. htmx:load by htmx:afterProcessNode event b. document.body event listener by htmx extension
5. api timeout increased to 30 seconds