### PR TITLE
Fix topic route tab state and filter reset

### DIFF
--- a/tests/test-chapters.spec.ts
+++ b/tests/test-chapters.spec.ts
@@ -1,6 +1,17 @@
 import { test, expect } from "@playwright/test";
 import { dropdowns, HOME_PAGE_URL } from "./utils";
 import * as mock from "./mock";
+import * as fs from "fs";
+
+function mergeHomeContent(contentPath: string) {
+    let contentData = fs.readFileSync(contentPath, "utf-8");
+    let baseData = fs.readFileSync("web/html/home.html", "utf-8");
+    const extractedBody = baseData.match(/<body>([\s\S]*?)<\/body>/);
+    if (extractedBody) {
+        baseData = extractedBody[1].trim();
+    }
+    return baseData.replace(/{{ block "content" . }}[\s\S]*?{{ end }}/, contentData);
+}
 
 test('verify that all table headers, add new chapter link are available and form is hidden', async ({ page }) => {
 
@@ -51,6 +62,35 @@ test('clicking add new chapter opens form and clicking it again hides it', async
 
     await addChapterLink.click();
     await expect(addChapterForm).toBeHidden();
+});
+
+test('topic routes keep Chapters active and restore top-level filters', async ({ page }) => {
+    for (const { urlPattern, content } of dropdowns) {
+        await mock.mockDropdownApi(page, urlPattern, content);
+    }
+
+    await page.route(/\/tests$/, async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'text/html',
+            body: mergeHomeContent('web/html/tests.html')
+        });
+    });
+
+    await page.goto(HOME_PAGE_URL);
+    await page.click('#tests-tab');
+    await expect(page.locator('#subject-dropdown')).toBeHidden();
+
+    await page.evaluate(() => {
+        history.pushState({}, '', '/topic?id=11');
+        htmx.trigger(document.body, 'htmx:afterSettle');
+    });
+
+    await expect(page).toHaveURL(/\/topic\?id=11$/);
+    await expect(page.locator('#chapters-tab')).toHaveClass(/active/);
+    await expect(page.locator('#curriculum-dropdown')).toBeVisible();
+    await expect(page.locator('#grade-dropdown')).toBeVisible();
+    await expect(page.locator('#subject-dropdown')).toBeVisible();
 });
 
 // TODO: Update following test once sorting state management is shifted from server to client

--- a/web/html/home.html
+++ b/web/html/home.html
@@ -131,6 +131,7 @@
             function getTabURLFromPath(path) {
                 // Define URL-to-tab mapping based on expected paths
                 if (path.startsWith("/chapter")) return "chapters-tab";
+                if (path.startsWith("/topic")) return "chapters-tab";
                 if (path.startsWith("/test")) return "tests-tab";
                 if (path.startsWith("/problem")) return "problems-tab";
                 return null;
@@ -155,9 +156,17 @@
                     const activeTab = document.getElementById(activeTabId);
                     if (activeTab) activeTab.classList.add("active");
                 }
-                
-                // Hide subject dropdown when "Tests" tab is active
+
+                const curriculumDropdown = document.getElementById("curriculum-dropdown");
+                const gradeDropdown = document.getElementById("grade-dropdown");
                 const subjectDropdown = document.getElementById("subject-dropdown");
+                [curriculumDropdown, gradeDropdown, subjectDropdown].forEach(dropdown => {
+                    if (dropdown) {
+                        dropdown.style.display = "";
+                    }
+                });
+
+                // Hide subject dropdown when "Tests" tab is active
                 if (activeTabId === "tests-tab") { 
                     if (!(currentPath.endsWith("/add-test") || currentPath.endsWith("/edit-test") 
                             || currentPath.endsWith("/copy-test"))) {
@@ -166,9 +175,7 @@
 
                 } else if (activeTabId === "problems-tab") {
                     if (currentPath.endsWith("/problems")) {
-                        const curriculumDropdown = document.getElementById("curriculum-dropdown");
                         curriculumDropdown.style.display = "none";
-                        const gradeDropdown = document.getElementById("grade-dropdown");
                         gradeDropdown.style.display = "none";
                         subjectDropdown.style.display = "none";
                     }


### PR DESCRIPTION
## Summary
- keep the Chapters tab active for topic routes
- reset top-level filter visibility before applying route-specific hiding rules
- add a Playwright regression test covering the route/filter behavior tied to issue #84

## Root Cause
The client-side route mapping in `home.html` handled chapter, test, and problem paths, but not topic paths. The same updater also hid dropdowns for some routes without first restoring them, so filters could remain hidden after navigating back into chapter/topic flows.

## Validation
- ran `npx playwright test tests/test-chapters.spec.ts --grep "topic routes keep Chapters active and restore top-level filters" --project=chromium --reporter=line`

Closes #84.
