### PR TITLE
🔒 Make Problem Type Read-Only in Edit Mode

### DIFF
--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -15,7 +15,8 @@
         <div>
             <p class="font-semibold mb-2">Select Type:</p>
             <select id="problem-type-dropdown" name="problem-type-dropdown"
-                class="w-full border border-gray-300 rounded p-2">
+                {{if .ProblemPtr}}disabled title="Problem type cannot be changed in edit mode"{{end}}
+                class="w-full border border-gray-300 rounded p-2 {{if .ProblemPtr}}bg-gray-100 text-gray-500 cursor-not-allowed{{end}}">
                 {{if .ProblemPtr}}
                 {{template "problem_type_options" .ProblemPtr.Subtype}}
                 {{else}}

--- a/web/static/css/output.css
+++ b/web/static/css/output.css
@@ -1357,6 +1357,10 @@ video {
   width: max-content;
 }
 
+.min-w-56 {
+  min-width: 14rem;
+}
+
 .min-w-\[100px\] {
   min-width: 100px;
 }


### PR DESCRIPTION
### ✨ Summary
Improved the **Edit Problem** experience by preventing changes to the problem type and making the UI clearly indicate its read-only state.

---

### 🛠️ Changes
- 🚫 Made **problem type non-editable** on the Edit Problem screen
- 🎨 Updated styling to clearly reflect **read-only mode**
- 💬 Added helpful tooltip:  
  `title="Problem type cannot be changed in edit mode"`

---

### 🎯 Why
- Prevents accidental or invalid changes to problem structure
- Ensures consistency across problem configurations
- Improves UX with clear visual and contextual cues

---

### 📸 UI Impact
- Problem type field appears **disabled/read-only**
- Tooltip provides **explicit guidance** to users

---

### ✅ Result
Safer edits, clearer UI, and better user guidance ✨