### PR TITLE
✨ Single problem screen - Remove Extra Space Before Comma in Concepts & Skills

### DIFF
--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -29,18 +29,18 @@
             CONCEPTS
         </h2>
         <p class="mt-2">
-            {{ range $index, $concept := .ProblemPtr.Concepts }}
-                {{ if $index }}, {{ end }}{{ getName $concept "en" }}
-            {{ end }}
+            {{- range $index, $concept := .ProblemPtr.Concepts -}}
+                {{- if $index }}, {{ end -}}{{ getName $concept "en" }}
+            {{- end -}}
         </p>
         {{ end }}
         <h2 class="text-lg font-semibold mt-4">
             SKILL
         </h2>
         <p class="mt-2">
-            {{ range $index, $skill := .ProblemPtr.Skills }}
-                {{ if $index }}, {{ end }}{{ $skill.Name }}
-            {{ end }}
+            {{- range $index, $skill := .ProblemPtr.Skills -}}
+                {{- if $index }}, {{ end -}}{{ $skill.Name }}
+            {{- end -}}
         </p>
         {{ if .ProblemPtr.MetaData.Options }}
         <h2 class="text-lg font-semibold mt-4">


### PR DESCRIPTION
### 📝 Description
- Fixed UI issue on the **Single Problem** screen where an extra space appeared before commas under **Concepts & Skills**
- Ensures cleaner and more consistent text formatting