### PR TITLE
🧩 Resources: topic & chapter resource lists supporting CRUD operations + move resource feature

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,7 +88,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.HandleFunc("/chapter", chaptersHandler.GetChapter)
 	muxHandler.HandleFunc("/topics", chaptersHandler.LoadTopics)
 	muxHandler.HandleFunc("/api/topics", chaptersHandler.GetTopics)
-	muxHandler.HandleFunc("/resources", chaptersHandler.LoadResources)
+	muxHandler.HandleFunc("/chapter/resources", chaptersHandler.LoadResources)
 
 	topicsHandler := appComponentPtr.TopicsHandler
 	muxHandler.HandleFunc("/add-topic", topicsHandler.OpenAddTopic)
@@ -97,6 +97,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.Handle("/edit-topic", middleware.RequireHTMX(http.HandlerFunc(topicsHandler.EditTopic)))
 	muxHandler.HandleFunc("/update-topic", topicsHandler.UpdateTopic)
 	muxHandler.HandleFunc("/topic", topicsHandler.GetTopic)
+	muxHandler.HandleFunc("/topic/resources", topicsHandler.LoadResources)
 
 	resourcesHandler := appComponentPtr.ResourcesHandler
 	muxHandler.HandleFunc("/add-resource", resourcesHandler.OpenAddResource)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -100,6 +100,8 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 
 	resourcesHandler := appComponentPtr.ResourcesHandler
 	muxHandler.HandleFunc("/api/resources", resourcesHandler.GetResources)
+	muxHandler.Handle("/edit-resource", middleware.RequireHTMX(http.HandlerFunc(resourcesHandler.EditResource)))
+	muxHandler.HandleFunc("/update-resource", resourcesHandler.UpdateResource)
 
 	conceptsHandler := appComponentPtr.ConceptsHandler
 	muxHandler.HandleFunc("/api/concepts", conceptsHandler.GetConcepts)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,6 +88,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.HandleFunc("/chapter", chaptersHandler.GetChapter)
 	muxHandler.HandleFunc("/topics", chaptersHandler.LoadTopics)
 	muxHandler.HandleFunc("/api/topics", chaptersHandler.GetTopics)
+	muxHandler.HandleFunc("/resources", chaptersHandler.LoadResources)
 
 	topicsHandler := appComponentPtr.TopicsHandler
 	muxHandler.HandleFunc("/add-topic", topicsHandler.OpenAddTopic)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,7 +89,6 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.HandleFunc("/topics", chaptersHandler.LoadTopics)
 	muxHandler.HandleFunc("/api/topics", chaptersHandler.GetTopics)
 	muxHandler.HandleFunc("/resources", chaptersHandler.LoadResources)
-	muxHandler.HandleFunc("/api/resources", appComponentPtr.ResourcesHandler.GetResources)
 
 	topicsHandler := appComponentPtr.TopicsHandler
 	muxHandler.HandleFunc("/add-topic", topicsHandler.OpenAddTopic)
@@ -98,6 +97,9 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.Handle("/edit-topic", middleware.RequireHTMX(http.HandlerFunc(topicsHandler.EditTopic)))
 	muxHandler.HandleFunc("/update-topic", topicsHandler.UpdateTopic)
 	muxHandler.HandleFunc("/topic", topicsHandler.GetTopic)
+
+	resourcesHandler := appComponentPtr.ResourcesHandler
+	muxHandler.HandleFunc("/api/resources", resourcesHandler.GetResources)
 
 	conceptsHandler := appComponentPtr.ConceptsHandler
 	muxHandler.HandleFunc("/api/concepts", conceptsHandler.GetConcepts)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,6 +89,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.HandleFunc("/topics", chaptersHandler.LoadTopics)
 	muxHandler.HandleFunc("/api/topics", chaptersHandler.GetTopics)
 	muxHandler.HandleFunc("/resources", chaptersHandler.LoadResources)
+	muxHandler.HandleFunc("/api/resources", appComponentPtr.ResourcesHandler.GetResources)
 
 	topicsHandler := appComponentPtr.TopicsHandler
 	muxHandler.HandleFunc("/add-topic", topicsHandler.OpenAddTopic)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,6 +102,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.HandleFunc("/api/resources", resourcesHandler.GetResources)
 	muxHandler.Handle("/edit-resource", middleware.RequireHTMX(http.HandlerFunc(resourcesHandler.EditResource)))
 	muxHandler.HandleFunc("/update-resource", resourcesHandler.UpdateResource)
+	muxHandler.HandleFunc("/archive-resource", resourcesHandler.ArchiveResource)
 
 	conceptsHandler := appComponentPtr.ConceptsHandler
 	muxHandler.HandleFunc("/api/concepts", conceptsHandler.GetConcepts)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,6 +99,8 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.HandleFunc("/topic", topicsHandler.GetTopic)
 
 	resourcesHandler := appComponentPtr.ResourcesHandler
+	muxHandler.HandleFunc("/add-resource", resourcesHandler.OpenAddResource)
+	muxHandler.HandleFunc("/create-resource", resourcesHandler.AddResource)
 	muxHandler.HandleFunc("/api/resources", resourcesHandler.GetResources)
 	muxHandler.Handle("/edit-resource", middleware.RequireHTMX(http.HandlerFunc(resourcesHandler.EditResource)))
 	muxHandler.HandleFunc("/update-resource", resourcesHandler.UpdateResource)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -106,6 +106,8 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.Handle("/edit-resource", middleware.RequireHTMX(http.HandlerFunc(resourcesHandler.EditResource)))
 	muxHandler.HandleFunc("/update-resource", resourcesHandler.UpdateResource)
 	muxHandler.HandleFunc("/archive-resource", resourcesHandler.ArchiveResource)
+	muxHandler.HandleFunc("/resources/move-resource", resourcesHandler.LoadMoveResources)
+	muxHandler.HandleFunc("/move-resource", resourcesHandler.MoveResource)
 
 	conceptsHandler := appComponentPtr.ConceptsHandler
 	muxHandler.HandleFunc("/api/concepts", conceptsHandler.GetConcepts)

