### PR TITLE
🗑️ Delete Gurukul Resources Instead of Archiving + Fix Subtype Preselection Issue

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -105,7 +105,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.HandleFunc("/api/resources", resourcesHandler.GetResources)
 	muxHandler.Handle("/edit-resource", middleware.RequireHTMX(http.HandlerFunc(resourcesHandler.EditResource)))
 	muxHandler.HandleFunc("/update-resource", resourcesHandler.UpdateResource)
-	muxHandler.HandleFunc("/archive-resource", resourcesHandler.ArchiveResource)
+	muxHandler.HandleFunc("/delete-resource", resourcesHandler.DeleteResource)
 	muxHandler.HandleFunc("/resources/move-resource", resourcesHandler.LoadMoveResources)
 	muxHandler.HandleFunc("/move-resource", resourcesHandler.MoveResource)
 

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/avantifellows/nex-gen-cms/internal/constants"
 	"github.com/avantifellows/nex-gen-cms/internal/dto"
 	"github.com/avantifellows/nex-gen-cms/internal/models"
 	"github.com/avantifellows/nex-gen-cms/internal/services"
@@ -106,7 +105,7 @@ func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, requ
 	// remove test & problem resources because we are already managing those via separate tabs
 	for _, resource := range *resources {
 		resourceType := strings.ToLower(resource.Type)
-		if resource.StatusID == constants.StatusArchived || resourceType == "problem" || resourceType == "test" {
+		if resourceType == "problem" || resourceType == "test" {
 			continue
 		}
 		// If the request is for chapter resources, keep only rows that don't belong to a topic.
@@ -176,7 +175,7 @@ func (h *ResourcesHandler) UpdateResource(responseWriter http.ResponseWriter, re
 	views.ExecuteTemplate(updateSuccessTemplate, responseWriter, "Resource", nil)
 }
 
-func (h *ResourcesHandler) ArchiveResource(responseWriter http.ResponseWriter, request *http.Request) {
+func (h *ResourcesHandler) DeleteResource(responseWriter http.ResponseWriter, request *http.Request) {
 	resourceIdStr := request.URL.Query().Get("id")
 	resourceId, err := utils.StringToIntType[int32](resourceIdStr)
 	if err != nil {
@@ -184,14 +183,10 @@ func (h *ResourcesHandler) ArchiveResource(responseWriter http.ResponseWriter, r
 		return
 	}
 
-	resourceMap := map[string]any{
-		"cms_status_id": constants.StatusArchived,
-	}
-
-	err = h.service.ArchiveObject(resourceIdStr, resourcesEndPoint, resourceMap, resourcesKey,
+	err = h.service.DeleteObject(resourceIdStr,
 		func(resource *models.Resource) bool {
 			return resource.ID != int(resourceId)
-		})
+		}, resourcesKey, resourcesEndPoint)
 
 	// If http error is thrown from here then target row won't be removed by htmx code
 	if err != nil {

--- a/web/html/edit_resource.html
+++ b/web/html/edit_resource.html
@@ -23,6 +23,7 @@
       <label for="subtype" class="block text-gray-700 font-medium mb-2">Subtype</label>
       <select id="edit-resource-subtype" name="subtype" class="w-full p-3 border border-gray-300 rounded" required>
       </select>
+      <input type="hidden" id="edit-resource-subtype-value" value="{{.Resource.Subtype}}">
     </div>
     <div class="mb-4">
       <label for="src_link" class="block text-gray-700 font-medium mb-2">SrcLink</label>
@@ -33,5 +34,8 @@
   </form>
 </div>
 <script>
-  ResourceForm.sync('edit-resource-type', 'edit-resource-subtype', {{ printf "%q" .Resource.Subtype }});
+  (() => {
+    const selectedSubtype = document.getElementById('edit-resource-subtype-value')?.value || '';
+    ResourceForm.sync('edit-resource-type', 'edit-resource-subtype', selectedSubtype);
+  })();
 </script>

--- a/web/html/resource_row.html
+++ b/web/html/resource_row.html
@@ -19,7 +19,7 @@
             hx-vals='{"resource_ids":"{{.ID}}"}' title="Move Resource">
             <i class="fa-solid fa-right-left"></i>
         </button>
-        <button class="action-button" hx-delete="/archive-resource?id={{.ID}}"
+        <button class="action-button" hx-delete="/delete-resource?id={{.ID}}"
             hx-confirm="Are you sure you want to delete resource {{ getName . "en" }}?" hx-target="closest tr">
             <i class="fa-solid fa-trash"></i>
         </button>


### PR DESCRIPTION
## 📄 Description  

### ✨ Gurukul Resources Updates  
- 🗑️ Replaced **archive functionality** with **permanent delete** for resources  
- 🔍 Removed logic to **filter archived resources** during fetch (no longer needed)

---

### 🛠️ Bug Fix: Subtype Not Preselected in Edit Resource  
- ❌ Subtype was not appearing as selected when visiting the **Edit Resource** screen  
- ⚠️ Root Cause:  
  - Inline Go template expression inside `<script>` broke JavaScript parsing  
  - As a result, the preselected subtype was **not passed to `ResourceForm.sync(...)`**

- ✅ Fix Implemented:  
  - Passed subtype via a **hidden input field**  
  - Retrieved the value safely in JavaScript to ensure correct preselection

---

### 📌 Impact  
- Simplifies resource lifecycle (no archive state)  
- Fixes incorrect UI behavior in Edit flow  
- Improves JS reliability by avoiding template injection issues

---