### PR TITLE
Edit test - Handle tests not having any problems; Store exam ids even if test rule is not defined for selected test & exam types

### DIFF
--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -60,7 +60,7 @@
     {{ $subtype := "null" }}
     {{ $curriculumGrades := "null" }}
 
-    {{ if .Problems }}
+    {{ if .TestPtr.ID }}
         <!-- edit test -->
         {{ $id = printf "%d" .TestPtr.ID }}
     {{ else }}
@@ -75,7 +75,7 @@
     an HTMX request, the before-request event is fired on the parent form, causing createTest(...) to be called 
     even for unrelated hx-get actions -->
     <form id="add-test-div" class="flex-1 p-5 overflow-auto bg-gray-50" hx-post="/create-test"
-        hx-on::before-request='if (event.target === this) createTest(event, {{$id}}, {{$subtype}}, {{$curriculumGrades}})'>
+        hx-on::before-request='if (event.target === this) createTest(event, {{$id}}, {{$subtype}}, {{$curriculumGrades}}, {{index .TestPtr.ExamIDs 0}})'>
 
         <label class="font-semibold">Select Test Code</label>
         <div class="flex items-center gap-2 mt-2 mb-2">
@@ -85,7 +85,7 @@
             {{ $seq := "" }}
             {{ $year := "" }}
 
-            {{if .Problems}}
+            {{if .TestPtr.Code}}
             {{ $parts := split .TestPtr.Code "-" }}
             {{ $program = index $parts 0 }}
             {{ $type = index $parts 1 }}
@@ -121,9 +121,9 @@
 
         <div class="flex items-center gap-2">
             <input id="test-name" type="text" placeholder="Test Name" class="p-2 border rounded flex-1"
-                value="{{if .Problems}}{{getName .TestPtr "en"}}{{end}}" 
+                value='{{if .TestPtr.Name}}{{.TestPtr.GetNameByLang "en"}}{{end}}' 
                 onchange="sessionStorage.setItem('selectedName', this.value);">
-            {{if .Problems}}
+            {{if .TestPtr.ID}}
             <select id="test-type-dropdown" class="p-2 border rounded flex-1">
                 {{ template "test_type_options" .TestPtr }}
             </select>
@@ -224,7 +224,7 @@
             {{ if .TestRule }}
                 {{ $duration = .TestRule.Config.Duration }}
             <!-- else for edit test case get it from test itself -->
-            {{ else if .Problems }}
+            {{ else }}
                 {{ $duration = .TestPtr.TypeParams.Duration }}
             {{ end }}
 
@@ -501,14 +501,14 @@
         }
     }
 
-    function createTest(event, testId, subtype, curriculumGrades) {
+    function createTest(event, testId, subtype, curriculumGrades, examId) {
         event.preventDefault();  // Cancel the request
 
         if (!validateFields()) {
             return false;
         }
 
-        const testJson = buildTestJson(subtype, curriculumGrades);
+        const testJson = buildTestJson(subtype, curriculumGrades, examId);
         if (testJson) {
             const url = curriculumGrades ? '/create-test' : `/update-test?id=${testId}`;
             const method = curriculumGrades ? 'POST' : 'PATCH';
@@ -559,7 +559,7 @@
         return true;
     }
 
-    function buildTestJson(subtype, curriculumGrades) {
+    function buildTestJson(subtype, curriculumGrades, examId) {
         const program = document.getElementById('program-dropdown').value;
         const testTypeCode = document.getElementById('test-type-code-dropdown').value;
         const testSequence = document.getElementById('test-sequence-dropdown').value;
@@ -672,7 +672,7 @@
             ],
             type: "test",
             subtype: subtype,
-            exam_ids: testRule ? [testRule.exam_id] : null,
+            exam_ids: [examId],
             skill_ids: Array.from(skillIdSet),
             type_params: {
                 duration: document.getElementById('duration').value,


### PR DESCRIPTION
1. Save exam id even if test rule is not defined for selected test & exam types
2. Handle edit tests for tests in which no problems are added while creating first - 
    a. Problems' existence checks replaced by required parameter's existence check in test object for add/edit test 
    b. Use test id check to find out if it is edit test scenario