### PR TITLE
🐛 Fix: Back navigation opening wrong Problems tab

### DIFF
--- a/web/html/topic.html
+++ b/web/html/topic.html
@@ -7,9 +7,9 @@
         <h3 class="text-base font-semibold ml-4">{{ getName .TopicPtr "en" }}</h3>
     </div>
     <div class="flex space-x-4 py-4">
-        <button id="concepts-tab" data-toggle="sub-tab" class="sub-tab active" onclick="onTopicTabClick(this)"
+        <button id="topic-concepts-tab" data-toggle="sub-tab" class="sub-tab active" onclick="onTopicTabClick(this)"
             hx-trigger="click, load" hx-get="/concepts" hx-target="#subContent">Concepts</button>
-        <button id="problems-tab" data-toggle="sub-tab" class="sub-tab" onclick="onTopicTabClick(this)"
+        <button id="topic-problems-tab" data-toggle="sub-tab" class="sub-tab" onclick="onTopicTabClick(this)"
             hx-get="/topic/problems?topic_id={{.TopicPtr.ID}}" hx-target="#subContent">Problems</button>
     </div>
     <div id="sub-tabContent">
@@ -36,8 +36,8 @@
     }
 
     document.querySelector(TOPIC_DIV_SELECTOR).addEventListener(BACK_TO_TOPIC_EVT, () => {
-        // Using default 1st tab having id "concepts-tab"
-        const selectedTab = sessionStorage.getItem(SESSION_KEY_TOPIC_TAB) || "concepts-tab";
+        // Using default 1st tab having id "topic-concepts-tab"
+        let selectedTab = sessionStorage.getItem(SESSION_KEY_TOPIC_TAB) || "topic-concepts-tab";
         const tabButton = document.getElementById(selectedTab);
         if (tabButton) {
             tabButton.click();


### PR DESCRIPTION
### 📌 Summary
Fixes an issue where using the back button would incorrectly open the **Home screen Problems tab** instead of the **Topic-level Problems tab**.

---

### 🔍 Root Cause
Both tabs (Home-level and Topic-level Problems tabs) were using the **same HTML `id`**, causing a conflict in tab selection logic.

---

### ✅ Fix Implemented
- Assigned **unique IDs** to Topic-level Problems tab

---

### 🎯 Result
- Back navigation now correctly restores the **Topic Problems tab**
- Eliminates unintended redirection to Home Problems tab

---

### 🧪 Testing
- Verified back navigation from problem detail view
- Confirmed correct tab state restoration for:
  - Topic-level Problems tab
  - Home-level Problems tab (unchanged behavior)