--- a/di/app_component.go
+++ b/di/app_component.go
@@ -15,6 +15,7 @@ type AppComponent struct {
 	CssPathHandler     http.Handler
 	LoginHandler       *handlers.LoginHandler
 	ChaptersHandler    *handlers.ChaptersHandler
+	ResourcesHandler   *handlers.ResourcesHandler
 	TopicsHandler      *handlers.TopicsHandler
 	ConceptsHandler    *handlers.ConceptsHandler
 	CurriculumsHandler *handlers.CurriculumsHandler
@@ -34,6 +35,7 @@ func NewAppComponent() (*AppComponent, error) {
 
 	// Initialize service
 	chaptersService := services.NewService[models.Chapter](cacheRepo, apiRepo)
+	resourcesService := services.NewService[models.Resource](cacheRepo, apiRepo)
 	topicsService := services.NewService[models.Topic](cacheRepo, apiRepo)
 	conceptsService := services.NewService[models.Concept](cacheRepo, apiRepo)
 	curriculumsService := services.NewService[models.Curriculum](cacheRepo, apiRepo)
@@ -50,6 +52,7 @@ func NewAppComponent() (*AppComponent, error) {
 	cssPathHandler := http.StripPrefix("/web/", http.FileServer(http.Dir("./web")))
 	loginHandler := handlers.NewLoginHandler()
 	chaptersHandler := handlers.NewChaptersHandler(chaptersService, topicsService)
+	resourcesHandler := handlers.NewResourcesHandler(resourcesService)
 	topicsHandler := handlers.NewTopicsHandler(topicsService)
 	conceptsHandler := handlers.NewConceptsHandler(conceptsService)
 	curriculumsHandler := handlers.NewCurriculumsHandler(curriculumsService)
@@ -67,6 +70,7 @@ func NewAppComponent() (*AppComponent, error) {
 		CssPathHandler:     cssPathHandler,
 		LoginHandler:       loginHandler,
 		ChaptersHandler:    chaptersHandler,
+		ResourcesHandler:   resourcesHandler,
 		TopicsHandler:      topicsHandler,
 		ConceptsHandler:    conceptsHandler,
 		CurriculumsHandler: curriculumsHandler,

--- a/input.css
+++ b/input.css
@@ -41,7 +41,7 @@
     }
 
     .sub-tab {
-        @apply text-gray-600 bg-white px-4 py-2;
+        @apply text-gray-600 bg-white px-4 py-2 cursor-pointer;
     }
 
     .sub-tab:focus {

--- a/internal/dto/chapter_dto.go
+++ b/internal/dto/chapter_dto.go
@@ -6,4 +6,5 @@ type TopicsData struct {
 
 type ResourcesData struct {
 	ChapterId string
+	TopicId   string
 }

--- a/internal/dto/chapter_dto.go
+++ b/internal/dto/chapter_dto.go
@@ -3,3 +3,7 @@ package dto
 type TopicsData struct {
 	ChapterId string
 }
+
+type ResourcesData struct {
+	ChapterId string
+}

--- a/internal/dto/move_resources_dto.go
+++ b/internal/dto/move_resources_dto.go
@@ -6,7 +6,8 @@ type MoveResourcesRequest struct {
 	ResourceIDs      []int                    `json:"resource_ids"`
 	CurriculumGrades []models.CurriculumGrade `json:"curriculum_grades"`
 	SubjectID        int8                     `json:"subject_id"`
-	TopicID          int16                    `json:"topic_id,omitempty"`
-	ChapterID        int16                    `json:"chapter_id"`
-	LangCode         string                   `json:"lang_code"`
+	// Pointer so JSON can send explicit null for chapter-level moves (clears old resource-topic mapping).
+	TopicID   *int16 `json:"topic_id"`
+	ChapterID int16  `json:"chapter_id"`
+	LangCode  string `json:"lang_code"`
 }

--- a/internal/dto/move_resources_dto.go
+++ b/internal/dto/move_resources_dto.go
@@ -2,11 +2,11 @@ package dto
 
 import "github.com/avantifellows/nex-gen-cms/internal/models"
 
-type MoveProblemsRequest struct {
-	ProblemIDs       []int                    `json:"resource_ids"`
+type MoveResourcesRequest struct {
+	ResourceIDs      []int                    `json:"resource_ids"`
 	CurriculumGrades []models.CurriculumGrade `json:"curriculum_grades"`
 	SubjectID        int8                     `json:"subject_id"`
-	TopicID          int16                    `json:"topic_id"`
+	TopicID          int16                    `json:"topic_id,omitempty"`
 	ChapterID        int16                    `json:"chapter_id"`
 	LangCode         string                   `json:"lang_code"`
 }

--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -27,6 +27,7 @@ const editChapterTemplate = "edit_chapter.html"
 const updateSuccessTemplate = "update_success.html"
 const chapterTemplate = "chapter.html"
 const chapterDropdownTemplate = "chapter_dropdown.html"
+const resourcesTemplate = "resources.html"
 
 type ChaptersHandler struct {
 	chaptersService *services.Service[models.Chapter]
@@ -300,6 +301,14 @@ func (h *ChaptersHandler) LoadTopics(responseWriter http.ResponseWriter, request
 		ChapterId: chapterIdStr,
 	}
 	views.ExecuteTemplate(topicsTemplate, responseWriter, data, nil)
+}
+
+func (h *ChaptersHandler) LoadResources(responseWriter http.ResponseWriter, request *http.Request) {
+	chapterIdStr := request.URL.Query().Get("chapterId")
+	data := dto.ResourcesData{
+		ChapterId: chapterIdStr,
+	}
+	views.ExecuteTemplate(resourcesTemplate, responseWriter, data, nil)
 }
 
 func (h *ChaptersHandler) GetTopics(responseWriter http.ResponseWriter, request *http.Request) {

--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -27,7 +27,6 @@ const editChapterTemplate = "edit_chapter.html"
 const updateSuccessTemplate = "update_success.html"
 const chapterTemplate = "chapter.html"
 const chapterDropdownTemplate = "chapter_dropdown.html"
-const resourcesTemplate = "resources.html"
 
 type ChaptersHandler struct {
 	chaptersService *services.Service[models.Chapter]

--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -27,6 +27,7 @@ const editChapterTemplate = "edit_chapter.html"
 const updateSuccessTemplate = "update_success.html"
 const chapterTemplate = "chapter.html"
 const chapterDropdownTemplate = "chapter_dropdown.html"
+const topicDropdownOptionalTemplate = "topic_dropdown_optional.html"
 
 type ChaptersHandler struct {
 	chaptersService *services.Service[models.Chapter]
@@ -316,6 +317,8 @@ func (h *ChaptersHandler) GetTopics(responseWriter http.ResponseWriter, request 
 	var filename string
 	if view == "list" {
 		filename = topicRowTemplate
+	} else if view == "dropdown-optional" {
+		filename = topicDropdownOptionalTemplate
 	} else {
 		filename = topicDropdownTemplate
 	}

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -25,7 +25,6 @@ const problemsEndPoint = "problems"
 const problemEndPoint = "resource/problem/%d/en/%s"
 const searchProblemsEndPoint = "problems/search"
 const testsContainingProblemsEndPoint = "resources/tests-containing-problems"
-const moveProblemEndPoint = "resources/move"
 
 const problemsTemplate = "problems.html"
 const problemTemplate = "problem.html"
@@ -465,8 +464,8 @@ func (h *ProblemsHandler) MoveProblems(responseWriter http.ResponseWriter, reque
 	problemIdsStr := request.Form.Get("problem_ids")
 	problemIds := utils.StringSliceToIntSlice(strings.Split(problemIdsStr, ","))
 
-	reqBody := dto.MoveProblemsRequest{
-		ProblemIDs: problemIds,
+	reqBody := dto.MoveResourcesRequest{
+		ResourceIDs: problemIds,
 		CurriculumGrades: []models.CurriculumGrade{
 			{
 				CurriculumID: curriculumId,
@@ -481,7 +480,7 @@ func (h *ProblemsHandler) MoveProblems(responseWriter http.ResponseWriter, reque
 
 	var result any
 
-	err = h.problemsService.Post(moveProblemEndPoint, reqBody, &result)
+	err = h.problemsService.Post(moveResourceEndPoint, reqBody, &result)
 	if err != nil {
 		log.Println("move problems error:", err)
 		http.Error(responseWriter, "Failed to move problems", http.StatusInternalServerError)

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -460,6 +460,7 @@ func (h *ProblemsHandler) MoveProblems(responseWriter http.ResponseWriter, reque
 		http.Error(responseWriter, fmt.Sprintf("Invalid Topic ID: %v", err), http.StatusBadRequest)
 		return
 	}
+	topicIdPtr := &topicId
 
 	problemIdsStr := request.Form.Get("problem_ids")
 	problemIds := utils.StringSliceToIntSlice(strings.Split(problemIdsStr, ","))
@@ -474,7 +475,7 @@ func (h *ProblemsHandler) MoveProblems(responseWriter http.ResponseWriter, reque
 		},
 		SubjectID: subjectId,
 		ChapterID: chapterId,
-		TopicID:   topicId,
+		TopicID:   topicIdPtr,
 		LangCode:  "en",
 	}
 

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -2,11 +2,13 @@ package handlers
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"text/template"
 
 	"github.com/avantifellows/nex-gen-cms/internal/constants"
+	"github.com/avantifellows/nex-gen-cms/internal/dto"
 	"github.com/avantifellows/nex-gen-cms/internal/models"
 	"github.com/avantifellows/nex-gen-cms/internal/services"
 	"github.com/avantifellows/nex-gen-cms/internal/views"
@@ -15,12 +17,14 @@ import (
 
 const resourcesEndPoint = "resource"
 const resourcesCurriculumEndPoint = "resources/curriculum"
+const moveResourceEndPoint = "resources/move"
 const resourcesKey = "resources"
 
 const resourcesTemplate = "resources.html"
 const resourceRowTemplate = "resource_row.html"
 const editResourceTemplate = "edit_resource.html"
 const addResourceTemplate = "add_resource.html"
+const moveResourcesTemplate = "move_resources_modal.html"
 
 var resourceTypeOptions = []string{"class", "content", "document", "quiz", "video"}
 var resourceSubtypeOptions = []string{"Module", "Previous Year Questions", "Assessment", "Video Lectures"}
@@ -252,6 +256,75 @@ func (h *ResourcesHandler) AddResource(responseWriter http.ResponseWriter, reque
 	views.ExecuteTemplate(resourceRowTemplate, responseWriter, resourcePtrs, template.FuncMap{
 		"getName": getResourceName,
 	})
+}
+
+func (h *ResourcesHandler) LoadMoveResources(responseWriter http.ResponseWriter, request *http.Request) {
+	resourceIDs := request.FormValue("resource_ids")
+	if strings.TrimSpace(resourceIDs) == "" {
+		http.Error(responseWriter, "Missing resource IDs", http.StatusBadRequest)
+		return
+	}
+	views.ExecuteTemplate(moveResourcesTemplate, responseWriter, resourceIDs, nil)
+}
+
+func (h *ResourcesHandler) MoveResource(responseWriter http.ResponseWriter, request *http.Request) {
+	err := request.ParseForm()
+	if err != nil {
+		http.Error(responseWriter, "Invalid form", http.StatusBadRequest)
+		return
+	}
+
+	curriculumID, gradeID, subjectID := getCurriculumGradeSubjectIds(request.Form)
+	if curriculumID == 0 || gradeID == 0 || subjectID == 0 {
+		http.Error(responseWriter, "Invalid curriculum, grade or subject ID", http.StatusBadRequest)
+		return
+	}
+
+	chapterIDStr := request.Form.Get("chapter-dropdown")
+	chapterID, err := utils.StringToIntType[int16](chapterIDStr)
+	if err != nil {
+		http.Error(responseWriter, fmt.Sprintf("Invalid Chapter ID: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	topicIDStr := strings.TrimSpace(request.Form.Get("topic_id"))
+	var topicID int16
+	if topicIDStr != "" {
+		topicID, err = utils.StringToIntType[int16](topicIDStr)
+		if err != nil {
+			http.Error(responseWriter, fmt.Sprintf("Invalid Topic ID: %v", err), http.StatusBadRequest)
+			return
+		}
+	}
+
+	resourceIDsStr := strings.TrimSpace(request.Form.Get("resource_ids"))
+	if resourceIDsStr == "" {
+		http.Error(responseWriter, "Missing resource IDs", http.StatusBadRequest)
+		return
+	}
+	resourceIDs := utils.StringSliceToIntSlice(strings.Split(resourceIDsStr, ","))
+
+	requestBody := dto.MoveResourcesRequest{
+		ResourceIDs: resourceIDs,
+		CurriculumGrades: []models.CurriculumGrade{
+			{
+				CurriculumID: curriculumID,
+				GradeID:      gradeID,
+			},
+		},
+		SubjectID: subjectID,
+		ChapterID: chapterID,
+		TopicID:   topicID,
+		LangCode:  "en",
+	}
+
+	var result any
+	err = h.service.Post(moveResourceEndPoint, requestBody, &result)
+	if err != nil {
+		log.Println("move resource error:", err)
+		http.Error(responseWriter, "Failed to move resource", http.StatusInternalServerError)
+		return
+	}
 }
 
 func getResourceName(r models.Resource, lang string) string {

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -62,6 +62,7 @@ func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, requ
 	curriculumIdStr := urlVals.Get(CURRICULUM_DROPDOWN_NAME)
 	gradeIdStr := urlVals.Get(GRADE_DROPDOWN_NAME)
 	chapterIdStr := urlVals.Get("chapter_id")
+	topicIdStr := urlVals.Get("topic_id")
 
 	curriculumId, err := utils.StringToIntType[int16](curriculumIdStr)
 	if err != nil {
@@ -73,14 +74,26 @@ func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, requ
 		http.Error(responseWriter, "Invalid Grade ID", http.StatusBadRequest)
 		return
 	}
-	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
-	if err != nil {
-		http.Error(responseWriter, "Invalid Chapter ID", http.StatusBadRequest)
-		return
+
+	isTopicRequest := strings.TrimSpace(topicIdStr) != ""
+	var queryParams string
+	if isTopicRequest {
+		topicId, err := utils.StringToIntType[int16](topicIdStr)
+		if err != nil {
+			http.Error(responseWriter, "Invalid Topic ID", http.StatusBadRequest)
+			return
+		}
+		queryParams = fmt.Sprintf("?curriculum_id=%d&grade_id=%d&topic_id=%d", curriculumId, gradeId, topicId)
+	} else {
+		chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+		if err != nil {
+			http.Error(responseWriter, "Invalid Chapter ID", http.StatusBadRequest)
+			return
+		}
+		queryParams = fmt.Sprintf("?curriculum_id=%d&grade_id=%d&chapter_id=%d", curriculumId, gradeId, chapterId)
 	}
 
-	queryParams := fmt.Sprintf("?curriculum_id=%d&grade_id=%d&chapter_id=%d", curriculumId, gradeId, chapterId)
-	resources, err := h.service.GetList(resourcesCurriculumEndPoint+queryParams, resourcesKey, false, false)
+	resources, err := h.service.GetList(resourcesCurriculumEndPoint+queryParams, resourcesKey, false, true)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching resources: %v", err), http.StatusInternalServerError)
 		return
@@ -91,6 +104,10 @@ func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, requ
 	for _, resource := range *resources {
 		resourceType := strings.ToLower(resource.Type)
 		if resource.StatusID == constants.StatusArchived || resourceType == "problem" || resourceType == "test" {
+			continue
+		}
+		// If the request is for chapter resources, keep only rows that don't belong to a topic.
+		if !isTopicRequest && resource.TopicID != 0 {
 			continue
 		}
 		filteredResources = append(filteredResources, resource)

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"text/template"
+
+	"github.com/avantifellows/nex-gen-cms/internal/models"
+	"github.com/avantifellows/nex-gen-cms/internal/services"
+	"github.com/avantifellows/nex-gen-cms/internal/views"
+)
+
+const resourcesCurriculumListEndPoint = "resources/curriculum"
+const resourcesKey = "resources"
+
+const resourcesTemplate = "resources.html"
+
+type ResourcesHandler struct {
+	service *services.Service[models.Resource]
+}
+
+func NewResourcesHandler(service *services.Service[models.Resource]) *ResourcesHandler {
+	return &ResourcesHandler{
+		service: service,
+	}
+}
+
+func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, request *http.Request) {
+	queryParams := "?curriculum_id=1&grade_id=3&chapter_id=1"
+	resources, err := h.service.GetList(resourcesCurriculumListEndPoint+queryParams, resourcesKey, false, false)
+	if err != nil {
+		http.Error(responseWriter, fmt.Sprintf("Error fetching resources: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	views.ExecuteTemplate(resourcesTemplate, responseWriter, resources, template.FuncMap{
+		"getName": getResourceName,
+	})
+}
+
+func getResourceName(r models.Resource, lang string) string {
+	return r.GetNameByLang(lang)
+}

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -13,13 +13,29 @@ import (
 	"github.com/avantifellows/nex-gen-cms/utils"
 )
 
-const resourcesCurriculumListEndPoint = "resources/curriculum"
-const resourceEndPoint = "resource"
+const resourcesEndPoint = "resource"
+const resourcesCurriculumEndPoint = "resources/curriculum"
 const resourcesKey = "resources"
 
 const resourcesTemplate = "resources.html"
 const resourceRowTemplate = "resource_row.html"
 const editResourceTemplate = "edit_resource.html"
+const addResourceTemplate = "add_resource.html"
+
+var resourceTypeOptions = []string{"class", "content", "document", "quiz", "video"}
+var resourceSubtypeOptions = []string{"Module", "Previous Year Questions", "Assessment", "Video Lectures"}
+
+type addResourceTemplateData struct {
+	ChapterID      string
+	TypeOptions    []string
+	SubtypeOptions []string
+}
+
+type editResourceTemplateData struct {
+	Resource       *models.Resource
+	TypeOptions    []string
+	SubtypeOptions []string
+}
 
 type ResourcesHandler struct {
 	service *services.Service[models.Resource]
@@ -31,10 +47,20 @@ func NewResourcesHandler(service *services.Service[models.Resource]) *ResourcesH
 	}
 }
 
+func (h *ResourcesHandler) OpenAddResource(responseWriter http.ResponseWriter, request *http.Request) {
+	chapterId := request.URL.Query().Get("chapterId")
+	data := addResourceTemplateData{
+		ChapterID:      chapterId,
+		TypeOptions:    resourceTypeOptions,
+		SubtypeOptions: resourceSubtypeOptions,
+	}
+	views.ExecuteTemplate(addResourceTemplate, responseWriter, data, nil)
+}
+
 func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, request *http.Request) {
 	urlVals := request.URL.Query()
-	curriculumIdStr := urlVals.Get("curriculum-dropdown")
-	gradeIdStr := urlVals.Get("grade-dropdown")
+	curriculumIdStr := urlVals.Get(CURRICULUM_DROPDOWN_NAME)
+	gradeIdStr := urlVals.Get(GRADE_DROPDOWN_NAME)
 	chapterIdStr := urlVals.Get("chapter_id")
 
 	curriculumId, err := utils.StringToIntType[int16](curriculumIdStr)
@@ -54,7 +80,7 @@ func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, requ
 	}
 
 	queryParams := fmt.Sprintf("?curriculum_id=%d&grade_id=%d&chapter_id=%d", curriculumId, gradeId, chapterId)
-	resources, err := h.service.GetList(resourcesCurriculumListEndPoint+queryParams, resourcesKey, false, false)
+	resources, err := h.service.GetList(resourcesCurriculumEndPoint+queryParams, resourcesKey, false, false)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching resources: %v", err), http.StatusInternalServerError)
 		return
@@ -64,7 +90,7 @@ func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, requ
 	// remove test & problem resources because we are already managing those via separate tabs
 	for _, resource := range *resources {
 		resourceType := strings.ToLower(resource.Type)
-		if resourceType == "problem" || resourceType == "test" {
+		if resource.StatusID == constants.StatusArchived || resourceType == "problem" || resourceType == "test" {
 			continue
 		}
 		filteredResources = append(filteredResources, resource)
@@ -86,13 +112,18 @@ func (h *ResourcesHandler) EditResource(responseWriter http.ResponseWriter, requ
 	selectedResourcePtr, err := h.service.GetObject(resourceIdStr,
 		func(resource *models.Resource) bool {
 			return resource.ID == int(resourceId)
-		}, resourcesKey, resourceEndPoint)
+		}, resourcesKey, resourcesEndPoint)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching resource: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	views.ExecuteTemplate(editResourceTemplate, responseWriter, selectedResourcePtr, template.FuncMap{
+	data := editResourceTemplateData{
+		Resource:       selectedResourcePtr,
+		TypeOptions:    resourceTypeOptions,
+		SubtypeOptions: resourceSubtypeOptions,
+	}
+	views.ExecuteTemplate(editResourceTemplate, responseWriter, data, template.FuncMap{
 		"getName": getResourceName,
 	})
 }
@@ -114,7 +145,7 @@ func (h *ResourcesHandler) UpdateResource(responseWriter http.ResponseWriter, re
 	dummyResourcePtr := &models.Resource{}
 	resourceMap := dummyResourcePtr.BuildMap(resourceCode, resourceName, resourceType, resourceSubtype, srcLink)
 
-	_, err = h.service.UpdateObject(resourceIdStr, resourceEndPoint, resourceMap, resourcesKey,
+	_, err = h.service.UpdateObject(resourceIdStr, resourcesEndPoint, resourceMap, resourcesKey,
 		func(resource *models.Resource) bool {
 			return resource.ID == int(resourceId)
 		})
@@ -138,7 +169,7 @@ func (h *ResourcesHandler) ArchiveResource(responseWriter http.ResponseWriter, r
 		"cms_status_id": constants.StatusArchived,
 	}
 
-	err = h.service.ArchiveObject(resourceIdStr, resourceEndPoint, resourceMap, resourcesKey,
+	err = h.service.ArchiveObject(resourceIdStr, resourcesEndPoint, resourceMap, resourcesKey,
 		func(resource *models.Resource) bool {
 			return resource.ID != int(resourceId)
 		})
@@ -147,6 +178,47 @@ func (h *ResourcesHandler) ArchiveResource(responseWriter http.ResponseWriter, r
 	if err != nil {
 		http.Error(responseWriter, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+func (h *ResourcesHandler) AddResource(responseWriter http.ResponseWriter, request *http.Request) {
+	resourceCode := request.FormValue("code")
+	resourceName := request.FormValue("name")
+	resourceType := request.FormValue("type")
+	resourceSubtype := request.FormValue("subtype")
+	srcLink := request.FormValue("src_link")
+
+	chapterIdStr := request.FormValue("chapter_id")
+	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+	if err != nil {
+		http.Error(responseWriter, "Invalid Chapter ID", http.StatusBadRequest)
+		return
+	}
+
+	curriculumIdStr := request.FormValue(CURRICULUM_DROPDOWN_NAME)
+	curriculumId, err := utils.StringToIntType[int16](curriculumIdStr)
+	if err != nil {
+		http.Error(responseWriter, "Invalid Curriculum ID", http.StatusBadRequest)
+		return
+	}
+
+	gradeIdStr := request.FormValue(GRADE_DROPDOWN_NAME)
+	gradeId, err := utils.StringToIntType[int8](gradeIdStr)
+	if err != nil {
+		http.Error(responseWriter, "Invalid Grade ID", http.StatusBadRequest)
+		return
+	}
+
+	newResourcePtr := models.NewResource(resourceCode, resourceName, resourceType, resourceSubtype, srcLink, chapterId, curriculumId, gradeId)
+	newResourcePtr, err = h.service.AddObject(newResourcePtr, resourcesKey, resourcesEndPoint)
+	if err != nil {
+		http.Error(responseWriter, fmt.Sprintf("Error adding resource: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	resourcePtrs := []*models.Resource{newResourcePtr}
+	views.ExecuteTemplate(resourceRowTemplate, responseWriter, resourcePtrs, template.FuncMap{
+		"getName": getResourceName,
+	})
 }
 
 func getResourceName(r models.Resource, lang string) string {

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -27,6 +27,7 @@ var resourceSubtypeOptions = []string{"Module", "Previous Year Questions", "Asse
 
 type addResourceTemplateData struct {
 	ChapterID      string
+	TopicID        string
 	TypeOptions    []string
 	SubtypeOptions []string
 }
@@ -49,8 +50,10 @@ func NewResourcesHandler(service *services.Service[models.Resource]) *ResourcesH
 
 func (h *ResourcesHandler) OpenAddResource(responseWriter http.ResponseWriter, request *http.Request) {
 	chapterId := request.URL.Query().Get("chapterId")
+	topicId := request.URL.Query().Get("topicId")
 	data := addResourceTemplateData{
 		ChapterID:      chapterId,
+		TopicID:        topicId,
 		TypeOptions:    resourceTypeOptions,
 		SubtypeOptions: resourceSubtypeOptions,
 	}
@@ -211,6 +214,16 @@ func (h *ResourcesHandler) AddResource(responseWriter http.ResponseWriter, reque
 		return
 	}
 
+	topicIdStr := request.FormValue("topic_id")
+	var topicId int16
+	if strings.TrimSpace(topicIdStr) != "" {
+		topicId, err = utils.StringToIntType[int16](topicIdStr)
+		if err != nil {
+			http.Error(responseWriter, "Invalid Topic ID", http.StatusBadRequest)
+			return
+		}
+	}
+
 	curriculumIdStr := request.FormValue(CURRICULUM_DROPDOWN_NAME)
 	curriculumId, err := utils.StringToIntType[int16](curriculumIdStr)
 	if err != nil {
@@ -226,6 +239,9 @@ func (h *ResourcesHandler) AddResource(responseWriter http.ResponseWriter, reque
 	}
 
 	newResourcePtr := models.NewResource(resourceCode, resourceName, resourceType, resourceSubtype, srcLink, chapterId, curriculumId, gradeId)
+	if topicId != 0 {
+		newResourcePtr.TopicID = topicId
+	}
 	newResourcePtr, err = h.service.AddObject(newResourcePtr, resourcesKey, resourcesEndPoint)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error adding resource: %v", err), http.StatusInternalServerError)

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -26,7 +26,7 @@ const editResourceTemplate = "edit_resource.html"
 const addResourceTemplate = "add_resource.html"
 const moveResourcesTemplate = "move_resources_modal.html"
 
-var resourceTypeOptions = []string{"document", "quiz", "video"}
+var resourceTypeOptions = []string{"document", "quiz", "quiz_template", "video"}
 
 type addResourceTemplateData struct {
 	ChapterID   string

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -3,17 +3,20 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"text/template"
 
 	"github.com/avantifellows/nex-gen-cms/internal/models"
 	"github.com/avantifellows/nex-gen-cms/internal/services"
 	"github.com/avantifellows/nex-gen-cms/internal/views"
+	"github.com/avantifellows/nex-gen-cms/utils"
 )
 
 const resourcesCurriculumListEndPoint = "resources/curriculum"
 const resourcesKey = "resources"
 
 const resourcesTemplate = "resources.html"
+const resourceRowTemplate = "resource_row.html"
 
 type ResourcesHandler struct {
 	service *services.Service[models.Resource]
@@ -26,14 +29,45 @@ func NewResourcesHandler(service *services.Service[models.Resource]) *ResourcesH
 }
 
 func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, request *http.Request) {
-	queryParams := "?curriculum_id=1&grade_id=3&chapter_id=1"
+	urlVals := request.URL.Query()
+	curriculumIdStr := urlVals.Get("curriculum-dropdown")
+	gradeIdStr := urlVals.Get("grade-dropdown")
+	chapterIdStr := urlVals.Get("chapter_id")
+
+	curriculumId, err := utils.StringToIntType[int16](curriculumIdStr)
+	if err != nil {
+		http.Error(responseWriter, "Invalid Curriculum ID", http.StatusBadRequest)
+		return
+	}
+	gradeId, err := utils.StringToIntType[int8](gradeIdStr)
+	if err != nil {
+		http.Error(responseWriter, "Invalid Grade ID", http.StatusBadRequest)
+		return
+	}
+	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+	if err != nil {
+		http.Error(responseWriter, "Invalid Chapter ID", http.StatusBadRequest)
+		return
+	}
+
+	queryParams := fmt.Sprintf("?curriculum_id=%d&grade_id=%d&chapter_id=%d", curriculumId, gradeId, chapterId)
 	resources, err := h.service.GetList(resourcesCurriculumListEndPoint+queryParams, resourcesKey, false, false)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching resources: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	views.ExecuteTemplate(resourcesTemplate, responseWriter, resources, template.FuncMap{
+	filteredResources := make([]*models.Resource, 0, len(*resources))
+	// remove test & problem resources because we are already managing those via separate tabs
+	for _, resource := range *resources {
+		resourceType := strings.ToLower(resource.Type)
+		if resourceType == "problem" || resourceType == "test" {
+			continue
+		}
+		filteredResources = append(filteredResources, resource)
+	}
+
+	views.ExecuteTemplate(resourceRowTemplate, responseWriter, &filteredResources, template.FuncMap{
 		"getName": getResourceName,
 	})
 }

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -288,13 +288,14 @@ func (h *ResourcesHandler) MoveResource(responseWriter http.ResponseWriter, requ
 	}
 
 	topicIDStr := strings.TrimSpace(request.Form.Get("topic_id"))
-	var topicID int16
+	var topicIDPtr *int16
 	if topicIDStr != "" {
-		topicID, err = utils.StringToIntType[int16](topicIDStr)
-		if err != nil {
-			http.Error(responseWriter, fmt.Sprintf("Invalid Topic ID: %v", err), http.StatusBadRequest)
+		topicID, parseErr := utils.StringToIntType[int16](topicIDStr)
+		if parseErr != nil {
+			http.Error(responseWriter, fmt.Sprintf("Invalid Topic ID: %v", parseErr), http.StatusBadRequest)
 			return
 		}
+		topicIDPtr = &topicID
 	}
 
 	resourceIDsStr := strings.TrimSpace(request.Form.Get("resource_ids"))
@@ -314,7 +315,7 @@ func (h *ResourcesHandler) MoveResource(responseWriter http.ResponseWriter, requ
 		},
 		SubjectID: subjectID,
 		ChapterID: chapterID,
-		TopicID:   topicID,
+		TopicID:   topicIDPtr,
 		LangCode:  "en",
 	}
 

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -13,10 +13,12 @@ import (
 )
 
 const resourcesCurriculumListEndPoint = "resources/curriculum"
+const resourceEndPoint = "resource"
 const resourcesKey = "resources"
 
 const resourcesTemplate = "resources.html"
 const resourceRowTemplate = "resource_row.html"
+const editResourceTemplate = "edit_resource.html"
 
 type ResourcesHandler struct {
 	service *services.Service[models.Resource]
@@ -70,6 +72,57 @@ func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, requ
 	views.ExecuteTemplate(resourceRowTemplate, responseWriter, &filteredResources, template.FuncMap{
 		"getName": getResourceName,
 	})
+}
+
+func (h *ResourcesHandler) EditResource(responseWriter http.ResponseWriter, request *http.Request) {
+	resourceIdStr := request.URL.Query().Get("id")
+	resourceId, err := utils.StringToIntType[int32](resourceIdStr)
+	if err != nil {
+		http.Error(responseWriter, "Invalid Resource ID", http.StatusBadRequest)
+		return
+	}
+
+	selectedResourcePtr, err := h.service.GetObject(resourceIdStr,
+		func(resource *models.Resource) bool {
+			return resource.ID == int(resourceId)
+		}, resourcesKey, resourceEndPoint)
+	if err != nil {
+		http.Error(responseWriter, fmt.Sprintf("Error fetching resource: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	views.ExecuteTemplate(editResourceTemplate, responseWriter, selectedResourcePtr, template.FuncMap{
+		"getName": getResourceName,
+	})
+}
+
+func (h *ResourcesHandler) UpdateResource(responseWriter http.ResponseWriter, request *http.Request) {
+	resourceIdStr := request.FormValue("id")
+	resourceId, err := utils.StringToIntType[int32](resourceIdStr)
+	if err != nil {
+		http.Error(responseWriter, "Invalid Resource ID", http.StatusBadRequest)
+		return
+	}
+
+	resourceName := request.FormValue("name")
+	resourceCode := request.FormValue("code")
+	resourceType := request.FormValue("type")
+	resourceSubtype := request.FormValue("subtype")
+	srcLink := request.FormValue("src_link")
+
+	dummyResourcePtr := &models.Resource{}
+	resourceMap := dummyResourcePtr.BuildMap(resourceCode, resourceName, resourceType, resourceSubtype, srcLink)
+
+	_, err = h.service.UpdateObject(resourceIdStr, resourceEndPoint, resourceMap, resourcesKey,
+		func(resource *models.Resource) bool {
+			return resource.ID == int(resourceId)
+		})
+	if err != nil {
+		http.Error(responseWriter, fmt.Sprintf("Error updating resource: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	views.ExecuteTemplate(updateSuccessTemplate, responseWriter, "Resource", nil)
 }
 
 func getResourceName(r models.Resource, lang string) string {

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/avantifellows/nex-gen-cms/internal/constants"
 	"github.com/avantifellows/nex-gen-cms/internal/models"
 	"github.com/avantifellows/nex-gen-cms/internal/services"
 	"github.com/avantifellows/nex-gen-cms/internal/views"
@@ -123,6 +124,29 @@ func (h *ResourcesHandler) UpdateResource(responseWriter http.ResponseWriter, re
 	}
 
 	views.ExecuteTemplate(updateSuccessTemplate, responseWriter, "Resource", nil)
+}
+
+func (h *ResourcesHandler) ArchiveResource(responseWriter http.ResponseWriter, request *http.Request) {
+	resourceIdStr := request.URL.Query().Get("id")
+	resourceId, err := utils.StringToIntType[int32](resourceIdStr)
+	if err != nil {
+		http.Error(responseWriter, "Invalid Resource ID", http.StatusBadRequest)
+		return
+	}
+
+	resourceMap := map[string]any{
+		"cms_status_id": constants.StatusArchived,
+	}
+
+	err = h.service.ArchiveObject(resourceIdStr, resourceEndPoint, resourceMap, resourcesKey,
+		func(resource *models.Resource) bool {
+			return resource.ID != int(resourceId)
+		})
+
+	// If http error is thrown from here then target row won't be removed by htmx code
+	if err != nil {
+		http.Error(responseWriter, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func getResourceName(r models.Resource, lang string) string {

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -26,20 +26,17 @@ const editResourceTemplate = "edit_resource.html"
 const addResourceTemplate = "add_resource.html"
 const moveResourcesTemplate = "move_resources_modal.html"
 
-var resourceTypeOptions = []string{"class", "content", "document", "quiz", "video"}
-var resourceSubtypeOptions = []string{"Module", "Previous Year Questions", "Assessment", "Video Lectures"}
+var resourceTypeOptions = []string{"document", "quiz", "video"}
 
 type addResourceTemplateData struct {
-	ChapterID      string
-	TopicID        string
-	TypeOptions    []string
-	SubtypeOptions []string
+	ChapterID   string
+	TopicID     string
+	TypeOptions []string
 }
 
 type editResourceTemplateData struct {
-	Resource       *models.Resource
-	TypeOptions    []string
-	SubtypeOptions []string
+	Resource    *models.Resource
+	TypeOptions []string
 }
 
 type ResourcesHandler struct {
@@ -56,10 +53,9 @@ func (h *ResourcesHandler) OpenAddResource(responseWriter http.ResponseWriter, r
 	chapterId := request.URL.Query().Get("chapterId")
 	topicId := request.URL.Query().Get("topicId")
 	data := addResourceTemplateData{
-		ChapterID:      chapterId,
-		TopicID:        topicId,
-		TypeOptions:    resourceTypeOptions,
-		SubtypeOptions: resourceSubtypeOptions,
+		ChapterID:   chapterId,
+		TopicID:     topicId,
+		TypeOptions: resourceTypeOptions,
 	}
 	views.ExecuteTemplate(addResourceTemplate, responseWriter, data, nil)
 }
@@ -143,9 +139,8 @@ func (h *ResourcesHandler) EditResource(responseWriter http.ResponseWriter, requ
 	}
 
 	data := editResourceTemplateData{
-		Resource:       selectedResourcePtr,
-		TypeOptions:    resourceTypeOptions,
-		SubtypeOptions: resourceSubtypeOptions,
+		Resource:    selectedResourcePtr,
+		TypeOptions: resourceTypeOptions,
 	}
 	views.ExecuteTemplate(editResourceTemplate, responseWriter, data, template.FuncMap{
 		"getName": getResourceName,

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -55,8 +55,6 @@ const addCurriculumGradeSelectsTemplate = "add_curriculum_grade_selects.html"
 const questionPaperTemplate = "question_paper.html"
 const answerSolutionSheetTemplate = "answer_sheet.html"
 
-const resourcesEndPoint = "resource"
-const resourcesCurriculumEndPoint = "resources/curriculum"
 const testProblemsEndPoint = "resource/test/%d/problems?lang_code=en&" + QUERY_PARAM_CURRICULUM_ID + "=%s"
 const testRulesEndPoint = "test-rule"
 

--- a/internal/handlers/topic_handler.go
+++ b/internal/handlers/topic_handler.go
@@ -35,6 +35,14 @@ func NewTopicsHandler(service *services.Service[models.Topic]) *TopicsHandler {
 	}
 }
 
+func (h *TopicsHandler) LoadResources(responseWriter http.ResponseWriter, request *http.Request) {
+	topicIdStr := request.URL.Query().Get("topicId")
+	data := dto.ResourcesData{
+		TopicId: topicIdStr,
+	}
+	views.ExecuteTemplate(resourcesTemplate, responseWriter, data, nil)
+}
+
 func (h *TopicsHandler) OpenAddTopic(responseWriter http.ResponseWriter, request *http.Request) {
 	chapterId := request.URL.Query().Get("chapterId")
 	views.ExecuteTemplate(addTopicTemplate, responseWriter, chapterId, nil)

--- a/internal/handlers/topic_handler.go
+++ b/internal/handlers/topic_handler.go
@@ -37,7 +37,9 @@ func NewTopicsHandler(service *services.Service[models.Topic]) *TopicsHandler {
 
 func (h *TopicsHandler) LoadResources(responseWriter http.ResponseWriter, request *http.Request) {
 	topicIdStr := request.URL.Query().Get("topicId")
+	chapterIdStr := request.URL.Query().Get("chapterId")
 	data := dto.ResourcesData{
+		ChapterId: chapterIdStr,
 		TopicId: topicIdStr,
 	}
 	views.ExecuteTemplate(resourcesTemplate, responseWriter, data, nil)

--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -3,17 +3,46 @@ package models
 import "strings"
 
 type Resource struct {
-	ID         int                `json:"id,omitempty"`
-	Name       []ResName          `json:"name"`
-	Code       string             `json:"code"`
-	Type       string             `json:"type"`
-	Subtype    string             `json:"subtype,omitempty"`
-	URL        string             `json:"url,omitempty"`
-	TypeParams ResourceTypeParams `json:"type_params,omitempty"`
+	ID               int                `json:"id,omitempty"`
+	Name             []ResName          `json:"name"`
+	Code             string             `json:"code"`
+	Type             string             `json:"type"`
+	Subtype          string             `json:"subtype,omitempty"`
+	StatusID         int8               `json:"cms_status_id,omitempty"`
+	ChapterID        int16              `json:"chapter_id,omitempty"`
+	CurriculumGrades []CurriculumGrade  `json:"curriculum_grades,omitempty"`
+	TypeParams       ResourceTypeParams `json:"type_params,omitempty"`
 }
 
 type ResourceTypeParams struct {
 	SrcLink string `json:"src_link,omitempty"`
+}
+
+func NewResource(code string, name string, resourceType string, subtype string, srcLink string, chapterID int16, curriculumID int16, gradeID int8) *Resource {
+	resource := &Resource{
+		Code:      code,
+		Name:      []ResName{{LangCode: "en", Resource: name}},
+		Type:      resourceType,
+		ChapterID: chapterID,
+		CurriculumGrades: []CurriculumGrade{
+			{
+				CurriculumID: curriculumID,
+				GradeID:      gradeID,
+			},
+		},
+	}
+
+	if strings.TrimSpace(subtype) != "" {
+		resource.Subtype = subtype
+	}
+
+	if strings.TrimSpace(srcLink) != "" {
+		resource.TypeParams = ResourceTypeParams{
+			SrcLink: srcLink,
+		}
+	}
+
+	return resource
 }
 
 func (resourcePtr *Resource) BuildMap(code string, name string, resourceType string, subtype string, srcLink string) map[string]any {

--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -1,0 +1,24 @@
+package models
+
+type Resource struct {
+	ID         int                `json:"id,omitempty"`
+	Name       []ResName          `json:"name"`
+	Code       string             `json:"code"`
+	Type       string             `json:"type"`
+	Subtype    string             `json:"subtype"`
+	URL        string             `json:"url,omitempty"`
+	TypeParams ResourceTypeParams `json:"type_params,omitempty"`
+}
+
+type ResourceTypeParams struct {
+	SrcLink string `json:"src_link,omitempty"`
+}
+
+func (r *Resource) GetNameByLang(langCode string) string {
+	for _, resourceLang := range r.Name {
+		if resourceLang.LangCode == langCode {
+			return resourceLang.Resource
+		}
+	}
+	return ""
+}

--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -10,6 +10,7 @@ type Resource struct {
 	Subtype          string             `json:"subtype,omitempty"`
 	StatusID         int8               `json:"cms_status_id,omitempty"`
 	ChapterID        int16              `json:"chapter_id,omitempty"`
+	TopicID          int16              `json:"topic_id,omitempty"`
 	CurriculumGrades []CurriculumGrade  `json:"curriculum_grades,omitempty"`
 	TypeParams       ResourceTypeParams `json:"type_params,omitempty"`
 }

--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -1,17 +1,39 @@
 package models
 
+import "strings"
+
 type Resource struct {
 	ID         int                `json:"id,omitempty"`
 	Name       []ResName          `json:"name"`
 	Code       string             `json:"code"`
 	Type       string             `json:"type"`
-	Subtype    string             `json:"subtype"`
+	Subtype    string             `json:"subtype,omitempty"`
 	URL        string             `json:"url,omitempty"`
 	TypeParams ResourceTypeParams `json:"type_params,omitempty"`
 }
 
 type ResourceTypeParams struct {
 	SrcLink string `json:"src_link,omitempty"`
+}
+
+func (resourcePtr *Resource) BuildMap(code string, name string, resourceType string, subtype string, srcLink string) map[string]any {
+	resourceMap := map[string]any{
+		"code": code,
+		"name": []ResName{{Resource: name, LangCode: "en"}},
+		"type": resourceType,
+	}
+
+	if strings.TrimSpace(subtype) != "" {
+		resourceMap["subtype"] = subtype
+	}
+
+	if strings.TrimSpace(srcLink) != "" {
+		resourceMap["type_params"] = ResourceTypeParams{
+			SrcLink: srcLink,
+		}
+	}
+
+	return resourceMap
 }
 
 func (r *Resource) GetNameByLang(langCode string) string {

--- a/web/html/add_resource.html
+++ b/web/html/add_resource.html
@@ -15,7 +15,7 @@
     <select id="add-resource-subtype" name="subtype" class="border p-2" required disabled>
         <option value="" selected disabled hidden>Select Subtype</option>
     </select>
-    <input type="url" name="src_link" placeholder="URL" class="border p-2 flex-1 min-w-56">
+    <input type="url" name="src_link" placeholder="URL" class="border p-2 flex-1 min-w-56" required>
     <button type="submit" class="bg-blue-500 text-white p-2 rounded">Create New Resource</button>
 </form>
 <script>

--- a/web/html/add_resource.html
+++ b/web/html/add_resource.html
@@ -1,5 +1,7 @@
 <!-- Form to add new resource -->
-<form id="addResourceForm" class="mt-2 flex flex-wrap gap-2" hx-post="/create-resource?chapter_id={{.ChapterID}}" hx-target="#resourceTableBody"
+<form id="addResourceForm" class="mt-2 flex flex-wrap gap-2"
+    hx-post="/create-resource?chapter_id={{.ChapterID}}{{ if .TopicID }}&topic_id={{.TopicID}}{{ end }}"
+    hx-target="#resourceTableBody"
     hx-swap="beforeend" hx-include="#curriculum-dropdown, #grade-dropdown"
     hx-on::after-request="if(event.detail.successful) this.reset()">
     <input type="text" name="name" placeholder="Resource Name" class="border p-2 w-1/3" required>

--- a/web/html/add_resource.html
+++ b/web/html/add_resource.html
@@ -3,20 +3,21 @@
     hx-post="/create-resource?chapter_id={{.ChapterID}}{{ if .TopicID }}&topic_id={{.TopicID}}{{ end }}"
     hx-target="#resourceTableBody"
     hx-swap="beforeend" hx-include="#curriculum-dropdown, #grade-dropdown"
-    hx-on::after-request="if(event.detail.successful) this.reset()">
+    hx-on::after-request="if(event.detail.successful) { this.reset(); ResourceForm.sync('add-resource-type','add-resource-subtype'); }">
     <input type="text" name="name" placeholder="Resource Name" class="border p-2 w-1/3" required>
-    <select name="type" class="border p-2" required>
+    <select id="add-resource-type" name="type" class="border p-2" required
+        onchange="ResourceForm.sync('add-resource-type','add-resource-subtype')">
         <option value="" selected disabled hidden>Select Type</option>
         {{ range .TypeOptions }}
         <option value="{{.}}">{{.}}</option>
         {{ end }}
     </select>
-    <select name="subtype" class="border p-2">
-        <option value="" selected>Subtype</option>
-        {{ range .SubtypeOptions }}
-        <option value="{{.}}">{{.}}</option>
-        {{ end }}
+    <select id="add-resource-subtype" name="subtype" class="border p-2" required disabled>
+        <option value="" selected disabled hidden>Select Subtype</option>
     </select>
     <input type="url" name="src_link" placeholder="URL" class="border p-2 flex-1 min-w-56">
     <button type="submit" class="bg-blue-500 text-white p-2 rounded">Create New Resource</button>
 </form>
+<script>
+    ResourceForm.sync('add-resource-type', 'add-resource-subtype');
+</script>

--- a/web/html/add_resource.html
+++ b/web/html/add_resource.html
@@ -1,0 +1,20 @@
+<!-- Form to add new resource -->
+<form id="addResourceForm" class="mt-2 flex flex-wrap gap-2" hx-post="/create-resource?chapter_id={{.ChapterID}}" hx-target="#resourceTableBody"
+    hx-swap="beforeend" hx-include="#curriculum-dropdown, #grade-dropdown"
+    hx-on::after-request="if(event.detail.successful) this.reset()">
+    <input type="text" name="name" placeholder="Resource Name" class="border p-2 w-1/3" required>
+    <select name="type" class="border p-2" required>
+        <option value="" selected disabled hidden>Select Type</option>
+        {{ range .TypeOptions }}
+        <option value="{{.}}">{{.}}</option>
+        {{ end }}
+    </select>
+    <select name="subtype" class="border p-2">
+        <option value="" selected>Subtype</option>
+        {{ range .SubtypeOptions }}
+        <option value="{{.}}">{{.}}</option>
+        {{ end }}
+    </select>
+    <input type="url" name="src_link" placeholder="URL" class="border p-2 flex-1 min-w-56">
+    <button type="submit" class="bg-blue-500 text-white p-2 rounded">Create New Resource</button>
+</form>

--- a/web/html/chapter.html
+++ b/web/html/chapter.html
@@ -20,7 +20,7 @@
         </div>
         <div class="sub-tab" 
             id="resources-sub-tab"
-            hx-get="/resources?chapterId={{.ChapterPtr.ID}}"
+            hx-get="/chapter/resources?chapterId={{.ChapterPtr.ID}}"
             hx-trigger="load[document.getElementById('resources-sub-tab').classList.contains('active')], click"
             hx-target="#subContent"
             onclick="

--- a/web/html/chapter.html
+++ b/web/html/chapter.html
@@ -7,8 +7,28 @@
         <h3 class="text-base font-semibold ml-4">{{ getName .ChapterPtr "en" }}</h3>
     </div>
     <div class="flex space-x-4 py-4">
-        <div class="sub-tab active" hx-trigger="load"
-            hx-get="/topics?id={{.ChapterPtr.ID}}" hx-target="#subContent">Topics</div>
+        <div class="sub-tab active" 
+            id="topics-sub-tab"
+            hx-trigger="load, click"
+            hx-get="/topics?id={{.ChapterPtr.ID}}" 
+            hx-target="#subContent"
+            onclick="
+                document.getElementById('topics-sub-tab').classList.add('active');
+                document.getElementById('resources-sub-tab').classList.remove('active');
+            ">
+            Topics
+        </div>
+        <div class="sub-tab" 
+            id="resources-sub-tab"
+            hx-get="/resources?chapterId={{.ChapterPtr.ID}}"
+            hx-trigger="click"
+            hx-target="#subContent"
+            onclick="
+                document.getElementById('resources-sub-tab').classList.add('active');
+                document.getElementById('topics-sub-tab').classList.remove('active');
+            ">
+            Resources
+        </div>
     </div>
     <div id="sub-tabContent">
         <div id="subContent">

--- a/web/html/chapter.html
+++ b/web/html/chapter.html
@@ -9,7 +9,7 @@
     <div class="flex space-x-4 py-4">
         <div class="sub-tab active" 
             id="topics-sub-tab"
-            hx-trigger="load, click"
+            hx-trigger="load[document.getElementById('topics-sub-tab').classList.contains('active')], click"
             hx-get="/topics?id={{.ChapterPtr.ID}}" 
             hx-target="#subContent"
             onclick="
@@ -21,7 +21,7 @@
         <div class="sub-tab" 
             id="resources-sub-tab"
             hx-get="/resources?chapterId={{.ChapterPtr.ID}}"
-            hx-trigger="click"
+            hx-trigger="load[document.getElementById('resources-sub-tab').classList.contains('active')], click"
             hx-target="#subContent"
             onclick="
                 document.getElementById('resources-sub-tab').classList.add('active');

--- a/web/html/edit_resource.html
+++ b/web/html/edit_resource.html
@@ -22,6 +22,7 @@
     <div class="mb-4">
       <label for="subtype" class="block text-gray-700 font-medium mb-2">Subtype</label>
       <select id="subtype" name="subtype" class="w-full p-3 border border-gray-300 rounded">
+        <option value="" {{if not .Subtype}}selected{{end}}></option>
         <option value="Module" {{if eq .Subtype "Module"}}selected{{end}}>Module</option>
         <option value="Previous Year Questions" {{if eq .Subtype "Previous Year Questions"}}selected{{end}}>Previous Year Questions</option>
         <option value="Assessment" {{if eq .Subtype "Assessment"}}selected{{end}}>Assessment</option>

--- a/web/html/edit_resource.html
+++ b/web/html/edit_resource.html
@@ -26,7 +26,7 @@
     </div>
     <div class="mb-4">
       <label for="src_link" class="block text-gray-700 font-medium mb-2">SrcLink</label>
-      <input type="url" id="src_link" name="src_link" class="w-full p-3 border border-gray-300 rounded"
+      <input type="url" id="src_link" name="src_link" class="w-full p-3 border border-gray-300 rounded" required
         placeholder="https://example.com/resource" value="{{.Resource.TypeParams.SrcLink}}">
     </div>
     <button type="submit" class="w-full bg-blue-500 text-white p-3 rounded hover:bg-blue-600 transition">SAVE</button>

--- a/web/html/edit_resource.html
+++ b/web/html/edit_resource.html
@@ -1,38 +1,36 @@
 <div class="container mx-auto bg-white shadow-md rounded p-6 mt-4">
   <h1 class="text-2xl font-semibold mb-4">Editing resource</h1>
-  <form hx-patch="/update-resource?id={{.ID}}">
+  <form hx-patch="/update-resource?id={{.Resource.ID}}">
     <div class="mb-4">
       <label for="name" class="block text-gray-700 font-medium mb-2">Resource Name</label>
-      <input type="text" id="name" name="name" class="w-full p-3 border border-gray-300 rounded" value="{{ getName . "en" }}">
+      <input type="text" id="name" name="name" class="w-full p-3 border border-gray-300 rounded" value="{{ getName .Resource "en" }}">
     </div>
     <div class="mb-4">
       <label for="code" class="block text-gray-700 font-medium mb-2">Code</label>
-      <input type="text" id="code" name="code" class="w-full p-3 border border-gray-300 rounded bg-gray-100 text-gray-600" value="{{.Code}}" readonly>
+      <input type="text" id="code" name="code" class="w-full p-3 border border-gray-300 rounded bg-gray-100 text-gray-600" value="{{.Resource.Code}}" readonly>
     </div>
     <div class="mb-4">
       <label for="type" class="block text-gray-700 font-medium mb-2">Type</label>
-      <select id="type" name="type" class="w-full p-3 border border-gray-300 rounded">
-        <option value="class" {{if eq .Type "class"}}selected{{end}}>class</option>
-        <option value="content" {{if eq .Type "content"}}selected{{end}}>content</option>
-        <option value="document" {{if eq .Type "document"}}selected{{end}}>document</option>
-        <option value="quiz" {{if eq .Type "quiz"}}selected{{end}}>quiz</option>
-        <option value="video" {{if eq .Type "video"}}selected{{end}}>video</option>
+      <select id="type" name="type" class="w-full p-3 border border-gray-300 rounded" required>
+        <option value="" disabled hidden {{if or (not .Resource.Type) (eq .Resource.Type "null")}}selected{{end}}>Select Type</option>
+        {{ range .TypeOptions }}
+        <option value="{{.}}" {{if eq $.Resource.Type .}}selected{{end}}>{{.}}</option>
+        {{ end }}
       </select>
     </div>
     <div class="mb-4">
       <label for="subtype" class="block text-gray-700 font-medium mb-2">Subtype</label>
       <select id="subtype" name="subtype" class="w-full p-3 border border-gray-300 rounded">
-        <option value="" {{if not .Subtype}}selected{{end}}></option>
-        <option value="Module" {{if eq .Subtype "Module"}}selected{{end}}>Module</option>
-        <option value="Previous Year Questions" {{if eq .Subtype "Previous Year Questions"}}selected{{end}}>Previous Year Questions</option>
-        <option value="Assessment" {{if eq .Subtype "Assessment"}}selected{{end}}>Assessment</option>
-        <option value="Video Lectures" {{if eq .Subtype "Video Lectures"}}selected{{end}}>Video Lectures</option>
+        <option value="" {{if or (not .Resource.Subtype) (eq .Resource.Subtype "null")}}selected{{end}}>Select Subtype</option>
+        {{ range .SubtypeOptions }}
+        <option value="{{.}}" {{if eq $.Resource.Subtype .}}selected{{end}}>{{.}}</option>
+        {{ end }}
       </select>
     </div>
     <div class="mb-4">
       <label for="src_link" class="block text-gray-700 font-medium mb-2">SrcLink</label>
       <input type="url" id="src_link" name="src_link" class="w-full p-3 border border-gray-300 rounded"
-        placeholder="https://example.com/resource" value="{{.TypeParams.SrcLink}}">
+        placeholder="https://example.com/resource" value="{{.Resource.TypeParams.SrcLink}}">
     </div>
     <button type="submit" class="w-full bg-blue-500 text-white p-3 rounded hover:bg-blue-600 transition">SAVE</button>
   </form>

--- a/web/html/edit_resource.html
+++ b/web/html/edit_resource.html
@@ -11,7 +11,8 @@
     </div>
     <div class="mb-4">
       <label for="type" class="block text-gray-700 font-medium mb-2">Type</label>
-      <select id="type" name="type" class="w-full p-3 border border-gray-300 rounded" required>
+      <select id="edit-resource-type" name="type" class="w-full p-3 border border-gray-300 rounded" required
+          onchange="ResourceForm.sync('edit-resource-type','edit-resource-subtype')">
         <option value="" disabled hidden {{if or (not .Resource.Type) (eq .Resource.Type "null")}}selected{{end}}>Select Type</option>
         {{ range .TypeOptions }}
         <option value="{{.}}" {{if eq $.Resource.Type .}}selected{{end}}>{{.}}</option>
@@ -20,11 +21,7 @@
     </div>
     <div class="mb-4">
       <label for="subtype" class="block text-gray-700 font-medium mb-2">Subtype</label>
-      <select id="subtype" name="subtype" class="w-full p-3 border border-gray-300 rounded">
-        <option value="" {{if or (not .Resource.Subtype) (eq .Resource.Subtype "null")}}selected{{end}}>Select Subtype</option>
-        {{ range .SubtypeOptions }}
-        <option value="{{.}}" {{if eq $.Resource.Subtype .}}selected{{end}}>{{.}}</option>
-        {{ end }}
+      <select id="edit-resource-subtype" name="subtype" class="w-full p-3 border border-gray-300 rounded" required>
       </select>
     </div>
     <div class="mb-4">
@@ -35,3 +32,6 @@
     <button type="submit" class="w-full bg-blue-500 text-white p-3 rounded hover:bg-blue-600 transition">SAVE</button>
   </form>
 </div>
+<script>
+  ResourceForm.sync('edit-resource-type', 'edit-resource-subtype', {{ printf "%q" .Resource.Subtype }});
+</script>

--- a/web/html/edit_resource.html
+++ b/web/html/edit_resource.html
@@ -1,0 +1,38 @@
+<div class="container mx-auto bg-white shadow-md rounded p-6 mt-4">
+  <h1 class="text-2xl font-semibold mb-4">Editing resource</h1>
+  <form hx-patch="/update-resource?id={{.ID}}">
+    <div class="mb-4">
+      <label for="name" class="block text-gray-700 font-medium mb-2">Resource Name</label>
+      <input type="text" id="name" name="name" class="w-full p-3 border border-gray-300 rounded" value="{{ getName . "en" }}">
+    </div>
+    <div class="mb-4">
+      <label for="code" class="block text-gray-700 font-medium mb-2">Code</label>
+      <input type="text" id="code" name="code" class="w-full p-3 border border-gray-300 rounded bg-gray-100 text-gray-600" value="{{.Code}}" readonly>
+    </div>
+    <div class="mb-4">
+      <label for="type" class="block text-gray-700 font-medium mb-2">Type</label>
+      <select id="type" name="type" class="w-full p-3 border border-gray-300 rounded">
+        <option value="class" {{if eq .Type "class"}}selected{{end}}>class</option>
+        <option value="content" {{if eq .Type "content"}}selected{{end}}>content</option>
+        <option value="document" {{if eq .Type "document"}}selected{{end}}>document</option>
+        <option value="quiz" {{if eq .Type "quiz"}}selected{{end}}>quiz</option>
+        <option value="video" {{if eq .Type "video"}}selected{{end}}>video</option>
+      </select>
+    </div>
+    <div class="mb-4">
+      <label for="subtype" class="block text-gray-700 font-medium mb-2">Subtype</label>
+      <select id="subtype" name="subtype" class="w-full p-3 border border-gray-300 rounded">
+        <option value="Module" {{if eq .Subtype "Module"}}selected{{end}}>Module</option>
+        <option value="Previous Year Questions" {{if eq .Subtype "Previous Year Questions"}}selected{{end}}>Previous Year Questions</option>
+        <option value="Assessment" {{if eq .Subtype "Assessment"}}selected{{end}}>Assessment</option>
+        <option value="Video Lectures" {{if eq .Subtype "Video Lectures"}}selected{{end}}>Video Lectures</option>
+      </select>
+    </div>
+    <div class="mb-4">
+      <label for="src_link" class="block text-gray-700 font-medium mb-2">SrcLink</label>
+      <input type="url" id="src_link" name="src_link" class="w-full p-3 border border-gray-300 rounded"
+        placeholder="https://example.com/resource" value="{{.TypeParams.SrcLink}}">
+    </div>
+    <button type="submit" class="w-full bg-blue-500 text-white p-3 rounded hover:bg-blue-600 transition">SAVE</button>
+  </form>
+</div>

--- a/web/html/home.html
+++ b/web/html/home.html
@@ -14,6 +14,7 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
     </script>
     <script src="/web/static/js/constants.js"></script>
+    <script src="/web/static/js/resource-form.js"></script>
     <script src="/web/static/js/infinite-scroll.js"></script>
     <script src="/web/static/js/table-sort.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>

--- a/web/html/move_resources_modal.html
+++ b/web/html/move_resources_modal.html
@@ -1,0 +1,118 @@
+<div id="move-resources-modal" data-resource-ids='{{.}}'
+    class="fixed inset-0 bg-gray-800 bg-opacity-50 flex justify-center items-center z-50">
+    <div class="bg-white p-6 rounded shadow-md w-full max-w-3xl">
+        <h2 class="text-lg font-semibold mb-2">Move Resource</h2>
+        <p class="text-sm text-gray-600 mb-6">
+            Select Curriculum, Grade and Subject in any order. Then select Chapter. Topic is optional.
+        </p>
+
+        <form id="move-resources-form" class="space-y-6" hx-post="/move-resource" hx-swap="none"
+            hx-vals='js:{resource_ids: document.getElementById("move-resources-modal").dataset.resourceIds}'
+            hx-on::after-request="handleMoveResourcesResponse(event)"
+            hx-disabled-elt="#move-resources-modal button">
+
+            <div class="grid grid-cols-3 gap-4">
+                <select id="curriculum-dropdown" name="curriculum-dropdown" class="border p-2 rounded w-full"
+                    hx-get="/api/curriculums" hx-trigger="load" hx-target="this" hx-swap="innerHTML"
+                    hx-on::after-request="afterMoveResourcesDropdownReq(this)">
+                    <option disabled selected>Loading curriculums...</option>
+                </select>
+
+                <select id="grade-dropdown" name="grade-dropdown" class="border p-2 rounded w-full"
+                    hx-get="/api/grades" hx-trigger="load" hx-target="this" hx-swap="innerHTML"
+                    hx-on::after-request="afterMoveResourcesDropdownReq(this)">
+                    <option disabled selected>Loading grades...</option>
+                </select>
+
+                <select id="subject-dropdown" name="subject-dropdown" class="border p-2 rounded w-full"
+                    hx-get="/api/subjects" hx-trigger="load" hx-target="this" hx-swap="innerHTML"
+                    hx-on::after-request="afterMoveResourcesDropdownReq(this)">
+                    <option disabled selected>Loading subjects...</option>
+                </select>
+
+                <select id="chapter-dropdown" name="chapter-dropdown" class="border p-2 rounded w-full"
+                    hx-get="/api/chapters" hx-target="this" hx-swap="innerHTML"
+                    hx-trigger="loadChapters, change from:(#move-resources-modal #curriculum-dropdown, #move-resources-modal #grade-dropdown, #move-resources-modal #subject-dropdown)"
+                    hx-include="#move-resources-modal #curriculum-dropdown, #move-resources-modal #grade-dropdown, #move-resources-modal #subject-dropdown"
+                    hx-params="not chapter-dropdown" hx-on::before-request="beforeMoveResourcesChaptersRequest()"
+                    hx-on::after-request="toggleMoveResourceButton()">
+                    <option disabled selected>Loading chapters...</option>
+                </select>
+
+                <select id="topic-dropdown" name="topic_id" class="border p-2 rounded w-full"
+                    hx-get="/api/topics?view=dropdown-optional" hx-trigger="change from:#chapter-dropdown"
+                    hx-target="this" hx-swap="innerHTML" hx-include="#chapter-dropdown"
+                    hx-on::before-request="beforeMoveResourcesTopicsRequest()" hx-on::after-request="toggleMoveResourceButton()">
+                    <option value="" selected hidden>Select Topic (Optional)</option>
+                </select>
+            </div>
+
+            <div class="w-full flex justify-end space-x-2 pt-4">
+                <button type="button" onclick="closeMoveResourcesModal()"
+                    class="bg-gray-300 px-4 py-2 rounded hover:bg-gray-400 transition">
+                    Cancel
+                </button>
+
+                <button id="move-resource-btn" type="submit" disabled
+                    class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition disabled:bg-gray-300 disabled:cursor-not-allowed">
+                    <span class="btn-text">Move</span>
+                    <span class="btn-loader hidden">Moving...</span>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+<script>
+function afterMoveResourcesDropdownReq(dropdown) {
+    dropdown.dataset.loaded = "true";
+
+    const modal = document.getElementById("move-resources-modal");
+    const allReady =
+        modal.querySelector("#curriculum-dropdown").dataset.loaded &&
+        modal.querySelector("#grade-dropdown").dataset.loaded &&
+        modal.querySelector("#subject-dropdown").dataset.loaded;
+
+    if (allReady) {
+        htmx.trigger("#chapter-dropdown", "loadChapters");
+    }
+}
+
+function beforeMoveResourcesChaptersRequest() {
+    const chapter = document.getElementById("chapter-dropdown");
+    chapter.innerHTML = '<option disabled selected>Loading chapters...</option>';
+
+    const topic = document.getElementById("topic-dropdown");
+    topic.innerHTML = '<option value="" selected hidden>Select Topic (Optional)</option>';
+
+    const modal = document.getElementById("move-resources-modal");
+    modal.querySelector("#move-resource-btn").disabled = true;
+}
+
+function beforeMoveResourcesTopicsRequest() {
+    const topic = document.getElementById("topic-dropdown");
+    topic.innerHTML = '<option disabled selected>Loading topics...</option>';
+}
+
+function toggleMoveResourceButton() {
+    const modal = document.getElementById("move-resources-modal");
+    const chapter = modal.querySelector("#chapter-dropdown");
+    const moveBtn = modal.querySelector("#move-resource-btn");
+    moveBtn.disabled = !chapter.value;
+}
+
+function handleMoveResourcesResponse(event) {
+    const { xhr, requestConfig } = event.detail;
+    if (requestConfig.path !== "/move-resource") return;
+
+    if (xhr.status === 200) {
+        closeMoveResourcesModal();
+        htmx.trigger("#resourceTableBody", "refreshResources");
+    } else {
+        showToast(xhr.responseText || "Failed to move resource");
+    }
+}
+
+function closeMoveResourcesModal() {
+    document.getElementById("move-resources-modal").remove();
+}
+</script>

--- a/web/html/resource_row.html
+++ b/web/html/resource_row.html
@@ -1,0 +1,23 @@
+{{ range . }}
+<tr class="border-b hover:bg-gray-100">
+    <td class="py-4 px-6">{{.Code}}</td>
+    <td class="px-6">{{ getName . "en" }}</td>
+    <td class="px-6">{{.Type}}</td>
+    <td class="px-6">{{.Subtype}}</td>
+    <td class="px-6 text-blue-500 hover:underline">
+        {{ if .TypeParams.SrcLink }}
+        <a href="{{ .TypeParams.SrcLink }}" target="_blank" rel="noopener noreferrer">
+            {{ .TypeParams.SrcLink }}
+        </a>
+        {{ end }}
+    </td>
+    <td class="space-x-4">
+        <button class="action-button">
+            <i class="fa-solid fa-pen"></i>
+        </button>
+        <button class="action-button">
+            <i class="fa-solid fa-trash"></i>
+        </button>
+    </td>
+</tr>
+{{ end }}

--- a/web/html/resource_row.html
+++ b/web/html/resource_row.html
@@ -15,7 +15,8 @@
         <button class="action-button" hx-get="/edit-resource?id={{.ID}}" hx-target="#subContent" hx-push-url="true">
             <i class="fa-solid fa-pen"></i>
         </button>
-        <button class="action-button">
+        <button class="action-button" hx-delete="/archive-resource?id={{.ID}}"
+            hx-confirm="Are you sure you want to delete resource {{ getName . "en" }}?" hx-target="closest tr">
             <i class="fa-solid fa-trash"></i>
         </button>
     </td>

--- a/web/html/resource_row.html
+++ b/web/html/resource_row.html
@@ -15,6 +15,9 @@
         <button class="action-button" hx-get="/edit-resource?id={{.ID}}" hx-target="#subContent" hx-push-url="true">
             <i class="fa-solid fa-pen"></i>
         </button>
+        <button class="action-button opacity-50 cursor-not-allowed" type="button" title="Move (coming soon)" disabled>
+            <i class="fa-solid fa-right-left"></i>
+        </button>
         <button class="action-button" hx-delete="/archive-resource?id={{.ID}}"
             hx-confirm="Are you sure you want to delete resource {{ getName . "en" }}?" hx-target="closest tr">
             <i class="fa-solid fa-trash"></i>

--- a/web/html/resource_row.html
+++ b/web/html/resource_row.html
@@ -12,7 +12,7 @@
         {{ end }}
     </td>
     <td class="space-x-4">
-        <button class="action-button">
+        <button class="action-button" hx-get="/edit-resource?id={{.ID}}" hx-target="#subContent" hx-push-url="true">
             <i class="fa-solid fa-pen"></i>
         </button>
         <button class="action-button">

--- a/web/html/resource_row.html
+++ b/web/html/resource_row.html
@@ -15,7 +15,8 @@
         <button class="action-button" hx-get="/edit-resource?id={{.ID}}" hx-target="#subContent" hx-push-url="true">
             <i class="fa-solid fa-pen"></i>
         </button>
-        <button class="action-button opacity-50 cursor-not-allowed" type="button" title="Move (coming soon)" disabled>
+        <button class="action-button" hx-post="/resources/move-resource" hx-target="body" hx-swap="beforeend"
+            hx-vals='{"resource_ids":"{{.ID}}"}' title="Move Resource">
             <i class="fa-solid fa-right-left"></i>
         </button>
         <button class="action-button" hx-delete="/archive-resource?id={{.ID}}"

--- a/web/html/resources.html
+++ b/web/html/resources.html
@@ -34,16 +34,15 @@
     </div>
 
     <!-- Form to add new resource -->
-    {{ if .ChapterId }}
-        <div class="mt-4">
-            <h4 id="addResourceLink" class="text-sm font-semibold text-blue-500 hover:underline" onclick="toggleResourceForm(event, '{{.ChapterId}}')">
-                <a href="#">Add New Resource</a>
-            </h4>
-        </div>
-    {{ end }}
+    <div class="mt-4">
+        <h4 id="addResourceLink" class="text-sm font-semibold text-blue-500 hover:underline"
+            onclick="toggleResourceForm(event, '{{.ChapterId}}', '{{.TopicId}}')">
+            <a href="#">Add New Resource</a>
+        </h4>
+    </div>
 </div>
 <script>
-    function toggleResourceForm(event, chapterId) {
+    function toggleResourceForm(event, chapterId, topicId) {
         event.preventDefault();
 
         var form = document.getElementById("addResourceForm");
@@ -51,7 +50,8 @@
         if (form != null) {
             form.remove();
         } else {
-            htmx.ajax('GET', `/add-resource?chapterId=${chapterId}`, {
+            const topicIdParam = topicId ? `&topicId=${topicId}` : '';
+            htmx.ajax('GET', `/add-resource?chapterId=${chapterId}${topicIdParam}`, {
                 target: '#addResourceLink',
                 swap: 'afterend'
             });

--- a/web/html/resources.html
+++ b/web/html/resources.html
@@ -11,13 +11,23 @@
                     <th class="px-6 text-center">Actions</th>
                 </tr>
             </thead>
+            <!-- Reason of using delay:150ms, change from:(#curriculum-dropdown, #grade-dropdown) here:
+             If we use hx-trigger="load", then it is fired immediately (often before afterDropdownReq() finishes 
+             restoring the curriculum/grade dropdown values from URL/session), which will produced the first request 
+             with the default dropdown values (like 1,1), then later another request with the restored values (like 2,3).
+             hx-trigger="load delay:150ms, change from:(#curriculum-dropdown, #grade-dropdown)" ensures the initial load 
+             happens after afterDropdownReq() has had time to set the correct dropdown values (it triggers onLoaded after 100ms), 
+             so you should see only one /api/resources call with the correct params when returning with Resources tab active. 
+             eg - Click edit on any resource -> Back. It should invoke /api/resources only once
+             -->
             <tbody id="resourceTableBody" class="text-gray-600 text-sm"
                 {{ if .TopicId }}
                     hx-get="/api/resources?topic_id={{.TopicId}}"
                 {{ else }}
                     hx-get="/api/resources?chapter_id={{.ChapterId}}"
                 {{ end }}
-                hx-trigger="load" hx-include="#curriculum-dropdown, #grade-dropdown">
+                hx-trigger="load delay:150ms, change from:(#curriculum-dropdown, #grade-dropdown)"
+                hx-include="#curriculum-dropdown, #grade-dropdown">
                 <!-- Rows will be dynamically inserted here -->
             </tbody>
         </table>

--- a/web/html/resources.html
+++ b/web/html/resources.html
@@ -26,7 +26,7 @@
                 {{ else }}
                     hx-get="/api/resources?chapter_id={{.ChapterId}}"
                 {{ end }}
-                hx-trigger="load delay:150ms, change from:(#curriculum-dropdown, #grade-dropdown)"
+                hx-trigger="load delay:150ms, change from:(#curriculum-dropdown, #grade-dropdown), refreshResources"
                 hx-include="#curriculum-dropdown, #grade-dropdown">
                 <!-- Rows will be dynamically inserted here -->
             </tbody>

--- a/web/html/resources.html
+++ b/web/html/resources.html
@@ -11,8 +11,8 @@
                     <th class="px-6 text-center">Actions</th>
                 </tr>
             </thead>
-            <tbody id="resourceTableBody" class="text-gray-600 text-sm" hx-get="/api/resources?chapterId={{.ChapterId}}"
-                hx-trigger="load">
+            <tbody id="resourceTableBody" class="text-gray-600 text-sm" hx-get="/api/resources?chapter_id={{.ChapterId}}"
+                hx-trigger="load" hx-include="#curriculum-dropdown, #grade-dropdown">
                 <!-- Rows will be dynamically inserted here -->
             </tbody>
         </table>
@@ -20,7 +20,7 @@
 
     <!-- Form to add new resource -->
     <div class="mt-4">
-        <h4 id="addResourceLink" class="text-sm font-semibold text-blue-500 hover:underline" onclick="toggleResourceForm(event, {{.ChapterId}})">
+        <h4 id="addResourceLink" class="text-sm font-semibold text-blue-500 hover:underline" onclick="toggleResourceForm(event, '{{.ChapterId}}')">
             <a href="#">Add New Resource</a>
         </h4>
     </div>

--- a/web/html/resources.html
+++ b/web/html/resources.html
@@ -1,2 +1,43 @@
-<h2>Resources Content</h2>
-<p>This is the content of Resources.</p>
+<div>
+    <div class="shadow-md overflow-x-auto">
+        <table class="min-w-full bg-white">
+            <thead>
+                <tr class="bg-gray-200 text-gray-600 text-sm">
+                    <th class="py-4 px-6 text-left">Code</th>
+                    <th class="px-6 text-left">Name</th>
+                    <th class="px-6 text-left">Type</th>
+                    <th class="px-6 text-left">Subtype</th>
+                    <th class="px-6 text-left">URL</th>
+                    <th class="px-6 text-center">Actions</th>
+                </tr>
+            </thead>
+            <tbody id="resourceTableBody" class="text-gray-600 text-sm" hx-get="/api/resources?chapterId={{.ChapterId}}"
+                hx-trigger="load">
+                <!-- Rows will be dynamically inserted here -->
+            </tbody>
+        </table>
+    </div>
+
+    <!-- Form to add new resource -->
+    <div class="mt-4">
+        <h4 id="addResourceLink" class="text-sm font-semibold text-blue-500 hover:underline" onclick="toggleResourceForm(event, {{.ChapterId}})">
+            <a href="#">Add New Resource</a>
+        </h4>
+    </div>
+</div>
+<script>
+    function toggleResourceForm(event, chapterId) {
+        event.preventDefault();
+
+        var form = document.getElementById("addResourceForm");
+
+        if (form != null) {
+            form.remove();
+        } else {
+            htmx.ajax('GET', `/add-resource?chapterId=${chapterId}`, {
+                target: '#addResourceLink',
+                swap: 'afterend'
+            });
+        }
+    }
+</script>

--- a/web/html/resources.html
+++ b/web/html/resources.html
@@ -11,7 +11,12 @@
                     <th class="px-6 text-center">Actions</th>
                 </tr>
             </thead>
-            <tbody id="resourceTableBody" class="text-gray-600 text-sm" hx-get="/api/resources?chapter_id={{.ChapterId}}"
+            <tbody id="resourceTableBody" class="text-gray-600 text-sm"
+                {{ if .TopicId }}
+                    hx-get="/api/resources?topic_id={{.TopicId}}"
+                {{ else }}
+                    hx-get="/api/resources?chapter_id={{.ChapterId}}"
+                {{ end }}
                 hx-trigger="load" hx-include="#curriculum-dropdown, #grade-dropdown">
                 <!-- Rows will be dynamically inserted here -->
             </tbody>
@@ -19,11 +24,13 @@
     </div>
 
     <!-- Form to add new resource -->
-    <div class="mt-4">
-        <h4 id="addResourceLink" class="text-sm font-semibold text-blue-500 hover:underline" onclick="toggleResourceForm(event, '{{.ChapterId}}')">
-            <a href="#">Add New Resource</a>
-        </h4>
-    </div>
+    {{ if .ChapterId }}
+        <div class="mt-4">
+            <h4 id="addResourceLink" class="text-sm font-semibold text-blue-500 hover:underline" onclick="toggleResourceForm(event, '{{.ChapterId}}')">
+                <a href="#">Add New Resource</a>
+            </h4>
+        </div>
+    {{ end }}
 </div>
 <script>
     function toggleResourceForm(event, chapterId) {

--- a/web/html/topic.html
+++ b/web/html/topic.html
@@ -11,6 +11,8 @@
             hx-trigger="click, load" hx-get="/concepts" hx-target="#subContent">Concepts</button>
         <button id="problems-tab" data-toggle="sub-tab" class="sub-tab" onclick="onTopicTabClick(this)"
             hx-get="/topic/problems?topic_id={{.TopicPtr.ID}}" hx-target="#subContent">Problems</button>
+        <button id="resources-tab" data-toggle="sub-tab" class="sub-tab" onclick="onTopicTabClick(this)"
+            hx-get="/topic/resources?topicId={{.TopicPtr.ID}}" hx-target="#subContent">Resources</button>
     </div>
     <div id="sub-tabContent">
         <div id="subContent">

--- a/web/html/topic.html
+++ b/web/html/topic.html
@@ -12,7 +12,7 @@
         <button id="problems-tab" data-toggle="sub-tab" class="sub-tab" onclick="onTopicTabClick(this)"
             hx-get="/topic/problems?topic_id={{.TopicPtr.ID}}" hx-target="#subContent">Problems</button>
         <button id="resources-tab" data-toggle="sub-tab" class="sub-tab" onclick="onTopicTabClick(this)"
-            hx-get="/topic/resources?topicId={{.TopicPtr.ID}}" hx-target="#subContent">Resources</button>
+            hx-get="/topic/resources?topicId={{.TopicPtr.ID}}&chapterId={{.TopicPtr.ChapterID}}" hx-target="#subContent">Resources</button>
     </div>
     <div id="sub-tabContent">
         <div id="subContent">

--- a/web/html/topic_dropdown_optional.html
+++ b/web/html/topic_dropdown_optional.html
@@ -1,0 +1,4 @@
+<option value="" selected hidden>Select Topic (Optional)</option>
+{{ range . }}
+    <option value="{{.ID}}">{{ getName . "en" }}</option>
+{{ end }}

--- a/web/static/css/output.css
+++ b/web/static/css/output.css
@@ -698,6 +698,7 @@ video {
 }
 
 .sub-tab {
+  cursor: pointer;
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
   padding-left: 1rem;
@@ -1841,11 +1842,6 @@ video {
   padding-bottom: 1rem;
 }
 
-.py-6 {
-  padding-top: 1.5rem;
-  padding-bottom: 1.5rem;
-}
-
 .pl-11 {
   padding-left: 2.75rem;
 }
@@ -2055,16 +2051,14 @@ video {
 
 /* Custom styles using @apply */
 
-#loader.htmx-request {
-  display: table-row-group;
-}
-
 /* Wrap MathJax formulae to next line */
+
 mjx-container[jax="CHTML"] mjx-math {
   white-space: normal !important;
 }
 
 /* If a matrix exists, disable wrapping for that formula */
+
 mjx-container[jax="CHTML"] mjx-math:has(mjx-mtable) {
   white-space: nowrap !important;
 }

--- a/web/static/js/resource-form.js
+++ b/web/static/js/resource-form.js
@@ -5,6 +5,7 @@ window.ResourceForm = {
     subtypesByType: {
         document: ["Module", "Previous Year Questions"],
         quiz: ["Assessment"],
+        quiz_template: ["Quiz Template"],
         video: ["Video Lectures"],
     },
 

--- a/web/static/js/resource-form.js
+++ b/web/static/js/resource-form.js
@@ -1,0 +1,60 @@
+/**
+ * Client-side type → subtype options for resource add/edit (no server-side validation).
+ */
+window.ResourceForm = {
+    subtypesByType: {
+        document: ["Module", "Previous Year Questions"],
+        quiz: ["Assessment"],
+        video: ["Video Lectures"],
+    },
+
+    /**
+     * @param {HTMLSelectElement} subtypeEl
+     * @param {string} typeValue raw type value (e.g. "document")
+     * @param {string} [selectedSubtype] pre-selected label, or "" to only show placeholder
+     */
+    fillSubtypeSelect: function (subtypeEl, typeValue, selectedSubtype) {
+        var t = (typeValue || "").toLowerCase();
+        var subs = this.subtypesByType[t] || [];
+        selectedSubtype = selectedSubtype === undefined || selectedSubtype === null ? "" : String(selectedSubtype);
+
+        subtypeEl.innerHTML = "";
+        var placeholder = document.createElement("option");
+        placeholder.value = "";
+        placeholder.disabled = true;
+        placeholder.hidden = true;
+        placeholder.textContent = subs.length ? "Select Subtype" : "Select type first";
+
+        var matched = selectedSubtype && subs.indexOf(selectedSubtype) !== -1;
+        placeholder.selected = !matched;
+        subtypeEl.appendChild(placeholder);
+
+        subs.forEach(function (label) {
+            var opt = document.createElement("option");
+            opt.value = label;
+            opt.textContent = label;
+            if (matched && selectedSubtype === label) {
+                opt.selected = true;
+                placeholder.selected = false;
+            }
+            subtypeEl.appendChild(opt);
+        });
+
+        subtypeEl.disabled = subs.length === 0;
+    },
+
+    /**
+     * @param {string} typeId element id of type select
+     * @param {string} subtypeId element id of subtype select
+     * @param {string} [selectedSubtype] omit or pass "" when type changes (clear subtype)
+     */
+    sync: function (typeId, subtypeId, selectedSubtype) {
+        var typeEl = document.getElementById(typeId);
+        var subEl = document.getElementById(subtypeId);
+        if (!typeEl || !subEl) return;
+        if (selectedSubtype === undefined) {
+            selectedSubtype = "";
+        }
+        this.fillSubtypeSelect(subEl, typeEl.value, selectedSubtype);
+    },
+};


### PR DESCRIPTION
## Summary
🎯 This PR improves **resource** handling for **chapters & topics**, adds a **Resources** tab on the chapter & topic screen supporting basic CRUD operations, implements **move resource**, and centralizes **type → subtype** UI in shared JS

## What’s included

### 📚 List
- New **Resources** Tab under single chapter & topic screen
- **Chapter resources**: response filtered so only selected chapter level resources with **no topic** (`topic_id == 0`) show .
- **Topic resources**: only resources from selected topic show 
- **Filtering**: Filter out _archived_ resources, and resources of types - _test / problem_

### Supported operations/actions:
- ➕ Create resource
- ✏️ Edit resource
     - Delayed load to avoid **double** calls on back navigation
- 🗑️ Delete/Archive resource
- 🔀 Move resource
    - **Move** action on resource rows → opens a modal with 5 dropdowns _curriculum, grade, subject, chapter, topic_ → **`/move-resource`** posting to **`resources/move`**.
    - **`topic_id`**: sends **`null`** in JSON when moving to **chapter-only** (so as to clear old resource-topic mapping); numeric when moving to a **topic**.
    - **Topic** selection is optional in _Move resource dialog_ when user wants to move it to chapter level

### 🎛️ Resource Type / subtype in add / edit resource form:
- **`resource-form.js`** (loaded from **`home.html`**) drives subtype options from type for **add** and **edit**.

### 🧾 DTO / problems move
- Shared **`MoveResourcesRequest`** DTO for both **problems** and **resources** move payloads; removed duplicate **`move_problems_dto`**.

## How to test
1. Open a **chapter** → Resources: list shows **chapter-level** resources only; add resource attaches to chapter; add/delete/move as needed.
2. Open a **topic** → Resources: list is **topic-scoped**; add resource attaches to topic; add/delete/move as needed.
3. **Move** a resource to another chapter (no topic): confirm API payload has **`"topic_id": null`** and list refreshes.
4. **Edit** resource: type change updates subtype options; save works and refreshes list on successful save.
