### PR TITLE
🐛 Fix: Prevent unintended removal of section & subject headers when deleting a problem

### DIFF
--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -685,18 +685,16 @@
         let nextRow = problemRow.nextElementSibling;
         problemRow.remove();
 
-        const subject = problemRow.dataset.subject;
-        const subtype = problemRow.dataset.subtype;
-        const tableBody = document.getElementById("questions-table-body");
+        // Remove subtype header row only when it's "dangling" (no problems under it)
+        const nextRowIsProblem = nextRow && nextRow.id.startsWith("problem-");
 
-        // Remove subtype header if no more problems of that subtype under same subject remain
-        const remainingSubtypeProblems = tableBody.querySelectorAll(`tr[id^="problem-"][data-subject="${subject}"][data-subtype="${subtype}"]`);
-        if (remainingSubtypeProblems.length === 0) {
+        if (prevRow.id.startsWith("subtype-") && !nextRowIsProblem) {
             prevRow.remove();
 
-            // Remove subject header if no more problems of that subject remain
-            const remainingSubjectProblems = tableBody.querySelectorAll(`tr[id^="problem-"][data-subject="${subject}"]`);
-            if (remainingSubjectProblems.length === 0) {
+            // Remove subject header row only when it's "dangling" (no sections under it)
+            const nextRowIsSubtypeHeader = nextRow && nextRow.id.startsWith("subtype-");
+
+            if (prevPrevRow.id.startsWith("subject-") && !nextRowIsSubtypeHeader) {
                 prevPrevRow.remove();
                 updateSubjectArrowStates();
             }


### PR DESCRIPTION
### 🔍 Issue
Removing a problem from a test was also incorrectly removing its corresponding **section** and **subject headers**, even when it should not.

---

### 🧠 Root Cause
- This issue occurred when a problem’s subtype was modified after being added to the test  
  (e.g., from **MCQ Single Answer** → **MCQ Multiple Answer**)
- Initially, the problem was grouped under its original subtype section
- After subtype change, it conflicted with its current section grouping logic
- Header removal logic relied on the removed problem’s subtype instead of actual DOM structure

---

### ✅ Fix Implemented
1. Updated logic to avoid blindly removing headers based on problem subtype
2. While removing a problem row:
   - 🔹 Remove **section header** only if:
     - Previous row is a section header  
     - Next row is **not** another problem row
   - 🔹 Remove **subject header** only if:
     - Previous-to-previous row is a subject header  
     - Next row is **not** a section header
3. Ensures headers are removed **only when truly empty**, preventing unintended UI inconsistencies

---

### 🎯 Result
- Correct handling of dynamically changed problem subtypes
- Stable UI with accurate section & subject grouping
- No accidental header deletions on problem removal

---