### PR TITLE
style: adopt AF Warm Professional UI across CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ To run the CMS locally, follow these steps:
 1. **nex-gen-cms:** [feat/tests](https://github.com/avantifellows/nex-gen-cms/tree/feat/tests)
 2. **db-service:** [adding-language-table](https://github.com/avantifellows/db-service/tree/adding-language-table)
 
+### UI Style Guide
+
+The CMS follows the **Warm Professional** design language shared with the rest of the AF product family (af_lms, hr-feedback.avantifellows.org). Brand tokens, typography rules, component conventions and HTML snippets are documented in [`docs/UI-Style-Guide.md`](docs/UI-Style-Guide.md). Read that before adding new screens or editing existing ones so the look stays consistent.
+
 ### Tailwind Setup:
 #### ✅ Only Running the App?
 

--- a/docs/UI-Style-Guide.md
+++ b/docs/UI-Style-Guide.md
@@ -1,0 +1,633 @@
+# Avanti Fellows CMS — UI Style Guide
+
+> **Purpose:** Reference for the nex-gen-cms design system — colors, typography, spacing, the shared utility classes, and HTML snippets that match the conventions used across our Go html/template files.
+
+> **Design Language:** Warm Professional — Avanti Brand Maroon (matching `hr-feedback.avantifellows.org`)
+>
+> **Font:** Inter (loaded via Google Fonts in `web/html/home.html` and `web/html/login.html`)
+>
+> **Icons:** Font Awesome 6 (loaded from `cdnjs.cloudflare.com` in the base template)
+>
+> **Shared classes:** Defined in [`input.css`](../input.css) under `@layer components`. Tokens live in [`tailwind.config.js`](../tailwind.config.js) under `theme.extend`. Use Tailwind class names (e.g. `bg-accent`, `text-ink-muted`), never raw hex values.
+>
+> **Sibling style guide:** This guide was adapted from [`af_lms/docs/UI-Style-Guide.md`](https://github.com/avantifellows/af_lms/blob/main/docs/UI-Style-Guide.md). Both apps share the same brand palette and design principles so the CMS, the LMS, and `hr-feedback.avantifellows.org` look like one product.
+
+---
+
+## Table of Contents
+
+1. [Design Philosophy](#1-design-philosophy)
+2. [Color System](#2-color-system)
+3. [Typography](#3-typography)
+4. [Spacing & Sizing](#4-spacing--sizing)
+5. [Shared Utility Classes](#5-shared-utility-classes)
+6. [Page Layouts](#6-page-layouts)
+7. [Headers & Navigation](#7-headers--navigation)
+8. [Cards & Panels](#8-cards--panels)
+9. [Buttons](#9-buttons)
+10. [Form Inputs](#10-form-inputs)
+11. [Tables](#11-tables)
+12. [Status Badges & Pills](#12-status-badges--pills)
+13. [Modals & Dialogs](#13-modals--dialogs)
+14. [Problem Editor & Specialised Components](#14-problem-editor--specialised-components)
+15. [HTMX Loading States](#15-htmx-loading-states)
+16. [Responsive & Mobile](#16-responsive--mobile)
+17. [Rebuilding the CSS](#17-rebuilding-the-css)
+
+---
+
+## 1. Design Philosophy
+
+The CMS UI follows the **Warm Professional** principles shared with the rest of the AF ecosystem:
+
+- **Rounded corners** (`rounded-lg`) on cards, buttons, inputs, form sections — approachable, modern.
+- **Soft shadows** (`shadow-card`, `shadow-xl`) for depth and card separation.
+- **Subtle borders** define hierarchy. `border-b border-border` for headers, `border-b-2 border-border-accent` for colored section dividers.
+- **Uppercase headings + tracking** (`uppercase tracking-wide` or `tracking-tight`) for a structured feel.
+- **Monospace numbers.** Numeric data (codes, counts, durations, dates) uses `font-mono` — this is what makes the data-rich screens feel like an admin tool, not a marketing page.
+- **48px minimum touch targets** on tab items / radio labels, **44px** on buttons and inputs.
+- **Hover + active states on every interactive element** — buttons darken, rows tint, links underline.
+- **Maroon accent** (`#ad2f2f`) is the only interactive color — no hardcoded `blue-500`/`text-blue-600` anywhere.
+- **Warm beige page** (`#f5efe8`) with **cream cards** (`#fffaf5`) — never pure white surfaces.
+- **AF logo** in the header is served from the CDN (`cdn.avantifellows.org/af_logos/avanti_logo_black_text.webp`).
+- **Brand color variety** — coral, gold, amber, blue used sparingly for badges, section dividers, status accents so the screen doesn't feel monotone.
+
+---
+
+## 2. Color System
+
+All colors are defined as Tailwind tokens in `tailwind.config.js`. Use the class names (`bg-accent`, `text-ink`, `border-border-accent`), never raw hex.
+
+### Brand palette
+
+| Color | Hex | Role |
+|-------|-----|------|
+| AF Maroon | `#ad2f2f` | **Primary accent** — buttons, links, active states |
+| AF Dark Brown | `#261410` | Primary text |
+| AF Beige | `#f5efe8` | Page background |
+| AF Cream | `#fffaf5` | Card backgrounds |
+| AF Muted Brown | `#685851` | Secondary/muted text |
+| Brand Coral | `#E96D57` | Stat accents, variety color |
+| Brand Gold | `#FFD063` | Warnings, difficulty stars |
+| Brand Amber | `#FFB763` | Section dividers, subject headers |
+| Brand Blue | `#9AC4FA` | Info, concept chips |
+| Brand Salmon | `#FF9683` | Decorative (available, used sparingly) |
+| Brand Orange | `#D77C11` | Available in palette, currently unused |
+
+### Design tokens
+
+#### Accent
+
+| Class | Value | Usage |
+|-------|-------|-------|
+| `bg-accent` / `text-accent` / `border-accent` | `#ad2f2f` | Primary buttons, active nav tab, links, focus rings |
+| `bg-accent-hover` / `text-accent-hover` | `#8a2525` | Hover states for accent elements |
+| `text-text-on-accent` | `#ffffff` | White text on accent backgrounds |
+
+#### Backgrounds
+
+| Class | Value | Usage |
+|-------|-------|-------|
+| `bg-bg` | `#f5efe8` | Page background (warm beige) — applied to `<body>` |
+| `bg-bg-card` | `#fffaf5` | Card / panel background (cream) |
+| `bg-bg-card-alt` | `#f3ece5` | Table headers, disabled inputs, alt-row striping |
+| `bg-bg-input` | `#ffffff` | Input field background |
+| `bg-bg-hover` | `rgba(173, 47, 47, 0.06)` | Row / item hover background |
+
+#### Text
+
+| Class | Value | Usage |
+|-------|-------|-------|
+| `text-ink` | `#261410` | Headings, main content (dark brown) |
+| `text-ink-secondary` | `#685851` | Supporting text (taupe) |
+| `text-ink-muted` | `#685851` | Labels, captions, metadata, table headers |
+
+#### Borders
+
+| Class | Value | Usage |
+|-------|-------|-------|
+| `border-border` (also bare `border`) | `rgba(38, 20, 16, 0.15)` | Default borders (translucent brown) |
+| `border-border-accent` | `#ad2f2f` | Section dividers under titles, table-head underline |
+
+#### Status
+
+| Class | Value | Usage |
+|-------|-------|-------|
+| `bg-danger` / `text-danger` | `#ad2f2f` | Errors, destructive actions (same hex as accent) |
+| `bg-danger-bg` | `rgba(173, 47, 47, 0.08)` | Light danger background — alerts, deactivate hover |
+| `text-success` / `bg-success` | `#1e6b4b` | Success states (forest green) |
+| `bg-success-bg` | `rgba(30, 107, 75, 0.12)` | Light success background — alerts, active pills |
+| `text-warning` | `#8c5a1d` | Warning text (brown-gold) |
+| `bg-warning-bg` | `rgba(140, 90, 29, 0.08)` | Light warning background |
+| `border-warning-border` | `#8c5a1d` | Warning border |
+| `text-info` | `#9AC4FA` | Info states |
+| `bg-info-bg` | `rgba(154, 196, 250, 0.15)` | Light info background |
+
+#### Brand color range (variety)
+
+Use these to break the monotone — section dividers, subject headers, badge tints, difficulty stars. Pick by hierarchy / semantic feel, not at random.
+
+| Class | Value | Used for |
+|-------|-------|----------|
+| `text-brand-coral` / `border-brand-coral` | `#E96D57` | Decorative accents |
+| `text-brand-gold` / `border-brand-gold` | `#FFD063` | Difficulty stars, warning highlights |
+| `text-brand-amber` / `border-brand-amber` | `#FFB763` | Subject headers on test detail (`border-l-4 border-brand-amber`) |
+| `text-brand-blue` / `border-brand-blue` | `#9AC4FA` | Concept chips, info accents |
+| `bg-brand-coral-bg` | `rgba(233, 109, 87, 0.10)` | Light coral tint |
+| `bg-brand-gold-bg` | `rgba(255, 208, 99, 0.15)` | Light gold tint |
+| `bg-brand-amber-bg` | `rgba(255, 183, 99, 0.12)` | Light amber tint |
+| `bg-brand-blue-bg` | `rgba(154, 196, 250, 0.15)` | Light blue tint — concept chip background |
+
+### Semantic category colors
+
+We don't currently render category-coded badges (problem subtype, test type, role) with distinct hues — they all use the muted/accent badge styles below. If you add a new screen where a single field carries 3-5 mutually-exclusive categories that the user needs to scan visually (e.g. role = viewer/editor/admin), reach for the brand color range above rather than introducing new hex values.
+
+---
+
+## 3. Typography
+
+### Font
+
+**Inter**, loaded via Google Fonts in the base template:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet">
+```
+
+Inter is set as the default `font-sans` in the Tailwind config, so any element inherits it unless `font-mono` is applied.
+
+### Scale
+
+| Element | Classes | Example |
+|---------|---------|---------|
+| Page title | `page-title` (`text-xl sm:text-2xl font-bold uppercase tracking-tight`) | CMS USERS, ADD NEW PROBLEM |
+| Section heading | `section-title` (`text-lg font-bold uppercase tracking-wide border-b-2 border-border-accent pb-2 mb-4`) | STATEMENT / TEXT, OPTIONS |
+| Card title | `text-lg font-bold uppercase tracking-wide text-ink` | (used inline) |
+| Form label | `form-label` (`text-xs font-bold uppercase tracking-wide text-ink-muted mb-1`) | CODE, NAME, DIFFICULTY |
+| Body text | `text-sm text-ink` | Default content |
+| Supporting text | `text-sm text-ink-muted` | Descriptions, table captions |
+| Metadata | `text-xs text-ink-muted` | Hints, "loading…" placeholders |
+| Codes / numbers | `font-mono` | `MTH-11-JEE-17`, `P002290`, `180 min` |
+
+### Rules
+
+- **Uppercase + tracking** for headings, labels, badges, button text — structured, professional feel.
+- **`font-mono`** for every code, count, duration, date and email — this is what makes the screens feel data-rich.
+- **Never ALL CAPS on body text** — only headings, labels, buttons, badges.
+
+---
+
+## 4. Spacing & Sizing
+
+### Touch targets
+
+| Element | Minimum height |
+|---------|----------------|
+| Buttons (default `.btn`) | `min-h-[44px]` |
+| Buttons (`.btn-lg`) | `min-h-[48px]` |
+| Buttons (`.btn-sm`) | `min-h-[36px]` |
+| Inputs / Selects (`.form-input`, `.form-select`) | `min-h-[44px]` |
+| Compact selects in nav (`.form-select-compact`) | `h-10` |
+| Sub-tabs | `min-h-[40px]` |
+
+### Border radius scale
+
+| Element | Radius |
+|---------|--------|
+| Buttons | `rounded-lg` |
+| Cards | `rounded-lg` (default), `rounded-xl` (modal) |
+| Inputs / Selects | `rounded-lg` |
+| Badges | `rounded-full` |
+| Modal shells | `rounded-xl` |
+
+### Shadow scale
+
+| Elevation | Class | Usage |
+|-----------|-------|-------|
+| Subtle (default for cards) | `shadow-card` | Cards, sticky bars, primary panels |
+| Prominent | `shadow-xl` | Modals |
+
+`shadow-card` is a custom token defined in the Tailwind config; it's a softer pair of brown-tinted shadows than the default Tailwind `shadow-md`.
+
+---
+
+## 5. Shared Utility Classes
+
+Defined in [`input.css`](../input.css). Apply by class name in templates — no imports, no JS.
+
+### Buttons
+
+```html
+<button class="btn-primary">Primary</button>
+<button class="btn-secondary">Cancel</button>
+<button class="btn-ghost">Link-style</button>
+<button class="btn-danger">Delete</button>
+<button class="btn-danger-ghost">Remove</button>
+
+<button class="btn-primary btn-sm">Small</button>
+<button class="btn-primary">Medium (default, 44px)</button>
+<button class="btn-primary btn-lg">Large (48px)</button>
+```
+
+All variants include `rounded-lg`, `uppercase tracking-wide`, `transition-colors`, `focus-visible:ring-2`, and `disabled:opacity-50`.
+
+### Card
+
+```html
+<div class="card card-pad">Standard (cream, shadow-card, p-6)</div>
+<div class="card card-pad-sm">Tight (p-4)</div>
+<div class="card shadow-xl rounded-xl p-6">Modal-level</div>
+```
+
+### Inputs
+
+```html
+<input class="form-input" placeholder="Search…">
+<select class="form-select"><option>All</option></select>
+<select class="form-select-compact">…</select>  <!-- For nav bar -->
+<label class="form-label" for="code">School Code</label>
+```
+
+### Badges
+
+Use these for status-style pills (Active, Completed, Pending):
+
+```html
+<span class="badge-success">active</span>
+<span class="badge-warning">in progress</span>
+<span class="badge-danger">archived</span>
+<span class="badge-muted">inactive</span>
+<span class="badge-info">info</span>
+<span class="badge-accent">primary</span>
+```
+
+For a "+ Add new X" inline link (used at the bottom of list tables):
+
+```html
+<h4 class="add-new-link" onclick="…">
+  <a href="#">+ Add New Chapter</a>
+</h4>
+```
+
+### Tables
+
+```html
+<div class="card overflow-x-auto">
+  <table class="app-table">
+    <thead>
+      <tr>
+        <th>Code</th>
+        <th>Name</th>
+        <th class="text-center">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="font-mono">MTH-11-JEE-17</td>
+        <td>Fundamentals of Mathematics</td>
+        <td class="text-center"><!-- action buttons --></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+`.app-table` styles `thead`, `th`, `td`, and `tbody tr:hover` automatically — you only need to add column alignment helpers where needed.
+
+---
+
+## 6. Page Layouts
+
+### Base template
+
+[`web/html/home.html`](../web/html/home.html) provides the standard chrome:
+
+```html
+<body class="bg-bg text-ink min-h-screen">
+  <header class="bg-bg-card border-b border-border shadow-card">
+    <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8">
+      <!-- logo + nav + dropdowns + sign out -->
+    </div>
+  </header>
+  <main class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
+    {{ block "content" . }}…{{ end }}
+  </main>
+</body>
+```
+
+### Detail pages
+
+Wrap the content in a `.card.card-pad` so the back button + title sit on a cream surface against the beige page:
+
+```html
+{{ define "content" }}
+<div class="card card-pad mb-4">
+  <div class="flex items-center mb-4">
+    <button class="btn-ghost btn-sm" onclick="window.history.back()">
+      <i class="fa-solid fa-chevron-left"></i> Back
+    </button>
+    <h3 class="ml-4 text-lg font-bold uppercase tracking-wide text-ink">
+      {{ getName .ChapterPtr "en" }}
+    </h3>
+  </div>
+  <!-- … -->
+</div>
+{{ end }}
+```
+
+---
+
+## 7. Headers & Navigation
+
+### Top nav (in the base template)
+
+```html
+<header class="bg-bg-card border-b border-border shadow-card">
+  <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8">
+    <nav>
+      <div class="nav nav-tabs flex flex-wrap items-center gap-y-2 border-b-0">
+        <a href="/chapters" class="shrink-0 mr-4 sm:mr-6 flex items-center">
+          <img src="https://cdn.avantifellows.org/af_logos/avanti_logo_black_text.webp"
+               alt="Avanti Fellows" class="h-8 sm:h-9">
+        </a>
+
+        <button class="nav-link" hx-get="/chapters" …>Chapters</button>
+        <button class="nav-link" hx-get="/tests" …>Tests</button>
+        <button class="nav-link" hx-get="/problems" …>Problems</button>
+
+        <select class="form-select-compact ms-4 sm:ms-6 w-auto" id="curriculum-dropdown" …>
+          …
+        </select>
+
+        <button hx-post="/logout" class="btn-secondary btn-sm ms-auto my-2">
+          Sign out
+        </button>
+      </div>
+    </nav>
+  </div>
+</header>
+```
+
+`.nav-link` is the state-machine class — JS toggles `.active` on the matching tab, which applies the maroon underline (`border-b-2 border-accent`).
+
+**Mobile notes:** Use `flex-wrap` + `gap-y-2` so items wrap instead of colliding. Tighten gaps to `gap-3` on mobile, `sm:gap-6` on desktop. Add `shrink-0` on the logo to prevent compression.
+
+### Sub-tabs (chapter / topic detail)
+
+```html
+<div class="flex flex-wrap gap-3 py-2 border-b border-border">
+  <div class="sub-tab active" id="topics-sub-tab">Topics</div>
+  <div class="sub-tab" id="resources-sub-tab">Resources</div>
+</div>
+```
+
+JS toggles `.active` to switch panels.
+
+### Section dividers
+
+Use `.section-title` for the standard subsection header inside a card:
+
+```html
+<h2 class="section-title mt-6">Options</h2>
+```
+
+For a thicker divider over a major section:
+
+```html
+<div class="border-b-4 border-border-accent pb-4 mb-6">
+  <h2 class="text-lg font-bold text-ink uppercase tracking-wide">Section Title</h2>
+</div>
+```
+
+---
+
+## 8. Cards & Panels
+
+Use `.card` as the base, then pick padding:
+
+```html
+<div class="card card-pad">Standard (p-6)</div>
+<div class="card card-pad-sm">Tight (p-4)</div>
+<div class="card overflow-hidden">…</div>           <!-- For wrapping tables -->
+<div class="card shadow-xl rounded-xl p-6">…</div>  <!-- Modal shell -->
+```
+
+---
+
+## 9. Buttons
+
+Use `.btn-*` everywhere a button or button-styled link is needed.
+
+```html
+<!-- Action bar at the bottom of a form -->
+<div class="flex gap-3 justify-end pt-2">
+  <button type="button" class="btn-secondary" onclick="window.history.back()">Cancel</button>
+  <button type="submit" class="btn-primary btn-lg">Save Changes</button>
+</div>
+
+<!-- Inline "+ Add new" link -->
+<a href="#" class="add-new-link" hx-get="…">+ Add concept from other topic</a>
+
+<!-- Icon-only row action — uses the legacy .action-button class -->
+<button class="action-button" hx-get="/edit-chapter?id={{.ID}}" title="Edit">
+  <i class="fa-solid fa-pen"></i>
+</button>
+```
+
+---
+
+## 10. Form Inputs
+
+```html
+<div>
+  <label class="form-label" for="code">Code</label>
+  <input id="code" type="text" class="form-input font-mono"
+         placeholder="e.g. MTH-11-JEE-17">
+</div>
+
+<div>
+  <label class="form-label" for="type">Type</label>
+  <select id="type" class="form-select">
+    <option value="">Select type</option>
+    <option value="major_test">Major Test</option>
+  </select>
+</div>
+```
+
+For dropdowns that sit in the global nav bar, prefer `.form-select-compact` (smaller height, lighter border) so they don't dominate.
+
+For the difficulty radio chips used in [`add_problem.html`](../web/html/add_problem.html), use the `has-[:checked]` pattern:
+
+```html
+<label class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-bg-card cursor-pointer
+              hover:bg-bg-hover
+              has-[:checked]:border-accent has-[:checked]:bg-accent has-[:checked]:text-text-on-accent
+              transition-colors">
+  <input type="radio" name="difficulty" value="easy" class="accent-accent">
+  <span class="font-bold">1 — Easy</span>
+</label>
+```
+
+---
+
+## 11. Tables
+
+```html
+<div class="card overflow-x-auto">
+  <table class="app-table">
+    <thead>
+      <tr>
+        <th>
+          <a href="#" class="hover:text-accent" hx-get="/api/tests?col=1">
+            Code <i class="fas fa-sort"></i>
+          </a>
+        </th>
+        <th>Name</th>
+        <th class="text-center">Marks</th>
+        <th class="text-center">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="font-mono">SB-MT-07-16</td>
+        <td>
+          <a class="text-accent hover:text-accent-hover hover:underline font-medium"
+             href="/test?id=…">Major Test 7</a>
+        </td>
+        <td class="text-center font-mono">360</td>
+        <td class="text-center">…</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+Don't add manual `bg-bg-card-alt` to `<thead>` or `border-b` to `<tr>` — `.app-table` handles those.
+
+---
+
+## 12. Status Badges & Pills
+
+For binary-status pills (active/inactive, completed/in-progress), use `.badge-*`:
+
+```html
+<span class="badge-success">active</span>
+<span class="badge-muted">inactive</span>
+```
+
+For semantic category badges where each color carries meaning (e.g. role types if added later), apply brand color classes directly rather than overloading the badge variants:
+
+```html
+<span class="badge bg-brand-blue-bg text-ink">teacher</span>
+<span class="badge bg-brand-coral-bg text-accent-hover">admin</span>
+```
+
+---
+
+## 13. Modals & Dialogs
+
+The standard modal shell:
+
+```html
+<div class="fixed inset-0 bg-ink/40 flex justify-center items-center z-50 p-4">
+  <div class="card shadow-xl rounded-xl w-full max-w-md p-6 max-h-[90vh] overflow-y-auto">
+    <h2 class="page-title mb-6">Move Problems</h2>
+
+    <!-- body -->
+    <form class="space-y-4">
+      <!-- … -->
+    </form>
+
+    <div class="flex gap-3 justify-end pt-4 border-t border-border">
+      <button type="button" class="btn-secondary" onclick="…">Cancel</button>
+      <button type="submit" class="btn-primary">Move</button>
+    </div>
+  </div>
+</div>
+```
+
+**Scrollbar rule:** Only the inner modal body should scroll. Either give the inner `.card` `max-h-[90vh] overflow-y-auto` (as above, for short forms), or split it into a header / `flex-1 overflow-y-auto` body / footer when the body needs to scroll independently. Never nest two `overflow-y-auto` containers.
+
+Backdrop is `bg-ink/40` (a translucent dark-brown wash) — not `bg-black/30`, because pure black against beige looks harsh.
+
+---
+
+## 14. Problem Editor & Specialised Components
+
+A handful of components are unique to the CMS and live as their own classes in `input.css`:
+
+| Class | Purpose | Used in |
+|-------|---------|---------|
+| `.editor` | Rich-text contenteditable surface (toolbar + preview) | `editor.html` (shared by problem, solution, options, instructions) |
+| `.mcq-tab`, `.mcq-tab-add` | Per-option tabs in the MCQ editor | `add_problem.html` |
+| `.chip`, `.chip-box`, `.chip-editor` | Editable comma-separated tag input (positive / negative marks per section) | `chip_box_cells.html`, `test_chip_editor.html` |
+| `.concept-chip` | Pill for selected concepts (blue tint) | rich-text editor + tags input |
+| `.sub-tab` | State-machine sub-navigation (Topics / Resources, Concepts / Problems / Resources) | `chapter.html`, `topic.html` |
+| `.action-button` | Icon-only row action (pencil, trash, copy, download) | every list row |
+| `.answer-pdf-table-row` | Border + padding for the answer-sheet PDF tables | `answer_sheet.html` |
+
+MathJax wrapping rules at the bottom of `input.css` force formulae to wrap, unless the formula contains an `<mtable>` (matrix), in which case it stays on one line.
+
+---
+
+## 15. HTMX Loading States
+
+Spinners use the brand border + accent top-border pattern:
+
+```html
+<div class="hidden flex justify-center py-4" id="some-loader">
+  <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
+</div>
+```
+
+`input.css` already wires `.htmx-request` visibility for the well-known loader ids (`#search-btn-loader`, `#searched-test-loader`, `#question-bank-loader`, `#topic-problems-loader`) and form-state classes (`#move-problems-form.htmx-request .btn-text { display: none; }` etc.). New loaders should follow the same naming so the existing rules apply, or add a fresh selector to the components layer.
+
+For an inline button spinner (e.g. on a submit button that fires HTMX):
+
+```html
+<button class="btn-primary group min-w-[120px]" hx-post="…">
+  <span class="group-[.htmx-request]:hidden">Move</span>
+  <span class="hidden group-[.htmx-request]:inline-flex">
+    <div class="w-4 h-4 border-2 border-text-on-accent border-t-transparent rounded-full animate-spin"></div>
+  </span>
+</button>
+```
+
+---
+
+## 16. Responsive & Mobile
+
+- **Progressive padding** on detail pages: `px-4 sm:px-6 lg:px-8`.
+- **Grid breakpoints**: `grid-cols-1 md:grid-cols-3 gap-6` for the type / skills / concepts row in the problem editor.
+- **Wrap nav items** on narrow screens with `flex-wrap` + `gap-y-2` (already applied in the base template).
+- **Touch targets** ≥44 px for buttons / inputs, ≥48 px for tab items / radio labels.
+- **Tab overflow**: add `overflow-x-auto` on tab bars that may exceed the viewport.
+- **Tables**: keep `overflow-x-auto` on the wrapping `.card` so horizontal scroll is graceful on phones.
+
+---
+
+## 17. Rebuilding the CSS
+
+You only need to run Tailwind locally if you change `input.css` or `tailwind.config.js`. The compiled `web/static/css/output.css` is checked in.
+
+```bash
+npm install        # First time only
+npm run build:css  # Rebuild after editing tokens or components
+```
+
+If you add a class that's only referenced from server-fetched HTML (e.g. PDF instructions loaded over fetch), add it to the `safelist` in `tailwind.config.js` so Tailwind doesn't tree-shake it away.
+
+For day-to-day editing, run the build once after each change to `input.css` — there's no watch mode wired up by default. Builds finish in ~200 ms.
+
+---
+
+## Cross-references
+
+- Original guide (LMS): <https://github.com/avantifellows/af_lms/blob/main/docs/UI-Style-Guide.md>
+- HR app this palette comes from: <https://hr-feedback.avantifellows.org>
+- Tokens / Tailwind config: [`tailwind.config.js`](../tailwind.config.js)
+- Shared classes: [`input.css`](../input.css)
+- Base template (nav, font loader, dropdowns): [`web/html/home.html`](../web/html/home.html)

--- a/input.css
+++ b/input.css
@@ -2,78 +2,105 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Custom styles using @apply */
+/* ===========================================================
+ * Avanti Fellows — Warm Professional
+ * Tokens live in tailwind.config.js (accent/bg/ink/brand/border).
+ * Use the @theme tokens via Tailwind classes in templates;
+ * the @apply rules below keep legacy component classes working.
+ * =========================================================== */
+
+@layer base {
+    html {
+        font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+        color: theme('colors.ink.DEFAULT');
+        background-color: theme('colors.bg.DEFAULT');
+    }
+
+    body {
+        @apply bg-bg text-ink min-h-screen;
+    }
+
+    /* Numeric data — codes, counts, dates, emails — uses a monospace face for a data-rich feel. */
+    .font-mono,
+    .font-mono * {
+        font-feature-settings: 'tnum' 1, 'lnum' 1;
+    }
+}
+
 @layer components {
+
+    /* --- Nav (top tab bar) ------------------------------------------------ */
     .nav {
         @apply flex flex-wrap pl-0 mb-0 list-none;
     }
 
     .nav-tabs {
-        @apply border-b border-gray-300;
+        @apply border-b border-border bg-bg-card;
     }
 
     .nav-link {
-        @apply block px-4 py-2 text-blue-600 no-underline transition-colors duration-150 ease-in-out;
+        @apply inline-flex items-center px-4 py-3 text-sm font-bold uppercase tracking-wide
+               text-ink-muted no-underline transition-colors duration-150 ease-in-out
+               border-b-2 border-transparent;
     }
 
-    .nav-link:focus {
-        @apply text-blue-700;
-    }
-
+    .nav-link:focus,
     .nav-link:hover {
-        @apply text-blue-700;
+        @apply text-ink border-accent/40;
     }
 
     .nav-tabs .nav-link {
-        @apply -mb-px border border-transparent rounded-t-md;
-    }
-
-    .nav-tabs .nav-link:focus {
-        @apply border-t border-t-gray-100 border-r border-r-gray-100 border-b border-b-gray-200 border-l border-l-gray-100 isolate;
-    }
-
-    .nav-tabs .nav-link:hover {
-        @apply border-t border-t-gray-100 border-r border-r-gray-100 border-b border-b-gray-200 border-l border-l-gray-100 isolate;
+        @apply -mb-px rounded-none;
     }
 
     .nav-tabs .nav-link.active {
-        @apply text-gray-600 bg-white border border-t-gray-200 border-r-gray-200 border-b-white border-l-gray-200;
+        @apply text-ink bg-transparent border-b-2 border-accent;
     }
 
+    /* --- Sub-tabs (used inside chapter / topic detail) ------------------- */
     .sub-tab {
-        @apply text-gray-600 bg-white px-4 py-2 cursor-pointer;
+        @apply inline-flex items-center min-h-[40px] px-4 py-2 rounded-lg cursor-pointer
+               text-sm font-bold uppercase tracking-wide text-ink-muted
+               bg-bg-card border border-border transition-colors;
     }
 
-    .sub-tab:focus {
-        @apply text-white bg-red-400 rounded;
-    }
-
+    .sub-tab:focus,
     .sub-tab:hover {
-        @apply text-white bg-red-400 rounded;
+        @apply text-text-on-accent bg-accent-hover border-accent-hover;
     }
 
     .sub-tab.active {
-        @apply text-white bg-red-500 rounded;
+        @apply text-text-on-accent bg-accent border-accent;
     }
 
+    /* --- Row action buttons (pencil, trash, copy, download icons) -------- */
     .action-button {
-        @apply text-blue-500 hover:text-red-500 hover:scale-110;
+        @apply text-ink-muted transition-transform hover:text-accent hover:scale-110;
     }
 
+    /* --- Chips (filter tags inside inputs) ------------------------------- */
     .chip {
-        @apply px-1 py-0.5 bg-gray-200 rounded text-xs inline-block;
+        @apply inline-block px-2 py-0.5 rounded-full text-xs font-medium
+               bg-bg-card-alt text-ink border border-border;
     }
 
     .chip-box {
-        @apply flex flex-wrap gap-1 border border-gray-300 rounded py-1 min-h-[2rem];
+        @apply flex flex-wrap gap-1 border border-border rounded-lg py-1 min-h-[2rem] bg-bg-input;
     }
 
     .chip-editor {
         @apply outline-none text-left min-w-[1rem];
     }
 
+    /* Concept chips (rich-text editor) */
+    .concept-chip {
+        @apply inline-flex items-center gap-1 rounded-full px-2 py-1
+               bg-brand-blue-bg text-ink border border-brand-blue;
+    }
+
+    /* --- Rich-text editor surface --------------------------------------- */
     .editor {
-        font-family: Arial, sans-serif;
+        font-family: 'Inter', system-ui, -apple-system, Arial, sans-serif;
     }
 
     .editor ul,
@@ -88,56 +115,182 @@
 
     .editor hr,
     .output hr {
-        @apply m-4 border-t border-gray-600 border-0;
+        @apply m-4 border-t border-border;
     }
 
     .editor-fullscreen {
-        @apply fixed top-0 left-0 w-screen h-screen z-[9999] bg-white flex flex-col;
+        @apply fixed top-0 left-0 w-screen h-screen z-[9999] bg-bg-card flex flex-col;
     }
 
     .editor-fullscreen #editor {
         @apply grow overflow-y-auto;
     }
 
+    /* --- MCQ tabs inside the problem editor ----------------------------- */
     .mcq-tab {
-        @apply flex items-center bg-white rounded-t px-3 py-1 relative cursor-pointer border border-gray-300;
+        @apply flex items-center relative cursor-pointer rounded-t-lg
+               bg-bg-card border border-border px-3 py-1;
     }
 
     .mcq-tab button {
-        @apply text-sm text-gray-500 hover:text-red-600;
+        @apply text-sm text-ink-muted hover:text-accent;
     }
 
     .mcq-tab-add {
-        @apply w-8 h-8 flex items-center justify-center text-gray-500 hover:text-blue-600 hover:bg-gray-100 border border-gray-300 rounded;
+        @apply w-8 h-8 flex items-center justify-center rounded-lg
+               text-ink-muted bg-bg-card border border-border
+               hover:text-accent hover:bg-bg-card-alt transition-colors;
     }
 
     .mcq-tab.active {
-        @apply border-t border-l border-r border-b-0 border-gray-300 bg-gray-100;
+        @apply bg-bg-card-alt border-b-0;
     }
 
     .answer-pdf-table-row {
-        @apply border border-gray-300 px-4 py-2;
+        @apply border border-border px-4 py-2;
     }
 
-    .concept-chip {
-        @apply flex items-center bg-blue-100 text-blue-800 rounded px-2 py-1 gap-1;
+    /* ====================================================================
+     * Shared "design system" component classes used by the template restyles.
+     * Treat these as the building blocks the af_lms UI Style Guide calls out.
+     * ==================================================================== */
+
+    /* --- Buttons -------------------------------------------------------- */
+    .btn {
+        @apply inline-flex items-center justify-center gap-2 rounded-lg
+               text-sm font-bold uppercase tracking-wide transition-colors
+               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40
+               disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px] px-4 py-2;
     }
-    
-    /* Loader is hidden by default */
-    #search-btn-loader {
+
+    .btn-sm {
+        @apply min-h-[36px] px-3 py-1 text-xs;
+    }
+
+    .btn-lg {
+        @apply min-h-[48px] px-5 py-3 text-sm;
+    }
+
+    .btn-primary {
+        @apply btn bg-accent text-text-on-accent shadow-sm
+               hover:bg-accent-hover active:bg-accent-hover;
+    }
+
+    .btn-secondary {
+        @apply btn bg-bg-card text-ink border-2 border-border
+               hover:bg-bg-card-alt hover:border-accent/40;
+    }
+
+    .btn-ghost {
+        @apply btn bg-transparent text-accent
+               hover:text-accent-hover hover:bg-bg-hover;
+    }
+
+    .btn-danger {
+        @apply btn bg-danger text-text-on-accent shadow-sm
+               hover:bg-accent-hover;
+    }
+
+    .btn-danger-ghost {
+        @apply btn bg-transparent text-danger
+               hover:bg-danger-bg;
+    }
+
+    /* "Add new <X>" link rendered as a soft accent button. */
+    .add-new-link {
+        @apply inline-flex items-center gap-1 text-sm font-bold uppercase tracking-wide
+               text-accent hover:text-accent-hover transition-colors;
+    }
+
+    /* --- Cards / Panels ------------------------------------------------- */
+    .card {
+        @apply bg-bg-card rounded-lg border border-border shadow-card;
+    }
+
+    .card-pad {
+        @apply p-6;
+    }
+
+    .card-pad-sm {
+        @apply p-4;
+    }
+
+    /* --- Form inputs ---------------------------------------------------- */
+    .form-input,
+    .form-select {
+        @apply min-h-[44px] w-full rounded-lg border-2 border-border bg-bg-input
+               px-3 py-2 text-sm text-ink placeholder:text-ink-muted/70
+               focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20
+               disabled:bg-bg-card-alt disabled:cursor-not-allowed transition-colors;
+    }
+
+    /* Compact variant used inside the nav bar so dropdowns don't dominate. */
+    .form-select-compact {
+        @apply h-10 min-h-0 rounded-lg border border-border bg-bg-input
+               px-3 py-1.5 text-sm text-ink
+               focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20
+               transition-colors;
+    }
+
+    .form-label {
+        @apply block text-xs font-bold uppercase tracking-wide text-ink-muted mb-1;
+    }
+
+    /* --- Tables --------------------------------------------------------- */
+    .app-table {
+        @apply min-w-full bg-bg-card;
+    }
+
+    .app-table thead tr {
+        @apply bg-bg-card-alt border-b-2 border-border-accent text-ink-muted;
+    }
+
+    .app-table th {
+        @apply px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-ink-muted;
+    }
+
+    .app-table td {
+        @apply px-6 py-4 text-sm text-ink;
+    }
+
+    .app-table tbody tr {
+        @apply border-b border-border/40 hover:bg-bg-hover transition-colors;
+    }
+
+    /* --- Badges --------------------------------------------------------- */
+    .badge {
+        @apply inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold uppercase tracking-wide;
+    }
+
+    .badge-muted   { @apply badge bg-bg-card-alt text-ink-muted; }
+    .badge-accent  { @apply badge bg-accent text-text-on-accent; }
+    .badge-success { @apply badge bg-success-bg text-success; }
+    .badge-warning { @apply badge bg-warning-bg text-warning border border-warning-border; }
+    .badge-danger  { @apply badge bg-danger-bg text-danger; }
+    .badge-info    { @apply badge bg-info-bg text-ink; }
+
+    /* --- Page chrome ---------------------------------------------------- */
+    .page-title {
+        @apply text-xl sm:text-2xl font-bold uppercase tracking-tight text-ink;
+    }
+
+    .section-title {
+        @apply text-lg font-bold uppercase tracking-wide text-ink
+               border-b-2 border-border-accent pb-2 mb-4;
+    }
+
+    /* HTMX loader visibility helpers ------------------------------------ */
+    #search-btn-loader,
+    #searched-test-loader,
+    #question-bank-loader,
+    #topic-problems-loader {
         display: none;
     }
 
-    /* HTMX makes the loader visible during request */
-    #search-btn-loader.htmx-request {
-        display: flex;
-    }  
-    
-    #searched-test-loader {
-        display: none;
-    }
-
-    #searched-test-loader.htmx-request {
+    #search-btn-loader.htmx-request,
+    #searched-test-loader.htmx-request,
+    #question-bank-loader.htmx-request,
+    #topic-problems-loader.htmx-request {
         display: flex;
     }
 
@@ -145,25 +298,8 @@
         display: block;
     }
 
-    /* Hide results during request */
     #searched-test-results.htmx-request {
         display: none;
-    }
-
-    #question-bank-loader {
-        display: none;
-    }
-
-    #question-bank-loader.htmx-request {
-        display: flex;
-    }
-
-    #topic-problems-loader {
-        display: none;
-    }
-
-    #topic-problems-loader.htmx-request {
-        display: flex;
     }
 
     /* When form is making request */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,77 @@ module.exports = {
         'htmx-request'
     ],
     theme: {
-        extend: {},
+        extend: {
+            // Avanti Fellows brand palette — Warm Professional.
+            // Mirrors the af_lms UI Style Guide tokens so the two CMS apps share a look.
+            colors: {
+                accent: {
+                    DEFAULT: '#ad2f2f',   // AF maroon
+                    hover:   '#8a2525',
+                },
+                'text-on-accent': '#ffffff',
+                bg: {
+                    DEFAULT:  '#f5efe8',  // warm beige page background
+                    card:     '#fffaf5',  // cream card background
+                    'card-alt': '#f3ece5', // table head / alt row
+                    input:    '#ffffff',
+                    hover:    'rgba(173, 47, 47, 0.06)',
+                },
+                ink: {
+                    DEFAULT:   '#261410', // dark brown — primary text
+                    secondary: '#685851', // taupe — muted text
+                    muted:     '#685851',
+                },
+                border: {
+                    DEFAULT: 'rgba(38, 20, 16, 0.15)',
+                    accent:  '#ad2f2f',
+                },
+                danger: {
+                    DEFAULT: '#ad2f2f',
+                    bg:      'rgba(173, 47, 47, 0.08)',
+                },
+                success: {
+                    DEFAULT: '#1e6b4b',
+                    bg:      'rgba(30, 107, 75, 0.12)',
+                },
+                warning: {
+                    DEFAULT: '#8c5a1d',
+                    bg:      'rgba(140, 90, 29, 0.08)',
+                    border:  '#8c5a1d',
+                },
+                info: {
+                    DEFAULT: '#9AC4FA',
+                    bg:      'rgba(154, 196, 250, 0.15)',
+                },
+                brand: {
+                    coral:  '#E96D57',
+                    gold:   '#FFD063',
+                    amber:  '#FFB763',
+                    blue:   '#9AC4FA',
+                    salmon: '#FF9683',
+                    orange: '#D77C11',
+                    'coral-bg': 'rgba(233, 109, 87, 0.10)',
+                    'gold-bg':  'rgba(255, 208, 99, 0.15)',
+                    'amber-bg': 'rgba(255, 183, 99, 0.12)',
+                    'blue-bg':  'rgba(154, 196, 250, 0.15)',
+                },
+            },
+            fontFamily: {
+                sans: ['Inter', 'system-ui', '-apple-system', 'Segoe UI', 'Roboto', 'Arial', 'sans-serif'],
+                mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+            },
+            // Make a bare `border` class use our brand border tint so legacy templates
+            // pick up the warm-professional palette without an explicit border-border-…
+            borderColor: {
+                DEFAULT: 'rgba(38, 20, 16, 0.15)',
+            },
+            ringColor: {
+                DEFAULT: 'rgba(173, 47, 47, 0.40)',
+            },
+            boxShadow: {
+                card: '0 1px 2px 0 rgba(38, 20, 16, 0.05), 0 1px 3px 0 rgba(38, 20, 16, 0.08)',
+            },
+        },
     },
     plugins: [],
 }

--- a/web/html/add_chapter.html
+++ b/web/html/add_chapter.html
@@ -1,8 +1,15 @@
 <!-- Form to add new chapter -->
-<form id="addChapterForm" class="mt-2 space-x-2" hx-post="/create-chapter" hx-target="#chapterTableBody"
+<form id="addChapterForm" class="card card-pad-sm mt-3 flex flex-wrap items-end gap-3"
+    hx-post="/create-chapter" hx-target="#chapterTableBody"
     hx-swap="beforeend" hx-include="#curriculum-dropdown, #grade-dropdown, #subject-dropdown"
     hx-on::after-request="if(event.detail.successful) this.reset()">
-    <input type="text" name="code" placeholder="Code" class="border p-2">
-    <input type="text" name="name" placeholder="Name" class="border p-2 w-1/3">
-    <button type="submit" class="bg-blue-500 text-white p-2 rounded">Create New Chapter</button>
+    <div>
+        <label class="form-label" for="add-chapter-code">Code</label>
+        <input id="add-chapter-code" type="text" name="code" placeholder="e.g. MTH-11-JEE-17" class="form-input w-48 font-mono">
+    </div>
+    <div class="flex-1 min-w-[240px]">
+        <label class="form-label" for="add-chapter-name">Name</label>
+        <input id="add-chapter-name" type="text" name="name" placeholder="Chapter name" class="form-input">
+    </div>
+    <button type="submit" class="btn-primary">Create Chapter</button>
 </form>

--- a/web/html/add_concept_modal.html
+++ b/web/html/add_concept_modal.html
@@ -1,60 +1,60 @@
-<div id="addConceptModal" class="fixed inset-0 bg-gray-800 bg-opacity-50 flex justify-center items-center z-50">
-    <div class="bg-white p-6 rounded shadow-md w-full max-w-5xl">
-        <h2 class="text-lg font-semibold mb-4">Add Concept</h2>
-        
+<div id="addConceptModal" class="fixed inset-0 bg-ink/40 flex justify-center items-center z-50 p-4">
+    <div class="card shadow-xl rounded-xl p-6 w-full max-w-5xl max-h-[90vh] overflow-y-auto">
+        <h2 class="page-title mb-6">Add Concept</h2>
+
         <form id="addConceptForm" class="space-y-6">
 
             <!-- Search by word -->
             <div>
-                <h3 class="text-md font-semibold mb-2">Search concept by word</h3>
-                <div id="chip-container" class="flex flex-wrap gap-2 border rounded p-2 min-h-[44px] cursor-text">
+                <h3 class="form-label mb-2">Search concept by word</h3>
+                <div id="chip-container" class="flex flex-wrap gap-2 border-2 border-border rounded-lg p-2 min-h-[44px] cursor-text bg-bg-input focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/20">
                     <!-- Chips will be added here dynamically -->
-                    <input id="chip-input" type="text" class="flex-1 min-w-[100px] outline-none"
-                           placeholder="Type to search concepts..." onfocus="showConceptDropdown()" 
+                    <input id="chip-input" type="text" class="flex-1 min-w-[100px] outline-none bg-transparent"
+                           placeholder="Type to search concepts..." onfocus="showConceptDropdown()"
                            oninput="filterConceptDropdown(this.value)" onkeydown="handleChipInputKey(event)"
                            onblur="hideConceptDropdown()">
                 </div>
                 <div id="concept-suggestion-box" class="relative">
                     <ul id="concept-suggestions"
-                        class="absolute bg-white border rounded mt-1 max-h-48 overflow-y-auto hidden w-full z-10">
+                        class="absolute bg-bg-card border border-border rounded-lg shadow-card mt-1 max-h-48 overflow-y-auto hidden w-full z-10">
                         <!-- Options inserted dynamically -->
                     </ul>
                 </div>
                 <!-- Separate Add button for word search -->
                 <div class="w-full flex justify-end mt-2">
                     <button type="button" onclick="addWordSearchConcepts()"
-                            class="bg-blue-500 text-white px-4 py-2 rounded">Add</button>
+                            class="btn-primary">Add</button>
                 </div>
             </div>
 
             <!-- Search by topic name -->
             <div>
-                <h3 class="text-md font-semibold mb-2">Search concept by topic name</h3>
+                <h3 class="form-label mb-2">Search concept by topic name</h3>
                 <div class="flex gap-2 mb-3">
                     <!-- Curriculum -->
                     <select id="curriculum-dropdown" name="curriculum-dropdown"
-                            class="border p-2 rounded w-40" hx-get="/api/curriculums"
+                            class="form-select w-40" hx-get="/api/curriculums"
                             hx-trigger="load" hx-on::after-request="afterConceptModalDropdownReq(this)">
                         <option disable selected>Loading curriculums...</option>
                     </select>
 
                     <!-- Grade -->
                     <select id="grade-dropdown" name="grade-dropdown"
-                            class="border p-2 rounded w-40" hx-get="/api/grades"
+                            class="form-select w-40" hx-get="/api/grades"
                             hx-trigger="load" hx-on::after-request="afterConceptModalDropdownReq(this)">
                         <option disabled selected>Loading grades...</option>
                     </select>
 
                     <!-- Subject -->
                     <select id="subject-dropdown" name="subject-dropdown"
-                            class="border p-2 rounded w-40" hx-get="/api/subjects"
+                            class="form-select w-40" hx-get="/api/subjects"
                             hx-trigger="load" hx-on::after-request="afterConceptModalDropdownReq(this)">
                         <option disabled selected>Loading subjects...</option>
                     </select>
 
                     <!-- Chapter -->
                     <select id="chapter-dropdown" name="chapter-dropdown"
-                            class="border p-2 rounded w-40" hx-get="/api/chapters"
+                            class="form-select w-40" hx-get="/api/chapters"
                             hx-trigger="loadChapters, change from:(#addConceptModal #curriculum-dropdown, #addConceptModal #grade-dropdown, #addConceptModal #subject-dropdown)"
                             hx-include="#addConceptModal #curriculum-dropdown, #addConceptModal #grade-dropdown, #addConceptModal #subject-dropdown"
                             hx-params="not chapter-dropdown" hx-on::before-request="beforeChaptersRequest();">
@@ -63,7 +63,7 @@
 
                     <!-- Topic -->
                     <select id="topic-dropdown" name="topic_id"
-                            class="border p-2 rounded w-40" hx-get="/api/topics?view=dropdown" 
+                            class="form-select w-40" hx-get="/api/topics?view=dropdown" 
                             hx-trigger="change from:#chapter-dropdown" hx-include="#chapter-dropdown"
                             hx-on::before-request="beforeTopicsRequest();">
                         <option disabled selected>Select a chapter first</option>
@@ -73,10 +73,10 @@
 
                 <!-- Concept -->
                 <div class="flex flex-col w-full">
-                    <label for="concept-dropdown" class="text-sm font-medium mb-1">Concepts</label>
-                    <select id="concept-dropdown" name="concept-dropdown" multiple 
-                            class="border p-2 rounded w-full max-h-48 overflow-y-auto"
-                            hx-get="/api/concepts?view=dropdown" 
+                    <label for="concept-dropdown" class="form-label">Concepts</label>
+                    <select id="concept-dropdown" name="concept-dropdown" multiple
+                            class="form-select max-h-48 overflow-y-auto"
+                            hx-get="/api/concepts?view=dropdown"
                             hx-trigger="change from:#topic-dropdown" hx-include="#topic-dropdown"
                             hx-on::before-request="this.innerHTML = '<option disabled>Loading concepts...</option>'">
                         <option disabled>Select a topic first</option>
@@ -85,11 +85,9 @@
             </div>
 
             <!-- Buttons -->
-            <div class="w-full flex-row flex justify-end space-x-2">
-                <button type="button" onclick="closeAddConceptModal()"
-                        class="bg-gray-300 px-4 py-2 rounded">Cancel</button>
-                <button type="button" onclick="addConcepts()" 
-                        class="bg-blue-500 text-white px-4 py-2 rounded">Add</button>
+            <div class="flex justify-end gap-3 pt-2 border-t border-border">
+                <button type="button" onclick="closeAddConceptModal()" class="btn-secondary">Cancel</button>
+                <button type="button" onclick="addConcepts()" class="btn-primary">Add</button>
             </div>
         </form>
     </div>
@@ -103,7 +101,7 @@
             // show loading placeholder
             const box = document.getElementById("concept-suggestions");
             box.classList.remove("hidden");
-            box.innerHTML = `<li class="px-3 py-2 text-gray-500">Loading concepts...</li>`;
+            box.innerHTML = `<li class="px-3 py-2 text-ink-muted">Loading concepts...</li>`;
 
             fetch('/api/concepts?mode=data')
                 .then(res => res.json())
@@ -113,7 +111,7 @@
                 })
                 .catch(err => {
                     console.error("Failed to load concepts", err);
-                    box.innerHTML = `<li class="px-3 py-2 text-red-500">Failed to load concepts</li>`;
+                    box.innerHTML = `<li class="px-3 py-2 text-danger">Failed to load concepts</li>`;
                 });
         } else {
             renderConceptSuggestions("");
@@ -153,7 +151,7 @@
             .forEach(c => {
                 const li = document.createElement("li");
                 li.textContent = getConceptName(c);
-                li.className = "px-3 py-2 hover:bg-gray-100 cursor-pointer";
+                li.className = "px-3 py-2 hover:bg-bg-card-alt cursor-pointer";
                 li.onmousedown = (e) => {
                     // preventDefault() ensures the input doesn’t lose focus by preventing call to onblur. 
                     // Without it suggestions box would hide as we are calling hideConceptDropdownWithDelay() onblur
@@ -175,7 +173,7 @@
         const chipContainer = document.getElementById("chip-container");
         const chip = document.createElement("div");
         chip.className = "concept-chip";
-        chip.innerHTML = `${getConceptName(concept)} <span class="cursor-pointer text-red-500" onclick="removeChip(${concept.id}, this)">×</span>`;
+        chip.innerHTML = `${getConceptName(concept)} <span class="cursor-pointer text-danger" onclick="removeChip(${concept.id}, this)">×</span>`;
         chip.dataset.id = concept.id;
         chipContainer.insertBefore(chip, document.getElementById("chip-input"));
 
@@ -332,10 +330,10 @@
     function updateHighlight(suggestions) {
         suggestions.forEach((li, idx) => {
             if (idx === highlightedIndex) {
-                li.classList.add("bg-blue-100");
+                li.classList.add("bg-brand-blue-bg");
                 ensureVisible(li);  // keep highlighted li in view
             } else {
-                li.classList.remove("bg-blue-100");
+                li.classList.remove("bg-brand-blue-bg");
             }
         });
     }

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -1,5 +1,5 @@
 {{ define "content" }}
-<form class="mx-auto px-4 bg-white shadow-md" onsubmit="createProblem(event,        
+<form class="card card-pad max-w-6xl mx-auto" onsubmit="createProblem(event,
         {{if .TopicPtr}}
         <!-- add problem -->
             {{.TopicPtr.ID}}, {{.TopicPtr.ChapterID}}, null
@@ -8,15 +8,15 @@
             {{.ProblemPtr.TopicID}}, {{.ProblemPtr.ChapterID}}, {{ .ProblemPtr.ID }}
         {{end}}
 );">
-    <h2 class="text-lg font-semibold mb-4">{{if .TopicPtr}}Add New{{else}}Edit{{end}} Problem</h2>
+    <h2 class="page-title mb-6">{{if .TopicPtr}}Add New{{else}}Edit{{end}} Problem</h2>
 
     <!-- type, skills, concepts -->
-    <div class="grid grid-cols-3 gap-6 mb-6">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
         <div>
-            <p class="font-semibold mb-2">Select Type:</p>
+            <label class="form-label" for="problem-type-dropdown">Type</label>
             <select id="problem-type-dropdown" name="problem-type-dropdown"
                 {{if .ProblemPtr}}disabled title="Problem type cannot be changed in edit mode"{{end}}
-                class="w-full border border-gray-300 rounded p-2 {{if .ProblemPtr}}bg-gray-100 text-gray-500 cursor-not-allowed{{end}}">
+                class="form-select {{if .ProblemPtr}}bg-bg-card-alt text-ink-muted cursor-not-allowed{{end}}">
                 {{if .ProblemPtr}}
                 {{template "problem_type_options" .ProblemPtr.Subtype}}
                 {{else}}
@@ -25,17 +25,17 @@
             </select>
         </div>
         <div>
-            <p class="font-semibold mb-2">Select Skills:</p>
+            <label class="form-label" for="skills-dropdown">Skills</label>
             <select id="skills-dropdown" name="skills-dropdown" multiple hx-trigger="load"
-                class="w-full border border-gray-300 rounded p-2 h-20 overflow-y-auto"
+                class="form-select h-24 overflow-y-auto"
                 hx-get='/api/skills{{if .ProblemPtr}}?selected_skill_ids={{joinInt16 .ProblemPtr.SkillIDs ","}}{{end}}'>
                 <option disabled>Loading skills...</option>
             </select>
         </div>
         <div>
-            <p class="font-semibold mb-2">Select Concepts:</p>
+            <label class="form-label" for="concepts-dropdown">Concepts</label>
             <select id="concepts-dropdown" name="concepts-dropdown" multiple hx-trigger="revealed once"
-                class="w-full border border-gray-300 rounded p-2 h-20 overflow-y-auto" hx-swap="beforeend"
+                class="form-select h-24 overflow-y-auto" hx-swap="beforeend"
                 hx-get="/api/concepts?topic_id={{if .TopicPtr}}{{.TopicPtr.ID}}{{else}}{{.ProblemPtr.TopicID}}{{end}}{{if .ProblemPtr}}&exclude={{range $i, $c := .ProblemPtr.Concepts}}{{if $i}},{{end}}{{$c.ID}}{{end}}{{end}}">
                     {{ if .ProblemPtr }}
                         {{ range .ProblemPtr.Concepts }}
@@ -46,25 +46,33 @@
                         <option disabled>Loading concepts...</option>
                     {{ end }}
             </select>
-            <a href="#" class="text-blue-600 underline" hx-get="/topic/add-problem/add-concept-dialog" 
-                hx-target="body" hx-swap="beforeend">Add Concept from other topic</a>
+            <a href="#" class="add-new-link mt-1 inline-block" hx-get="/topic/add-problem/add-concept-dialog"
+                hx-target="body" hx-swap="beforeend">+ Add concept from other topic</a>
         </div>
     </div>
 
     <!-- difficulty -->
     <div class="mb-6">
-        <p class="font-semibold mb-2">Difficulty Rating</p>
-        <label class="mr-4"><input type="radio" name="difficulty" value="easy" {{if and .ProblemPtr (eq
-                .ProblemPtr.DifficultyLevel "easy" )}}checked{{end}}> 1</label>
-        <label class="mr-4"><input type="radio" name="difficulty" value="medium" {{if and .ProblemPtr (eq
-                .ProblemPtr.DifficultyLevel "medium" )}}checked{{end}}> 2</label>
-        <label class="mr-4"><input type="radio" name="difficulty" value="hard" {{if and .ProblemPtr (eq
-                .ProblemPtr.DifficultyLevel "hard" )}}checked{{end}}> 3</label>
+        <p class="form-label mb-2">Difficulty Rating</p>
+        <div class="flex gap-2 flex-wrap">
+            <label class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-bg-card cursor-pointer hover:bg-bg-hover has-[:checked]:border-accent has-[:checked]:bg-accent has-[:checked]:text-text-on-accent transition-colors">
+                <input type="radio" name="difficulty" value="easy" class="accent-accent" {{if and .ProblemPtr (eq .ProblemPtr.DifficultyLevel "easy" )}}checked{{end}}>
+                <span class="font-bold">1 — Easy</span>
+            </label>
+            <label class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-bg-card cursor-pointer hover:bg-bg-hover has-[:checked]:border-accent has-[:checked]:bg-accent has-[:checked]:text-text-on-accent transition-colors">
+                <input type="radio" name="difficulty" value="medium" class="accent-accent" {{if and .ProblemPtr (eq .ProblemPtr.DifficultyLevel "medium" )}}checked{{end}}>
+                <span class="font-bold">2 — Medium</span>
+            </label>
+            <label class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-bg-card cursor-pointer hover:bg-bg-hover has-[:checked]:border-accent has-[:checked]:bg-accent has-[:checked]:text-text-on-accent transition-colors">
+                <input type="radio" name="difficulty" value="hard" class="accent-accent" {{if and .ProblemPtr (eq .ProblemPtr.DifficultyLevel "hard" )}}checked{{end}}>
+                <span class="font-bold">3 — Hard</span>
+            </label>
+        </div>
     </div>
 
     <!-- Question editor -->
     <div id="questionDiv" class="mb-6">
-        <p class="font-semibold mb-2">Text:</p>
+        <p class="form-label mb-2">Text</p>
         {{ if .ProblemPtr }}
         {{ template "editor" .ProblemPtr.MetaData.Question }}
         {{ else }}
@@ -74,7 +82,7 @@
 
     <!-- Options -->
     <div id="optionsDiv" class="mb-6">
-        <p class="font-semibold mb-2">Options:</p>
+        <p class="form-label mb-2">Options</p>
         <!-- MCQ Option Tabs -->
         <div id="optionTabs" class="flex items-center overflow-x-auto">
             <!-- Tabs will be inserted before this -->
@@ -90,7 +98,7 @@
 
     <!-- Answer -->
     <div class="mb-6" id="answerDiv">
-        <p class="font-semibold mb-2">Answer:</p>
+        <p class="form-label mb-2">Answer</p>
         <div id="answerContent">
             <!-- Either checkboxes or integer input will be inserted here -->
         </div>
@@ -98,7 +106,7 @@
 
     <!-- Solution -->
     <div class="mb-6" id="solutionDiv">
-        <p class="font-semibold mb-2">Solution:</p>
+        <p class="form-label mb-2">Solution</p>
         {{ if and .ProblemPtr (gt (len .ProblemPtr.MetaData.Solutions) 0) }}
         {{ template "editor" (index .ProblemPtr.MetaData.Solutions 0).Value }}
         {{ else }}
@@ -108,7 +116,7 @@
 
     <!-- Tags -->
     <div class="mb-6">
-        <p class="font-semibold mb-2">Tags:</p>
+        <p class="form-label mb-2">Tags</p>
         {{ if .ProblemPtr }}
             {{ template "input_tags" .ProblemPtr.TagNames }}
         {{ else }}
@@ -119,8 +127,8 @@
     <!-- SOURCE -->
     <!-- <div class="mb-6">
         <p class="font-semibold mb-2">SOURCE</p>
-        <table class="w-full text-left border border-gray-300">
-            <thead class="bg-gray-200">
+        <table class="w-full text-left border border-border">
+            <thead class="bg-bg-card-alt">
                 <tr>
                     <th class="px-4 py-2">Name</th>
                     <th class="px-4 py-2">Mode</th>
@@ -135,12 +143,14 @@
                 </tr>
             </tbody>
         </table>
-        <a href="#" class="text-blue-600 underline mt-2 inline-block">Add Source</a>
+        <a href="#" class="text-accent underline mt-2 inline-block">Add Source</a>
     </div> -->
 
     <!-- Save button -->
-    <button id="saveButton" type="submit"
-        class="w-full bg-blue-500 text-white mb-4 py-3 font-semibold rounded hover:bg-blue-600">Save</button>
+    <div class="flex gap-3 justify-end pt-2">
+        <button type="button" class="btn-secondary" onclick="window.history.back()">Cancel</button>
+        <button id="saveButton" type="submit" class="btn-primary btn-lg">Save Problem</button>
+    </div>
 
 </form>
 
@@ -244,8 +254,8 @@
                     answer = '';
                 }
                 answerContent.innerHTML = `
-                    <input type="text" name="answer" id="answerInput" 
-                        class="w-full border border-gray-300 rounded p-2" 
+                    <input type="text" name="answer" id="answerInput"
+                        class="form-input font-mono"
                         inputmode="numeric" value="${answer}">
                 `;
 

--- a/web/html/add_resource.html
+++ b/web/html/add_resource.html
@@ -1,22 +1,34 @@
 <!-- Form to add new resource -->
-<form id="addResourceForm" class="mt-2 flex flex-wrap gap-2"
+<form id="addResourceForm" class="card card-pad-sm mt-3 flex flex-wrap items-end gap-3"
     hx-post="/create-resource?chapter_id={{.ChapterID}}{{ if .TopicID }}&topic_id={{.TopicID}}{{ end }}"
     hx-target="#resourceTableBody"
     hx-swap="beforeend" hx-include="#curriculum-dropdown, #grade-dropdown"
     hx-on::after-request="if(event.detail.successful) { this.reset(); ResourceForm.sync('add-resource-type','add-resource-subtype'); }">
-    <input type="text" name="name" placeholder="Resource Name" class="border p-2 w-1/3" required>
-    <select id="add-resource-type" name="type" class="border p-2" required
-        onchange="ResourceForm.sync('add-resource-type','add-resource-subtype')">
-        <option value="" selected disabled hidden>Select Type</option>
-        {{ range .TypeOptions }}
-        <option value="{{.}}">{{.}}</option>
-        {{ end }}
-    </select>
-    <select id="add-resource-subtype" name="subtype" class="border p-2" required disabled>
-        <option value="" selected disabled hidden>Select Subtype</option>
-    </select>
-    <input type="url" name="src_link" placeholder="URL" class="border p-2 flex-1 min-w-56" required>
-    <button type="submit" class="bg-blue-500 text-white p-2 rounded">Create New Resource</button>
+    <div class="w-1/3 min-w-[200px]">
+        <label class="form-label" for="add-resource-name">Name</label>
+        <input id="add-resource-name" type="text" name="name" placeholder="Resource name" class="form-input" required>
+    </div>
+    <div>
+        <label class="form-label" for="add-resource-type">Type</label>
+        <select id="add-resource-type" name="type" class="form-select" required
+            onchange="ResourceForm.sync('add-resource-type','add-resource-subtype')">
+            <option value="" selected disabled hidden>Select Type</option>
+            {{ range .TypeOptions }}
+            <option value="{{.}}">{{.}}</option>
+            {{ end }}
+        </select>
+    </div>
+    <div>
+        <label class="form-label" for="add-resource-subtype">Subtype</label>
+        <select id="add-resource-subtype" name="subtype" class="form-select" required disabled>
+            <option value="" selected disabled hidden>Select Subtype</option>
+        </select>
+    </div>
+    <div class="flex-1 min-w-[240px]">
+        <label class="form-label" for="add-resource-url">URL</label>
+        <input id="add-resource-url" type="url" name="src_link" placeholder="https://…" class="form-input font-mono" required>
+    </div>
+    <button type="submit" class="btn-primary">Create Resource</button>
 </form>
 <script>
     ResourceForm.sync('add-resource-type', 'add-resource-subtype');

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -33,23 +33,23 @@
 {{ else }}
   {{ $mode = "new" }}
 {{ end }}
-<h1 class="text-lg font-semibold">
+<h1 class="page-title mb-4">
     {{ if eq $mode "edit" }}Edit
     {{ else if eq $mode "copy" }}Copy
     {{ else }}New{{ end }} Test
 </h1>
-<div id="add-test-div" class="flex h-screen">
+<div id="add-test-div" class="flex h-screen gap-4">
     <!-- Left Panel -->
-    <div class="w-1/3 p-5 bg-white shadow overflow-auto">
+    <div class="w-1/3 p-5 card overflow-auto">
         <!-- Questions Sources: Tabs -->
         <div>
-            <div class="flex gap-2 border-b">
+            <div class="flex gap-2 border-b border-border">
                 <button id="left-tab-bank" type="button" hx-on:click="activateLeftTab('bank')"
-                    class="px-3 py-2 font-semibold border-b-2 border-blue-600 text-blue-700">
+                    class="px-3 py-2 font-bold uppercase tracking-wide text-sm border-b-2 border-accent text-accent-hover">
                     Question Bank
                 </button>
                 <button id="left-tab-search" type="button" hx-on:click="activateLeftTab('search')"
-                    class="px-3 py-2 font-semibold text-gray-600 hover:text-gray-800">
+                    class="px-3 py-2 font-bold uppercase tracking-wide text-sm text-ink-muted hover:text-ink border-b-2 border-transparent">
                     Search Tests
                 </button>
             </div>
@@ -65,7 +65,7 @@
                          Search Test tab -> click problem -> back -> switch to question bank tab -> shows blank for 
                          chapter & topic dropdowns clearing session storage values -->
                     <select id="chapter-dropdown" name="chapter-dropdown" hx-ext="cascade-clear"
-                        class="p-2 border rounded w-full"
+                        class="form-select"
                         hx-trigger="load, onLoaded from:(#curriculum-dropdown, #grade-dropdown, #subject-dropdown), change from:(#curriculum-dropdown, #grade-dropdown, #subject-dropdown)"
                         hx-get="/api/chapters?view=dropdown"
                         hx-include="#curriculum-dropdown, #grade-dropdown, #subject-dropdown"
@@ -73,14 +73,14 @@
                         hx-on::after-request="onDropdownLoaded(this, 'selectedChapter')">
                         <option>Select Chapter</option>
                     </select>
-                    <select id="topic-dropdown" name="topic-dropdown" hx-ext="cascade-clear" class="p-2 border rounded w-full"
+                    <select id="topic-dropdown" name="topic-dropdown" hx-ext="cascade-clear" class="form-select"
                         hx-get="/api/topics?view=dropdown" hx-trigger="change from:#chapter-dropdown"
                         hx-include="#chapter-dropdown" onchange="if (this.value) sessionStorage.setItem('selectedTopic', this.value);"
                         hx-on::after-request="onDropdownLoaded(this, 'selectedTopic')">
                         <option value="">Select Topic</option>
                     </select>
-                    <label class="font-semibold">Level</label>
-                    <label class="font-semibold">Problem Type</label>
+                    <label class="form-label">Level</label>
+                    <label class="form-label">Problem Type</label>
                     <div class="grid grid-cols-1 lg:grid-cols-2 gap-2" id="level-checkboxes">
                         <label class="flex items-center">
                             <input type="checkbox" name="level" value="" checked class="mr-2 level-checkbox" id="level-all">
@@ -99,18 +99,18 @@
                             Hard
                         </label>            
                     </div>
-                    <select id="ptype-dropdown" name="ptype-dropdown" class="p-2 border rounded w-full h-10">
+                    <select id="ptype-dropdown" name="ptype-dropdown" class="form-select-compact w-full">
                         <option value="">All</option>
                         {{ template "problem_type_options" }}
                     </select>
                 </div>
 
-                <table class="mt-3 w-full border text-left">
+                <table class="app-table mt-3 border border-border rounded-lg overflow-hidden">
                     <thead>
-                        <tr class="bg-gray-200">
-                            <th class="p-2">Code</th>
-                            <th class="p-2">Question</th>
-                            <th class="p-2">Action</th>
+                        <tr>
+                            <th>Code</th>
+                            <th>Question</th>
+                            <th>Action</th>
                         </tr>
                     </thead>
                     <tbody id="question-bank" hx-ext="addSelectedIds" hx-get="/api/topic/problems"
@@ -122,7 +122,7 @@
                     </tbody>
                 </table>
                 <div id="question-bank-loader" class="hidden flex justify-center py-4">
-                    <div class="w-6 h-6 border-4 border-gray-300 border-t-blue-600 rounded-full animate-spin"></div>
+                    <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
                 </div>                
             </div>
 
@@ -132,13 +132,13 @@
                 <div id="search-block" class="mt-3 relative w-full">
                     <div class="flex items-center gap-2">
                         <input id="query-input" name="search" type="text"
-                            class="p-2 border rounded w-full" placeholder="Search by Code or Name">
+                            class="form-input" placeholder="Search by Code or Name">
                 
                         <!-- Button + Loader wrapper -->
                         <div class="relative w-28 flex-shrink-0">
                             <!-- Search button -->
                             <button id="search-btn" type="button"
-                                class="w-full px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+                                class="btn-primary w-full"
                                 hx-get="/api/search-tests?view=add-test&limit=20&offset=0"
                                 hx-include="#query-input" hx-target="#suggestions" hx-indicator="#search-btn-loader" 
                                 hx-on::before-request="this.classList.add('hidden')"
@@ -148,18 +148,18 @@
 
                             <!-- loader -->
                             <div id="search-btn-loader" class="hidden absolute inset-0 flex items-center justify-center">
-                                <div class="w-6 h-6 border-4 border-gray-300 border-t-blue-600 rounded-full animate-spin"></div>
+                                <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
                             </div>
                         </div>
                     </div>
                 
                     <!-- Suggestions full width because parent is relative -->
                     <div id="suggestions"
-                         class="hidden absolute left-0 mt-1 border rounded bg-white shadow z-10 w-full">
+                         class="hidden absolute left-0 mt-1 border rounded bg-bg-card shadow z-10 w-full">
                     </div>
                 </div>         
                 <div id="searched-test-loader" class="hidden flex justify-center py-4">
-                    <div class="w-6 h-6 border-4 border-gray-300 border-t-blue-600 rounded-full animate-spin"></div>
+                    <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
                 </div>                                   
                 <div id="searched-test-results" class="mt-4">
                 </div>
@@ -184,7 +184,7 @@
     So when any child element inside the form (like our <a> tag with hx-get on clicking problem code) triggers 
     an HTMX request, the before-request event is fired on the parent form, causing createTest(...) to be called 
     even for unrelated hx-get actions -->
-    <form id="add-test-right-div" class="flex-1 p-5 overflow-auto bg-gray-50"
+    <form id="add-test-right-div" class="flex-1 p-5 overflow-auto bg-bg-card-alt"
         {{ if ne $mode "copy" }}
             hx-post="/create-test"
             hx-on::before-request='if (event.target === this) createTest(event, {{$id}}, {{$subtype}}, {{$curriculumGrades}}, {{index .TestPtr.ExamIDs 0}})'
@@ -201,7 +201,7 @@
         <div class="flex items-center justify-between">
             <label class="font-semibold">Select Test Code</label>
             <button type="button" id="test-instructions-link"
-                class="text-blue-600 hover:text-blue-800 hover:underline"
+                class="text-accent hover:text-accent-hover hover:underline"
                 onclick="openInstructionsModal()">
                 Test Instructions
             </button>
@@ -220,7 +220,7 @@
             {{ $seq = index $parts 2 }}
             {{ $year = index $parts 3 }}
             {{end}}
-            <select id="program-dropdown" class="p-2 border rounded flex-1"
+            <select id="program-dropdown" class="form-input flex-1"
                 onchange="sessionStorage.setItem('selectedProgram', this.value);">
                 {{ if ne $mode "edit" }}
                 <option value="" selected disabled hidden>Select Program</option>
@@ -230,7 +230,7 @@
                 <option {{if eq $program $opt}}selected{{end}}>{{$opt}}</option>
                 {{end}}
             </select>
-            <select id="test-type-code-dropdown" class="p-2 border rounded flex-1"
+            <select id="test-type-code-dropdown" class="form-input flex-1"
                 onchange="sessionStorage.setItem('selectedTestTypeCode', this.value);">
                 {{ if ne $mode "edit" }}
                 <option value="" selected disabled hidden>Select Type Code</option>
@@ -240,7 +240,7 @@
                 <option {{if eq $type $opt}}selected{{end}}>{{$opt}}</option>
                 {{end}}
             </select>
-            <select id="test-sequence-dropdown" class="p-2 border rounded flex-1"
+            <select id="test-sequence-dropdown" class="form-input flex-1"
                 onchange="sessionStorage.setItem('selectedSequence', this.value);">
                 {{ if ne $mode "edit" }}
                 <option value="" selected disabled hidden>Select Sequence</option>
@@ -251,7 +251,7 @@
                 <option {{if eq $seq (printf "%d" $i)}}selected{{end}}>{{$i}}</option>
                 {{end}}
             </select>
-            <select id="year-dropdown" class="p-2 border rounded flex-1"
+            <select id="year-dropdown" class="form-input flex-1"
                 onchange="sessionStorage.setItem('selectedYear', this.value);">
                 {{ if ne $mode "edit" }}
                 <option value="" selected disabled hidden>Select Year</option>
@@ -269,11 +269,11 @@
         {{ template "test_instructions_modal" }}
 
         <div class="flex items-center gap-2">
-            <input id="test-name" type="text" placeholder="Test Name" class="p-2 border rounded flex-1"
+            <input id="test-name" type="text" placeholder="Test Name" class="form-input flex-1"
                 value='{{ if eq $mode "edit" }}{{.TestPtr.GetNameByLang "en"}}{{end}}' 
                 onchange="sessionStorage.setItem('selectedName', this.value);">
             {{ if eq $mode "edit" }}
-            <select id="test-type-dropdown" class="p-2 border rounded flex-1">
+            <select id="test-type-dropdown" class="form-input flex-1">
                 {{ template "test_type_options" .TestPtr }}
             </select>
             {{end}}
@@ -333,7 +333,7 @@
         <!-- Levels Table -->
         <table class="mt-4 w-full border text-center">
             <thead>
-                <tr class="bg-gray-200">
+                <tr class="bg-bg-card-alt">
                     <th class="p-2">Level 1</th>
                     <th class="p-2">Level 2</th>
                     <th class="p-2">Level 3</th>
@@ -351,7 +351,7 @@
         <!-- Questions Table -->
         <table class="mt-4 w-full border text-left">
             <thead>
-                <tr class="bg-gray-200">
+                <tr class="bg-bg-card-alt">
                     <th class="p-2">S.No</th>
                     <th class="p-2">Code</th>
                     <th class="p-2">Level</th>
@@ -410,7 +410,7 @@
         </div>
         {{ if eq $mode "copy" }}
             <button id="continue-btn" type="button"
-                class="mt-4 w-full px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+                class="btn-primary w-full mt-4"
                 hx-get="/tests/add-test-dialog" hx-target="body" hx-swap="beforeend" hx-push-url="true"
                 hx-vals='{
                     "subtype": {{$subtype}},
@@ -419,7 +419,7 @@
                 }'
                 hx-on::before-request="if (!validateFields()) event.preventDefault()">Continue</button>
         {{ else }}
-            <button type="submit" class="mt-4 w-full px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
+            <button type="submit" class="btn-primary w-full mt-4">
                 Save</button>
         {{ end }}
     </form>
@@ -546,8 +546,8 @@
         const bankView = document.getElementById('bank-view');
         const searchView = document.getElementById('search-view');
 
-        const activeClasses = ['border-b-2', 'border-blue-600', 'text-blue-700'];
-        const inactiveClasses = ['text-gray-600'];
+        const activeClasses = ['border-b-2', 'border-accent', 'text-accent-hover'];
+        const inactiveClasses = ['text-ink-muted'];
 
         if (tab === 'bank') {
             bankView.classList.remove('hidden');
@@ -1172,8 +1172,8 @@
 
     function addValidationErrorUI(row, reason) {
         // mark colors
-        row.classList.add('bg-red-100');
-        row.classList.remove('bg-green-100');
+        row.classList.add('bg-danger-bg');
+        row.classList.remove('bg-success-bg');
 
         // store reason
         row.dataset.validationError = reason || 'Validation failed.';
@@ -1190,8 +1190,8 @@
     }
 
     function clearValidationErrorUI(row) {
-        row.classList.remove('bg-red-100');
-        row.classList.add('bg-green-100');
+        row.classList.remove('bg-danger-bg');
+        row.classList.add('bg-success-bg');
         delete row.dataset.validationError;
 
         const actionCell = row.querySelector('td:last-child');
@@ -1397,7 +1397,7 @@
         button.title = "Saved";
 
         const icon = button.querySelector("i");
-        icon.className = "fa-solid fa-check fa-lg text-green-600";
+        icon.className = "fa-solid fa-check fa-lg text-success";
 
         setTimeout(() => {
             resetSubjSaveButton(button);
@@ -1408,7 +1408,7 @@
         button.title = "Save failed";
 
         const icon = button.querySelector("i");
-        icon.className = "fa-solid fa-triangle-exclamation fa-lg text-red-600";
+        icon.className = "fa-solid fa-triangle-exclamation fa-lg text-danger";
 
         setTimeout(() => {
             resetSubjSaveButton(button);
@@ -1437,7 +1437,7 @@
         Sortable.create(tableBody, {
             animation: 150,
             multiDrag: true,
-            selectedClass: "bg-blue-100",
+            selectedClass: "bg-brand-blue-bg",
             draggable: "tr[id^='problem-']",
             
             onMove(evt) {

--- a/web/html/add_test_modal.html
+++ b/web/html/add_test_modal.html
@@ -1,17 +1,17 @@
-<div id="addTestModal" class="fixed inset-0 bg-gray-800 bg-opacity-50 flex justify-center items-center z-50">
-    <div class="bg-white p-6 rounded shadow-md w-full max-w-md">
-        <h2 class="text-lg font-semibold mb-4">
+<div id="addTestModal" class="fixed inset-0 bg-ink/40 flex justify-center items-center z-50 p-4">
+    <div class="card shadow-xl rounded-xl w-full max-w-md p-6 max-h-[90vh] overflow-y-auto">
+        <h2 class="page-title mb-6">
             {{ if .Subtype }}Copy Test{{ else }}Create New Test{{ end }}
         </h2>
         <form id="addTestForm">
             <div id="curriculum-grade-container" class="space-y-4 mb-6">
                 <div class="curriculum-grade-set">
-                    <div class="grid grid-cols-[1fr_1fr_auto] gap-4 items-center">
-                        <label class="font-medium">Curriculum</label>
-                        <label class="font-medium">Grade</label>
+                    <div class="grid grid-cols-[1fr_1fr_auto] gap-3 items-center">
+                        <label class="form-label mb-0">Curriculum</label>
+                        <label class="form-label mb-0">Grade</label>
                         <div class="w-6"><!-- empty header space for ✕ button --></div>
                     </div>
-                    <div id="curriculum-grade-set" name="curriculum-grade-set" class="grid gap-4 mt-1">
+                    <div id="curriculum-grade-set" name="curriculum-grade-set" class="grid gap-3 mt-1">
                         {{ if .CurriculumGrades }}
                             {{ $count := len .CurriculumGrades }}
                             {{ range .CurriculumGrades }}
@@ -26,23 +26,23 @@
 
             <!-- Link to add more Curriculum-Grade sets -->
             <div class="mb-6">
-                <a href="#" class="text-blue-500 text-sm hover:underline" hx-get="/add-curriculum-grade-selects"
-                    hx-target="#curriculum-grade-set" hx-swap="beforeend" 
+                <a href="#" class="add-new-link" hx-get="/add-curriculum-grade-selects"
+                    hx-target="#curriculum-grade-set" hx-swap="beforeend"
                     hx-on::after-request="handleAddCurriculumGradeResponse(event)">+ Add one more set</a>
             </div>
 
             <!-- Test Type Dropdown -->
-            <div class="mb-6 flex items-center gap-4">
-                <label for="modal-testType" class="font-medium whitespace-nowrap">Test Type</label>
-                <select id="modal-testType" name="modal-testType" class="flex-1 border p-2 rounded">
+            <div class="mb-4">
+                <label for="modal-testType" class="form-label">Test Type</label>
+                <select id="modal-testType" name="modal-testType" class="form-select">
                     {{ template "test_type_options" . }}
                 </select>
             </div>
 
             <!-- Exam Type Dropdown -->
-            <div class="mb-6 flex items-center gap-4">
-                <label for="modal-examType" class="font-medium whitespace-nowrap">Exam Type</label>
-                <select id="modal-examType" name="modal-examType" class="flex-1 border p-2 rounded"
+            <div class="mb-6">
+                <label for="modal-examType" class="form-label">Exam Type</label>
+                <select id="modal-examType" name="modal-examType" class="form-select"
                     hx-get="/api/exams" hx-trigger="revealed once"
                     {{ if .ExamID }}
                         hx-on::after-request="document.getElementById('modal-examType').value='{{ .ExamID }}'"
@@ -52,21 +52,20 @@
             </div>
 
             <!-- Buttons -->
-            <div class="w-full flex-row flex justify-end space-x-2">
-                <button type="button" onclick="closeAddTestModal()"
-                    class="bg-gray-300 px-4 py-2 rounded">Cancel</button>
+            <div class="flex gap-3 justify-end pt-2 border-t border-border">
+                <button type="button" onclick="closeAddTestModal()" class="btn-secondary">Cancel</button>
 
                 <!-- Continue (normal new test flow) -->
                 <button type="button" hx-post="/tests/add-test" hx-target="body" hx-push-url="true"
                     hx-on::before-request="if (!validateSelectedOptions()) event.preventDefault()"
-                    class="bg-blue-500 text-white px-4 py-2 rounded {{ if .Subtype }}hidden{{ end }}">Continue</button>
+                    class="btn-primary {{ if .Subtype }}hidden{{ end }}">Continue</button>
 
                 <!-- Validate (copy mode) -->
                 <button type="button" hx-post="/tests/validate-test" hx-swap="none"
-                    class="bg-blue-500 text-white px-4 py-2 rounded {{ if not .Subtype }}hidden{{ end }}"
+                    class="btn-primary {{ if not .Subtype }}hidden{{ end }}"
                     hx-on::before-request="if (!validateSelectedOptions()) event.preventDefault()"
                     hx-on::after-request="handleValidateTestResponse(event)">
-                    Validate & Save
+                    Validate &amp; Save
                 </button>
             </div>
 

--- a/web/html/add_test_search_row.html
+++ b/web/html/add_test_search_row.html
@@ -1,5 +1,5 @@
 {{range .Tests}}
-<div id="search-row-{{.ID}}" class="p-2 hover:bg-gray-100 cursor-pointer" hx-target="#searched-test-results"
+<div id="search-row-{{.ID}}" class="p-2 hover:bg-bg-card-alt cursor-pointer" hx-target="#searched-test-results"
     hx-get="/api/test/subjectwise-problems?id={{.ID}}&curriculum_id={{(index .CurriculumGrades 0).CurriculumID}}&grade_id={{(index .CurriculumGrades 0).GradeID}}"
     hx-indicator="#searched-test-loader, #searched-test-results" hx-trigger="click" hx-ext="addSelectedIds"
     hx-on::before-request="selectSuggestion(this.id, '{{.Code}} — {{ (index .Name 0).Resource }}')">

--- a/web/html/add_test_searched.html
+++ b/web/html/add_test_searched.html
@@ -1,11 +1,11 @@
 <div>
 	<div class="flex items-center justify-between mb-2">
 		<h3 class="text-base font-semibold">Selected Test</h3>
-		<div class="text-sm text-gray-600">{{.TestPtr.Code}} — {{ (index .TestPtr.Name 0).Resource }}</div>
+		<div class="text-sm text-ink-muted">{{.TestPtr.Code}} — {{ (index .TestPtr.Name 0).Resource }}</div>
 	</div>
 	<table class="mt-2 w-full border text-left">
 		<thead>
-			<tr class="bg-gray-200">
+			<tr class="bg-bg-card-alt">
 				<th class="p-2">Code</th>
 				<th class="p-2">Question</th>
 				<th class="p-2">Action</th>
@@ -15,12 +15,12 @@
 			{{ range $index, $subject := .TestPtr.TypeParams.Subjects }}
 				<tr>
 					<td colspan="3" class="p-0">
-						<div class="flex items-center justify-between p-1 bg-gray-100">
-							<h2 class="text-sm font-semibold bg-gray-100 p-2 capitalize">
+						<div class="flex items-center justify-between p-1 bg-bg-card-alt">
+							<h2 class="text-sm font-semibold bg-bg-card-alt p-2 capitalize">
 								{{$subject.Name}}
 							</h2>	
 							<button type="button"
-								class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs"
+								class="px-3 py-1 bg-accent text-white rounded hover:bg-accent text-xs"
 								onclick="addAllFromSubject(this)">
 								Add All
 							</button>

--- a/web/html/add_topic.html
+++ b/web/html/add_topic.html
@@ -1,8 +1,15 @@
 <!-- Form to add new topic -->
-<form id="addTopicForm" class="mt-2 space-x-2" hx-post="/create-topic?chapter_id={{.}}" hx-target="#topicTableBody"
+<form id="addTopicForm" class="card card-pad-sm mt-3 flex flex-wrap items-end gap-3"
+    hx-post="/create-topic?chapter_id={{.}}" hx-target="#topicTableBody"
     hx-swap="beforeend" hx-include="#curriculum-dropdown"
     hx-on::after-request="if(event.detail.successful) this.reset()">
-    <input type="text" name="code" placeholder="Code" class="border p-2">
-    <input type="text" name="name" placeholder="Name" class="border p-2 w-1/3">
-    <button type="submit" class="bg-blue-500 text-white p-2 rounded">Create New Topic</button>
+    <div>
+        <label class="form-label" for="add-topic-code">Code</label>
+        <input id="add-topic-code" type="text" name="code" placeholder="Topic code" class="form-input w-48 font-mono">
+    </div>
+    <div class="flex-1 min-w-[240px]">
+        <label class="form-label" for="add-topic-name">Name</label>
+        <input id="add-topic-name" type="text" name="name" placeholder="Topic name" class="form-input">
+    </div>
+    <button type="submit" class="btn-primary">Create Topic</button>
 </form>

--- a/web/html/admin_user_row.html
+++ b/web/html/admin_user_row.html
@@ -1,6 +1,6 @@
 <tr class="border-b" id="user-row-{{ .ID }}">
     <td class="py-2 px-4">{{ .Email }}</td>
-    <td class="py-2 px-4">{{ if .FullName }}{{ .FullName }}{{ else }}<span class="text-gray-400">—</span>{{ end }}</td>
+    <td class="py-2 px-4">{{ if .FullName }}{{ .FullName }}{{ else }}<span class="text-ink-muted/70">—</span>{{ end }}</td>
     <td class="py-2 px-4">
         <form hx-post="/admin/users/role" hx-target="#user-row-{{ .ID }}" hx-swap="outerHTML">
             <input type="hidden" name="id" value="{{ .ID }}">
@@ -13,24 +13,24 @@
     </td>
     <td class="py-2 px-4">
         {{ if .IsActive }}
-        <span class="px-2 py-0.5 rounded text-xs bg-green-100 text-green-700">active</span>
+        <span class="px-2 py-0.5 rounded text-xs bg-success-bg text-success">active</span>
         {{ else }}
-        <span class="px-2 py-0.5 rounded text-xs bg-gray-200 text-gray-600">inactive</span>
+        <span class="px-2 py-0.5 rounded text-xs bg-bg-card-alt text-ink-muted">inactive</span>
         {{ end }}
     </td>
-    <td class="py-2 px-4 text-gray-500">
-        {{ if .LastLoginAt }}{{ .LastLoginAt.Format "2006-01-02 15:04" }}{{ else }}<span class="text-gray-400">never</span>{{ end }}
+    <td class="py-2 px-4 text-ink-muted">
+        {{ if .LastLoginAt }}{{ .LastLoginAt.Format "2006-01-02 15:04" }}{{ else }}<span class="text-ink-muted/70">never</span>{{ end }}
     </td>
     <td class="py-2 px-4 text-right">
         {{ if .IsActive }}
         <button hx-post="/admin/users/active?id={{ .ID }}&active=false"
                 hx-target="#user-row-{{ .ID }}" hx-swap="outerHTML"
                 hx-confirm="Deactivate {{ .Email }}?"
-                class="text-red-600 hover:underline">Deactivate</button>
+                class="text-danger hover:text-accent-hover hover:underline">Deactivate</button>
         {{ else }}
         <button hx-post="/admin/users/active?id={{ .ID }}&active=true"
                 hx-target="#user-row-{{ .ID }}" hx-swap="outerHTML"
-                class="text-blue-600 hover:underline">Reactivate</button>
+                class="text-accent hover:text-accent-hover hover:underline font-medium">Reactivate</button>
         {{ end }}
     </td>
 </tr>

--- a/web/html/admin_users.html
+++ b/web/html/admin_users.html
@@ -1,45 +1,45 @@
 {{ define "content" }}
 <div class="max-w-5xl">
     <div class="flex items-center justify-between mb-4">
-        <h1 class="text-2xl font-bold">CMS Users</h1>
+        <h1 class="page-title">CMS Users</h1>
     </div>
 
     <form hx-post="/admin/users/create" hx-target="#users-tbody" hx-swap="beforeend"
           hx-on::after-request="if(event.detail.successful){this.reset()}"
-          class="bg-white rounded shadow p-4 mb-6 grid grid-cols-12 gap-3 items-end">
+          class="card card-pad-sm mb-6 grid grid-cols-12 gap-3 items-end">
         <div class="col-span-5">
-            <label class="block text-xs text-gray-600 mb-1">Email</label>
+            <label class="form-label">Email</label>
             <input name="email" type="email" required placeholder="someone@avantifellows.org"
-                   class="w-full border p-2 rounded">
+                   class="form-input">
         </div>
         <div class="col-span-3">
-            <label class="block text-xs text-gray-600 mb-1">Full name</label>
+            <label class="form-label">Full name</label>
             <input name="full_name" type="text" placeholder="Optional"
-                   class="w-full border p-2 rounded">
+                   class="form-input">
         </div>
         <div class="col-span-2">
-            <label class="block text-xs text-gray-600 mb-1">Role</label>
-            <select name="role" class="w-full border p-2 rounded">
+            <label class="form-label">Role</label>
+            <select name="role" class="form-select">
                 {{ range .Roles }}<option value="{{ . }}" {{ if eq . "editor" }}selected{{ end }}>{{ . }}</option>{{ end }}
             </select>
         </div>
         <div class="col-span-2">
-            <button type="submit" class="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 rounded">
+            <button type="submit" class="btn-primary w-full">
                 Add user
             </button>
         </div>
     </form>
 
-    <div class="bg-white rounded shadow overflow-hidden">
-        <table class="w-full text-sm">
-            <thead class="bg-gray-50 text-left text-gray-600">
+    <div class="card overflow-hidden">
+        <table class="app-table">
+            <thead>
                 <tr>
-                    <th class="py-2 px-4">Email</th>
-                    <th class="py-2 px-4">Full name</th>
-                    <th class="py-2 px-4">Role</th>
-                    <th class="py-2 px-4">Active</th>
-                    <th class="py-2 px-4">Last login</th>
-                    <th class="py-2 px-4"></th>
+                    <th>Email</th>
+                    <th>Full name</th>
+                    <th>Role</th>
+                    <th>Active</th>
+                    <th>Last login</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody id="users-tbody">

--- a/web/html/chapter.html
+++ b/web/html/chapter.html
@@ -1,16 +1,16 @@
 {{ define "content" }}
-<div class="bg-white mb-4">
-    <div class="flex items-center">
-        <button class="action-button" onclick="window.history.back()">
+<div class="card card-pad mb-4">
+    <div class="flex items-center mb-4">
+        <button class="btn-ghost btn-sm" onclick="window.history.back()">
             <i class="fa-solid fa-chevron-left"></i> Back
         </button>
-        <h3 class="text-base font-semibold ml-4">{{ getName .ChapterPtr "en" }}</h3>
+        <h3 class="ml-4 text-lg font-bold uppercase tracking-wide text-ink">{{ getName .ChapterPtr "en" }}</h3>
     </div>
-    <div class="flex space-x-4 py-4">
-        <div class="sub-tab active" 
+    <div class="flex flex-wrap gap-3 py-2 border-b border-border">
+        <div class="sub-tab active"
             id="topics-sub-tab"
             hx-trigger="load[document.getElementById('topics-sub-tab').classList.contains('active')], click"
-            hx-get="/topics?id={{.ChapterPtr.ID}}" 
+            hx-get="/topics?id={{.ChapterPtr.ID}}"
             hx-target="#subContent"
             onclick="
                 document.getElementById('topics-sub-tab').classList.add('active');
@@ -18,7 +18,7 @@
             ">
             Topics
         </div>
-        <div class="sub-tab" 
+        <div class="sub-tab"
             id="resources-sub-tab"
             hx-get="/chapter/resources?chapterId={{.ChapterPtr.ID}}"
             hx-trigger="load[document.getElementById('resources-sub-tab').classList.contains('active')], click"
@@ -30,7 +30,7 @@
             Resources
         </div>
     </div>
-    <div id="sub-tabContent">
+    <div id="sub-tabContent" class="pt-4">
         <div id="subContent">
         </div>
     </div>

--- a/web/html/chapter_row.html
+++ b/web/html/chapter_row.html
@@ -1,9 +1,9 @@
 {{ range . }}
-<tr class="border-b hover:bg-gray-100">
+<tr class="border-b border-border/40 hover:bg-bg-hover transition-colors">
     <td class="py-4 px-6">{{.Code}}</td>
-    <td class="px-6 text-blue-500 hover:underline"><a href="/chapter?id={{.ID}}" hx-get="/chapter?id={{.ID}}" 
+    <td class="px-6 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/chapter?id={{.ID}}" hx-get="/chapter?id={{.ID}}" 
         hx-target="body" hx-push-url="true">{{ getName . "en" }}</a></td>
-    <td class="px-6 text-center text-blue-500 hover:underline"><a href="#">{{.TopicCount}}</a></td>
+    <td class="px-6 text-center text-accent hover:text-accent-hover hover:underline font-medium"><a href="#">{{.TopicCount}}</a></td>
     <td></td>
     <td></td>
     <td></td>

--- a/web/html/chapters.html
+++ b/web/html/chapters.html
@@ -1,39 +1,39 @@
 {{ define "content" }}
 <div>
-    <div class="shadow-md my-6 overflow-x-auto" hx-ext="table-sort" data-sort-scope="chapters">
-        <table class="min-w-full bg-white">
+    <div class="card overflow-x-auto my-6" hx-ext="table-sort" data-sort-scope="chapters">
+        <table class="app-table">
             <thead>
-                <tr class="bg-gray-200 text-gray-600 text-sm">
-                    <th class="py-4 px-6 text-left">
-                        <a href="#" hx-get="/chapters" hx-target="body" hx-on:click="updateTableSortState('1', 'chapters');"
+                <tr>
+                    <th>
+                        <a href="#" class="hover:text-accent" hx-get="/chapters" hx-target="body" hx-on:click="updateTableSortState('1', 'chapters');"
                             hx-on::before-request="sessionStorage.removeItem(window.CHAPTERS_LOADED_KEY)">
                             Code <i class="fas fa-sort"></i>
                         </a>
                     </th>
-                    <th class="px-6 text-left">
-                        <a href="#" hx-get="/chapters" hx-target="body" hx-on:click="updateTableSortState('2', 'chapters');"
+                    <th>
+                        <a href="#" class="hover:text-accent" hx-get="/chapters" hx-target="body" hx-on:click="updateTableSortState('2', 'chapters');"
                             hx-on::before-request="sessionStorage.removeItem(window.CHAPTERS_LOADED_KEY)">
                             Name <i class="fas fa-sort"></i>
                         </a>
                     </th>
-                    <th class="px-6 text-center">
-                        <a href="#" hx-get="/chapters" hx-target="body" hx-on:click="updateTableSortState('3', 'chapters');"
+                    <th class="text-center">
+                        <a href="#" class="hover:text-accent" hx-get="/chapters" hx-target="body" hx-on:click="updateTableSortState('3', 'chapters');"
                             hx-on::before-request="sessionStorage.removeItem(window.CHAPTERS_LOADED_KEY)">
                             Topics <i class="fas fa-sort"></i>
                         </a>
                     </th>
-                    <th class="px-6 text-center">Chapter Tests</th>
-                    <th class="px-6 text-center">PSV</th>
-                    <th class="px-6 text-center">MOD</th>
-                    <th class="px-6 text-center">CV</th>
-                    <th class="px-6 text-center">CT</th>
-                    <th class="px-6 text-center">Status</th>
-                    <th class="px-6 text-center">Actions</th>
+                    <th class="text-center">Chapter Tests</th>
+                    <th class="text-center">PSV</th>
+                    <th class="text-center">MOD</th>
+                    <th class="text-center">CV</th>
+                    <th class="text-center">CT</th>
+                    <th class="text-center">Status</th>
+                    <th class="text-center">Actions</th>
                 </tr>
             </thead>
-            <tbody id="chapterTableBody" hx-ext="chaptersLoader" class="text-gray-600 text-sm" hx-get="/api/chapters?view=list"
-                hx-trigger="load[!document.getElementById('curriculum-dropdown').options[0].disabled], 
-                onLoaded from:(#curriculum-dropdown, #grade-dropdown, #subject-dropdown), 
+            <tbody id="chapterTableBody" hx-ext="chaptersLoader" hx-get="/api/chapters?view=list"
+                hx-trigger="load[!document.getElementById('curriculum-dropdown').options[0].disabled],
+                onLoaded from:(#curriculum-dropdown, #grade-dropdown, #subject-dropdown),
                 change from:(#curriculum-dropdown, #grade-dropdown, #subject-dropdown)"
                 hx-include="#curriculum-dropdown, #grade-dropdown, #subject-dropdown"
                 hx-on::after-request="sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'true')">
@@ -44,8 +44,8 @@
 
     <!-- Form to add new chapter -->
     <div class="mt-4">
-        <h4 id="addChapterLink" class="text-sm font-semibold text-blue-500 hover:underline" onclick="toggleForm(event)">
-            <a href="#">Add New Chapter</a>
+        <h4 id="addChapterLink" class="add-new-link" onclick="toggleForm(event)">
+            <a href="#">+ Add New Chapter</a>
         </h4>
     </div>
 

--- a/web/html/curriculum_grade_selects.html
+++ b/web/html/curriculum_grade_selects.html
@@ -2,11 +2,11 @@
 {{ $count := .Count }}
 {{ if not $count }}{{ $count = 1 }}{{ end }}
 <div class="grid grid-cols-[1fr_1fr_auto] gap-4 items-center curriculum-grade-row">
-    <select name="curriculum[]" class="border p-2 rounded w-full" hx-get="/api/curriculums" hx-trigger="load"
+    <select name="curriculum[]" class="form-select" hx-get="/api/curriculums" hx-trigger="load"
         data-selected="{{with .Item}}{{.CurriculumID}}{{end}}" hx-on::after-request="selectPreloadedOption(this)">
         <option disabled selected>Loading curriculums...</option>
     </select>
-    <select name="grade[]" class="border p-2 rounded w-full" hx-get="/api/grades" hx-trigger="load"
+    <select name="grade[]" class="form-select" hx-get="/api/grades" hx-trigger="load"
         data-selected="{{with .Item}}{{.GradeID}}{{end}}" hx-on::after-request="selectPreloadedOption(this)">
         <option disabled selected>Loading grades...</option>
     </select>

--- a/web/html/curriculum_grade_selects.html
+++ b/web/html/curriculum_grade_selects.html
@@ -11,7 +11,7 @@
         <option disabled selected>Loading grades...</option>
     </select>
 
-    <button type="button" class="text-red-500 text-sm hover:font-bold w-6 text-center {{ if eq $count 1 }}invisible{{ end }}"
+    <button type="button" class="text-danger text-sm hover:font-bold w-6 text-center {{ if eq $count 1 }}invisible{{ end }}"
         hx-on:click="removeCurriculumGradeRow(this)">✕</button>
 </div>
 {{ end }}

--- a/web/html/dest_problem_row.html
+++ b/web/html/dest_problem_row.html
@@ -5,11 +5,11 @@
     data-skill-ids="{{joinInt16 .SkillIDs ","}}" data-difficulty="{{$difficulty}}" data-mathjax="true" 
     class="cursor-move">
     <td class="p-2">{{if $.SrNo}}{{$.SrNo}}{{end}}</td>
-    <td class="p-2 text-blue-500 hover:underline"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" 
+    <td class="p-2 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" 
         hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body" hx-push-url="true">
         {{ .Code }}</a></td>
     <td class="p-2 text-center">
-        <select class="border border-gray-300 rounded px-2 py-1 text-sm bg-white"
+        <select class="border border-border rounded px-2 py-1 text-sm bg-bg-card"
             name="difficulty-level" data-problem-id="{{.ID}}" onchange="handleDifficultyChange(this)">
             <option value="easy"   {{if eq $difficulty "easy"}}selected{{end}}>1</option>
             <option value="medium" {{if eq $difficulty "medium"}}selected{{end}}>2</option>
@@ -21,7 +21,7 @@
      in type *models.Problem" -->
     {{ template "chip_box_cells" (dict "PosMarks" $.PosMarks "NegMarks" $.NegMarks "ReadOnlyMarks" $.ReadOnlyMarks) }}
 	<td class="p-2">
-        <select class="border border-gray-300 rounded px-2 py-1 text-sm bg-white" name="options-layout">
+        <select class="border border-border rounded px-2 py-1 text-sm bg-bg-card" name="options-layout">
             <option value="2x2"
                 {{if or
                     (and $.OptionLayout (eq $.OptionLayout.Rows 2) (eq $.OptionLayout.Cols 2))
@@ -43,10 +43,10 @@
     </td>    
     <td class="p-2">
 		<div class="action-cell-flex flex items-center justify-between w-full whitespace-nowrap">
-			<button class="px-2 bg-red-500 text-white rounded"
+			<button class="px-2 bg-danger text-white rounded"
 				hx-on:click="removeQuestionFromTest(this)">X</button>
 			<span class="validation-error-slot inline-flex items-center justify-center w-4">
-				<i class="validation-error-icon fa-solid fa-circle-exclamation text-red-500 invisible"></i>
+				<i class="validation-error-icon fa-solid fa-circle-exclamation text-danger invisible"></i>
 			</span>
 		</div>
 	</td>

--- a/web/html/dest_subject_row.html
+++ b/web/html/dest_subject_row.html
@@ -1,5 +1,5 @@
 {{ define "dest_subject_row" }}
-<tr id="subject-{{.SubjectId}}" class="bg-white">
+<tr id="subject-{{.SubjectId}}" class="bg-bg-card">
     <td class="p-2 font-medium capitalize" colspan="4">{{.SubjectName}}</td>
     {{ template "chip_box_cells" . }}
     <td></td>

--- a/web/html/dest_subtype_row.html
+++ b/web/html/dest_subtype_row.html
@@ -1,9 +1,9 @@
 {{ define "dest_subtype_row" }}
-<tr id="subtype-{{.SubjectId}}-{{.Subtype}}" class="bg-gray-100">
+<tr id="subtype-{{.SubjectId}}-{{.Subtype}}" class="bg-bg-card-alt">
     <td class="p-2 whitespace-nowrap" colspan="4">
         <!-- Editable field -->
         <input type="text" name="section-name" value="{{.DisplaySubtype}}"
-            class="border rounded px-2 py-1 w-full bg-white" maxlength="100"
+            class="border rounded px-2 py-1 w-full bg-bg-card" maxlength="100"
             onchange="saveSectionName('{{.SubjectId}}','{{.Subtype}}', this.value)"/>
     </td>
     {{ template "chip_box_cells" . }}

--- a/web/html/edit_chapter.html
+++ b/web/html/edit_chapter.html
@@ -1,22 +1,26 @@
 {{ define "content" }}
 <!-- Edit Chapter Form -->
-<div class="container mx-auto bg-white shadow-md rounded p-6 mt-4">
-  <h1 class="text-2xl font-semibold mb-4">Editing chapter</h1>
-  <form hx-patch="/update-chapter?id={{.ChapterPtr.ID}}" hx-on::after-request="sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false')">
-    <div class="mb-4">
-      <label for="name" class="block text-gray-700 font-medium mb-2">Chapter Title</label>
-      <input type="text" id="name" name="name" class="w-full p-3 border border-gray-300 rounded" value="{{ getName .ChapterPtr "en" }}">
+<div class="max-w-2xl mx-auto card card-pad mt-6">
+  <h1 class="page-title mb-4">Edit Chapter</h1>
+  <form hx-patch="/update-chapter?id={{.ChapterPtr.ID}}" class="space-y-4"
+        hx-on::after-request="sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false')">
+    <div>
+      <label class="form-label" for="name">Chapter Title</label>
+      <input type="text" id="name" name="name" class="form-input" value="{{ getName .ChapterPtr "en" }}">
     </div>
-    <div class="mb-4">
-      <label for="description" class="block text-gray-700 font-medium mb-2">Description</label>
-      <textarea id="description" name="description" class="w-full p-3 border border-gray-300 rounded"
+    <div>
+      <label class="form-label" for="description">Description</label>
+      <textarea id="description" name="description" rows="4" class="form-input"
         placeholder="Enter chapter description..."></textarea>
     </div>
-    <div class="mb-4">
-      <label for="code" class="block text-gray-700 font-medium mb-2">Chapter Code</label>
-      <input type="text" id="code" name="code" class="w-full p-3 border border-gray-300 rounded" value="{{.ChapterPtr.Code}}">
+    <div>
+      <label class="form-label" for="code">Chapter Code</label>
+      <input type="text" id="code" name="code" class="form-input font-mono" value="{{.ChapterPtr.Code}}">
     </div>
-    <button type="submit" class="w-full bg-blue-500 text-white p-3 rounded hover:bg-blue-600 transition">SAVE</button>
+    <div class="flex gap-3 justify-end pt-2">
+      <button type="button" class="btn-secondary" onclick="window.history.back()">Cancel</button>
+      <button type="submit" class="btn-primary">Save Changes</button>
+    </div>
   </form>
 </div>
 {{ end }}

--- a/web/html/edit_resource.html
+++ b/web/html/edit_resource.html
@@ -1,17 +1,17 @@
-<div class="container mx-auto bg-white shadow-md rounded p-6 mt-4">
-  <h1 class="text-2xl font-semibold mb-4">Editing resource</h1>
-  <form hx-patch="/update-resource?id={{.Resource.ID}}">
-    <div class="mb-4">
-      <label for="name" class="block text-gray-700 font-medium mb-2">Resource Name</label>
-      <input type="text" id="name" name="name" class="w-full p-3 border border-gray-300 rounded" value="{{ getName .Resource "en" }}">
+<div class="max-w-2xl mx-auto card card-pad mt-6">
+  <h1 class="page-title mb-4">Edit Resource</h1>
+  <form hx-patch="/update-resource?id={{.Resource.ID}}" class="space-y-4">
+    <div>
+      <label class="form-label" for="name">Resource Name</label>
+      <input type="text" id="name" name="name" class="form-input" value="{{ getName .Resource "en" }}">
     </div>
-    <div class="mb-4">
-      <label for="code" class="block text-gray-700 font-medium mb-2">Code</label>
-      <input type="text" id="code" name="code" class="w-full p-3 border border-gray-300 rounded bg-gray-100 text-gray-600" value="{{.Resource.Code}}" readonly>
+    <div>
+      <label class="form-label" for="code">Code</label>
+      <input type="text" id="code" name="code" class="form-input bg-bg-card-alt text-ink-muted font-mono" value="{{.Resource.Code}}" readonly>
     </div>
-    <div class="mb-4">
-      <label for="type" class="block text-gray-700 font-medium mb-2">Type</label>
-      <select id="edit-resource-type" name="type" class="w-full p-3 border border-gray-300 rounded" required
+    <div>
+      <label class="form-label" for="type">Type</label>
+      <select id="edit-resource-type" name="type" class="form-select" required
           onchange="ResourceForm.sync('edit-resource-type','edit-resource-subtype')">
         <option value="" disabled hidden {{if or (not .Resource.Type) (eq .Resource.Type "null")}}selected{{end}}>Select Type</option>
         {{ range .TypeOptions }}
@@ -19,18 +19,21 @@
         {{ end }}
       </select>
     </div>
-    <div class="mb-4">
-      <label for="subtype" class="block text-gray-700 font-medium mb-2">Subtype</label>
-      <select id="edit-resource-subtype" name="subtype" class="w-full p-3 border border-gray-300 rounded" required>
+    <div>
+      <label class="form-label" for="subtype">Subtype</label>
+      <select id="edit-resource-subtype" name="subtype" class="form-select" required>
       </select>
       <input type="hidden" id="edit-resource-subtype-value" value="{{.Resource.Subtype}}">
     </div>
-    <div class="mb-4">
-      <label for="src_link" class="block text-gray-700 font-medium mb-2">SrcLink</label>
-      <input type="url" id="src_link" name="src_link" class="w-full p-3 border border-gray-300 rounded" required
+    <div>
+      <label class="form-label" for="src_link">Source Link</label>
+      <input type="url" id="src_link" name="src_link" class="form-input font-mono" required
         placeholder="https://example.com/resource" value="{{.Resource.TypeParams.SrcLink}}">
     </div>
-    <button type="submit" class="w-full bg-blue-500 text-white p-3 rounded hover:bg-blue-600 transition">SAVE</button>
+    <div class="flex gap-3 justify-end pt-2">
+      <button type="button" class="btn-secondary" onclick="window.history.back()">Cancel</button>
+      <button type="submit" class="btn-primary">Save Changes</button>
+    </div>
   </form>
 </div>
 <script>

--- a/web/html/edit_topic.html
+++ b/web/html/edit_topic.html
@@ -1,19 +1,22 @@
-<div class="container mx-auto bg-white shadow-md rounded p-6 mt-4">
-  <h1 class="text-2xl font-semibold mb-4">Editing topic</h1>
-  <form hx-patch="/update-topic?id={{.ID}}">
-    <div class="mb-4">
-      <label for="name" class="block text-gray-700 font-medium mb-2">Topic Title</label>
-      <input type="text" id="name" name="name" class="w-full p-3 border border-gray-300 rounded" value="{{ getName . "en" }}">
+<div class="max-w-2xl mx-auto card card-pad mt-6">
+  <h1 class="page-title mb-4">Edit Topic</h1>
+  <form hx-patch="/update-topic?id={{.ID}}" class="space-y-4">
+    <div>
+      <label class="form-label" for="name">Topic Title</label>
+      <input type="text" id="name" name="name" class="form-input" value="{{ getName . "en" }}">
     </div>
-    <div class="mb-4">
-      <label for="description" class="block text-gray-700 font-medium mb-2">Description</label>
-      <textarea id="description" name="description" class="w-full p-3 border border-gray-300 rounded"
+    <div>
+      <label class="form-label" for="description">Description</label>
+      <textarea id="description" name="description" rows="4" class="form-input"
         placeholder="Enter topic description..."></textarea>
     </div>
-    <div class="mb-4">
-      <label for="code" class="block text-gray-700 font-medium mb-2">Topic Code</label>
-      <input type="text" id="code" name="code" class="w-full p-3 border border-gray-300 rounded" value="{{.Code}}">
+    <div>
+      <label class="form-label" for="code">Topic Code</label>
+      <input type="text" id="code" name="code" class="form-input font-mono" value="{{.Code}}">
     </div>
-    <button type="submit" class="w-full bg-blue-500 text-white p-3 rounded hover:bg-blue-600 transition">SAVE</button>
+    <div class="flex gap-3 justify-end pt-2">
+      <button type="button" class="btn-secondary" onclick="window.history.back()">Cancel</button>
+      <button type="submit" class="btn-primary">Save Changes</button>
+    </div>
   </form>
 </div>

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -2,12 +2,12 @@
 <div class="container flex gap-4 items-stretch max-w-full -mt-px">
 
     <!-- Editor Container -->
-    <div class="editor-wrapper w-1/2 border border-gray-300">
+    <div class="editor-wrapper w-1/2 border border-border">
 
         <!-- Toolbar with icons -->
-        <div class="toolbar bg-gray-100 border-b border-gray-300 flex flex-wrap gap-2 p-2">
+        <div class="toolbar bg-bg-card-alt border-b border-border flex flex-wrap gap-2 p-2">
             <select title="Font Family"
-                class="fontSelector border border-gray-300 rounded px-2 py-1 text-sm cursor-pointer">
+                class="fontSelector border border-border rounded px-2 py-1 text-sm cursor-pointer">
                 <option value="Arial" style="font-family: Arial;">Arial</option>
                 <option value="'Courier New', monospace" style="font-family: 'Courier New', monospace;">Courier New
                 </option>
@@ -17,21 +17,21 @@
             </select>
 
             <!-- Bold/Italic/Underline grouped buttons -->
-            <div class="flex gap-0 border border-gray-300 rounded overflow-hidden">
+            <div class="flex gap-0 border border-border rounded overflow-hidden">
                 <button title="Bold" type="button"
-                    class="boldBtn px-3 py-1 text-sm bg-white hover:bg-blue-100 border-r border-gray-300"><i
+                    class="boldBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg border-r border-border"><i
                         class="fas fa-bold"></i></button>
                 <button title="Italic" type="button"
-                    class="italicBtn px-3 py-1 text-sm bg-white hover:bg-blue-100 border-r border-gray-300"><i
+                    class="italicBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg border-r border-border"><i
                         class="fas fa-italic"></i></button>
                 <button title="Underline" type="button"
-                    class="underlineBtn px-3 py-1 text-sm bg-white hover:bg-blue-100"><i
+                    class="underlineBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg"><i
                         class="fas fa-underline"></i></button>
             </div>
 
             <!-- Font Size Selector -->
             <select title="Font Size"
-                class="fontSizeSelector border border-gray-300 rounded px-2 py-1 text-sm cursor-pointer">
+                class="fontSizeSelector border border-border rounded px-2 py-1 text-sm cursor-pointer">
                 <option value="8px">8</option>
                 <option value="9px">9</option>
                 <option value="10px">10</option>
@@ -44,29 +44,29 @@
             </select>
 
             <!-- Color Pickers with Icons -->
-            <div class="flex items-center border border-gray-300 rounded overflow-hidden">
+            <div class="flex items-center border border-border rounded overflow-hidden">
                 <!-- Foreground/Text Color -->
                 <label title="Text Color"
-                    class="foreColorLabel flex items-center justify-center w-8 h-8 border-r border-gray-300 bg-white hover:bg-blue-100 cursor-pointer">
-                    <i class="fas fa-font text-black"></i>
+                    class="foreColorLabel flex items-center justify-center w-8 h-8 border-r border-border bg-bg-card hover:bg-brand-blue-bg cursor-pointer">
+                    <i class="fas fa-font text-ink"></i>
                     <input type="color" class="foreColor hidden" />
                 </label>
 
                 <!-- Background Color -->
                 <label title="Background Color"
-                    class="backColorLabel flex items-center justify-center w-8 h-8 bg-white hover:bg-blue-100 cursor-pointer">
-                    <i class="fas fa-fill-drip text-black"></i>
+                    class="backColorLabel flex items-center justify-center w-8 h-8 bg-bg-card hover:bg-brand-blue-bg cursor-pointer">
+                    <i class="fas fa-fill-drip text-ink"></i>
                     <input type="color" class="backColor hidden" />
                 </label>
             </div>
 
             <!-- Ordered and Unordered List Buttons -->
-            <div class="flex gap-0 border border-gray-300 rounded overflow-hidden">
+            <div class="flex gap-0 border border-border rounded overflow-hidden">
                 <button title="Unordered List" type="button"
-                    class="ulBtn px-3 py-1 text-sm bg-white hover:bg-blue-100 border-r border-gray-300">
+                    class="ulBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg border-r border-border">
                     <i class="fas fa-list-ul"></i>
                 </button>
-                <button title="Ordered List" type="button" class="olBtn px-3 py-1 text-sm bg-white hover:bg-blue-100">
+                <button title="Ordered List" type="button" class="olBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg">
                     <i class="fas fa-list-ol"></i>
                 </button>
             </div>
@@ -74,43 +74,43 @@
             <!-- Paragraph Formatting Dropdown -->
             <div class="relative flex-shrink-0">
                 <button title="Alignment" type="button"
-                    class="paragraphDropdownBtn px-3 py-1 text-sm bg-white hover:bg-blue-100 border border-gray-300 rounded h-full flex items-center justify-center">
+                    class="paragraphDropdownBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg border border-border rounded h-full flex items-center justify-center">
                     <i class="fas fa-align-left"></i>
                     <i class="fas fa-caret-down text-xs ml-1"></i>
                 </button>
 
                 <!-- Dropdown: 3x2 Grid of Icon Buttons -->
                 <div
-                    class="paragraphDropdownMenu absolute mt-1 hidden bg-white border border-gray-300 rounded shadow-md p-2 grid grid-cols-3 gap-2 w-32">
+                    class="paragraphDropdownMenu absolute mt-1 hidden bg-bg-card border border-border rounded shadow-card p-2 grid grid-cols-3 gap-2 w-32">
                     <button data-cmd="justifyLeft" type="button"
-                        class="w-8 h-8 flex items-center justify-center hover:bg-blue-100 rounded" title="Align Left">
+                        class="w-8 h-8 flex items-center justify-center hover:bg-brand-blue-bg rounded" title="Align Left">
                         <i class="fas fa-align-left"></i>
                     </button>
                     <button data-cmd="justifyCenter" type="button"
-                        class="w-8 h-8 flex items-center justify-center hover:bg-blue-100 rounded" title="Align Center">
+                        class="w-8 h-8 flex items-center justify-center hover:bg-brand-blue-bg rounded" title="Align Center">
                         <i class="fas fa-align-center"></i>
                     </button>
                     <button data-cmd="justifyRight" type="button"
-                        class="w-8 h-8 flex items-center justify-center hover:bg-blue-100 rounded" title="Align Right">
+                        class="w-8 h-8 flex items-center justify-center hover:bg-brand-blue-bg rounded" title="Align Right">
                         <i class="fas fa-align-right"></i>
                     </button>
                     <button data-cmd="justifyFull" type="button"
-                        class="w-8 h-8 flex items-center justify-center hover:bg-blue-100 rounded" title="Justify">
+                        class="w-8 h-8 flex items-center justify-center hover:bg-brand-blue-bg rounded" title="Justify">
                         <i class="fas fa-align-justify"></i>
                     </button>
                     <button data-cmd="outdent" type="button"
-                        class="w-8 h-8 flex items-center justify-center hover:bg-blue-100 rounded" title="Outdent">
+                        class="w-8 h-8 flex items-center justify-center hover:bg-brand-blue-bg rounded" title="Outdent">
                         <i class="fas fa-indent fa-rotate-180"></i>
                     </button>
                     <button data-cmd="indent" type="button"
-                        class="w-8 h-8 flex items-center justify-center hover:bg-blue-100 rounded" title="Indent">
+                        class="w-8 h-8 flex items-center justify-center hover:bg-brand-blue-bg rounded" title="Indent">
                         <i class="fas fa-indent"></i>
                     </button>
                 </div>
             </div>
 
             <select title="Line Height"
-                class="lineHeightSelector border border-gray-300 rounded px-2 py-1 text-sm cursor-pointer">
+                class="lineHeightSelector border border-border rounded px-2 py-1 text-sm cursor-pointer">
                 <option value="1">1</option>
                 <option value="1.2">1.2</option>
                 <option value="1.5" selected>1.5</option>
@@ -121,51 +121,51 @@
             <!-- Insert Table Button + Grid Popup -->
             <div class="relative">
                 <button title="Table" type="button"
-                    class="insertTableBtn bg-white border border-gray-300 rounded px-3 py-1 text-sm hover:bg-blue-100 h-full">
+                    class="insertTableBtn bg-bg-card border border-border rounded px-3 py-1 text-sm hover:bg-brand-blue-bg h-full">
                     <i class="fas fa-table"></i>
                 </button>
 
                 <!-- Table Grid Picker -->
                 <div
-                    class="tableGridPopup absolute left-0 mt-1 p-2 border border-gray-300 bg-white shadow-md rounded hidden z-50 w-max">
+                    class="tableGridPopup absolute left-0 mt-1 p-2 border border-border bg-bg-card shadow-card rounded hidden z-50 w-max">
                     <div class="tableGrid grid grid-cols-10 gap-1"></div>
-                    <div class="tableGridLabel text-xs text-center mt-2 text-gray-600">0 × 0</div>
+                    <div class="tableGridLabel text-xs text-center mt-2 text-ink-muted">0 × 0</div>
                 </div>
             </div>
 
             <button title="Link" type="button"
-                class="linkBtn bg-white border border-gray-300 rounded px-3 py-1 text-sm hover:bg-blue-100">
+                class="linkBtn bg-bg-card border border-border rounded px-3 py-1 text-sm hover:bg-brand-blue-bg">
                 <i class="fas fa-link"></i>
             </button>
 
             <button title="Horizontal Rule" type="button"
-                class="hrBtn bg-white border border-gray-300 rounded px-3 py-1 text-sm hover:bg-blue-100">
+                class="hrBtn bg-bg-card border border-border rounded px-3 py-1 text-sm hover:bg-brand-blue-bg">
                 <i class="fas fa-minus"></i>
             </button>
 
             <input type="file" accept="image/*" class="imageUpload hidden">
             <button title="Image" type="button"
-                class="imageBtn bg-white border border-gray-300 rounded px-3 py-1 text-sm hover:bg-blue-100"><i
+                class="imageBtn bg-bg-card border border-border rounded px-3 py-1 text-sm hover:bg-brand-blue-bg"><i
                     class="fas fa-image"></i></button>
 
-            <div class="flex gap-0 border border-gray-300 rounded overflow-hidden">
+            <div class="flex gap-0 border border-border rounded overflow-hidden">
                 <button title="Toggle Fullscreen" type="button"
-                    class="fullscreenBtn bg-white border-r border-gray-300 px-3 py-1 text-sm hover:bg-blue-100">
+                    class="fullscreenBtn bg-bg-card border-r border-border px-3 py-1 text-sm hover:bg-brand-blue-bg">
                     <i class="fas fa-expand-arrows-alt"></i>
                 </button>
 
                 <button title="Toggle Code View" type="button"
-                    class="codeViewBtn bg-white px-3 py-1 text-sm hover:bg-blue-100">
+                    class="codeViewBtn bg-bg-card px-3 py-1 text-sm hover:bg-brand-blue-bg">
                     <i class="fas fa-code"></i>
                 </button>
             </div>
 
             <button title="Math" type="button"
-                class="mathBtn bg-white border border-gray-300 rounded px-3 py-1 text-sm hover:bg-blue-100"><i
+                class="mathBtn bg-bg-card border border-border rounded px-3 py-1 text-sm hover:bg-brand-blue-bg"><i
                     class="fas fa-square-root-variable"></i></button>
 
             <button title="Toggle Preview" type="button"
-                class="previewToggleBtn bg-white border border-gray-300 rounded px-3 py-1 text-sm hover:bg-blue-100">
+                class="previewToggleBtn bg-bg-card border border-border rounded px-3 py-1 text-sm hover:bg-brand-blue-bg">
                 <i class="fas fa-eye"></i>
             </button>
 
@@ -175,11 +175,11 @@
         </div>
 
         <pre contenteditable="true"
-            class="codeView whitespace-pre-wrap text-sm p-2 h-52 bg-gray-100 border border-gray-300 rounded overflow-y-auto hidden"></pre>
+            class="codeView whitespace-pre-wrap text-sm p-2 h-52 bg-bg-card-alt border border-border rounded overflow-y-auto hidden"></pre>
 
     </div>
 
-    <div class="output w-1/2 self-end bg-gray-100 border border-gray-300 p-2 h-52 overflow-y-auto">
+    <div class="output w-1/2 self-end bg-bg-card-alt border border-border p-2 h-52 overflow-y-auto">
     </div>
 </div>
 

--- a/web/html/home.html
+++ b/web/html/home.html
@@ -5,6 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Avanti Next Generation CMS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <!-- For tailwind css library -->
     <link href="/web/static/css/output.css" rel="stylesheet">
@@ -61,59 +64,68 @@
     </script>
 </head>
 
-<body hx-ext="mathJaxLoader">
+<body class="bg-bg text-ink min-h-screen" hx-ext="mathJaxLoader">
     <script src="/web/static/js/nav-tracker.js"></script>
     <div>
-        <nav>
-            <div class="nav nav-tabs flex" id="nav-tab">
-                <button class="nav-link" id="chapters-tab" hx-get="/chapters" hx-push-url="true" hx-target="body"
-                    data-toggle="tab"
-                    hx-on::before-request="sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false')">Chapters</button>
-                <button class="nav-link" id="tests-tab" hx-get="/tests" hx-push-url="true" hx-target="body"
-                    data-toggle="tab"
-                    hx-on::before-request="sessionStorage.setItem(window.TESTS_VIEW_LOADED_KEY, 'false')">Tests</button>
-                <button class="nav-link" id="problems-tab" hx-get="/problems" hx-push-url="true" hx-target="body"
-                    data-toggle="tab">Problems</button>
-                <button class="nav-link hidden" id="admin-tab" hx-get="/admin/users" hx-push-url="true" hx-target="body"
-                    data-toggle="tab">Admin</button>
+        <header class="bg-bg-card border-b border-border shadow-card">
+            <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8">
+                <nav>
+                    <div class="nav nav-tabs flex flex-wrap items-center gap-y-2 border-b-0" id="nav-tab">
+                        <a href="/chapters" class="shrink-0 mr-4 sm:mr-6 flex items-center" aria-label="Avanti Fellows">
+                            <img src="https://cdn.avantifellows.org/af_logos/avanti_logo_black_text.webp"
+                                 alt="Avanti Fellows" class="h-8 sm:h-9">
+                        </a>
 
-                <!-- name attribute is used, because query parameters passed via http request can be 
-                 identified by element names only. It is used in chapter_handler.go -->
-                <select class="ms-8" id="curriculum-dropdown" name="curriculum-dropdown" hx-get="/api/curriculums"
-                    hx-trigger="load" hx-on::after-request="afterDropdownReq(this, 
-                    {{ if .CurriculumID }}{{ .CurriculumID }}{{ else }}null{{ end }})"
-                    onchange="sessionStorage.setItem('selectedCurriculum', this.value); sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false'); sessionStorage.setItem(window.TESTS_VIEW_LOADED_KEY, 'false');">
-                    <!-- HTMX will replace this with the new options -->
-                    <option value="" disabled selected>Loading curriculums...</option>
-                </select>
-                <select class="ms-4" id="grade-dropdown" name="grade-dropdown" hx-get="/api/grades" hx-trigger="load"
-                    hx-on::after-request="afterDropdownReq(this, 
-                    {{ if .GradeID }}{{ .GradeID }}{{ else }}null{{ end }})"
-                    onchange="sessionStorage.setItem('selectedGrade', this.value); sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false'); sessionStorage.setItem(window.TESTS_VIEW_LOADED_KEY, 'false');">
-                    <!-- HTMX will replace this with the new options -->
-                    <option value="" disabled selected>Loading grades...</option>
-                </select>
-                <select class="ms-4" id="subject-dropdown" name="subject-dropdown" hx-get="/api/subjects"
-                    hx-trigger="load"
-                    hx-on::after-request="afterDropdownReq(this, {{ if .SubjectID }}{{ .SubjectID }}{{ else }}null{{ end }})"
-                    onchange="sessionStorage.setItem('selectedSubject', this.value); sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false');">
-                    <!-- HTMX will replace this with the new options -->
-                    <option value="" disabled selected>Loading subjects...</option>
-                </select>
+                        <button class="nav-link" id="chapters-tab" hx-get="/chapters" hx-push-url="true" hx-target="body"
+                            data-toggle="tab"
+                            hx-on::before-request="sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false')">Chapters</button>
+                        <button class="nav-link" id="tests-tab" hx-get="/tests" hx-push-url="true" hx-target="body"
+                            data-toggle="tab"
+                            hx-on::before-request="sessionStorage.setItem(window.TESTS_VIEW_LOADED_KEY, 'false')">Tests</button>
+                        <button class="nav-link" id="problems-tab" hx-get="/problems" hx-push-url="true" hx-target="body"
+                            data-toggle="tab">Problems</button>
+                        <button class="nav-link hidden" id="admin-tab" hx-get="/admin/users" hx-push-url="true" hx-target="body"
+                            data-toggle="tab">Admin</button>
 
-                <!-- Logout button at far right -->
-                <button hx-post="/logout"
-                    class="text-sm font-semibold px-3 py-1 ms-auto me-2 my-1 rounded bg-blue-500 text-white hover:bg-blue-600">
-                    Logout
-                </button>
+                        <!-- name attribute is used, because query parameters passed via http request can be
+                         identified by element names only. It is used in chapter_handler.go -->
+                        <select class="form-select-compact ms-4 sm:ms-6 w-auto" id="curriculum-dropdown" name="curriculum-dropdown" hx-get="/api/curriculums"
+                            hx-trigger="load" hx-on::after-request="afterDropdownReq(this,
+                            {{ if .CurriculumID }}{{ .CurriculumID }}{{ else }}null{{ end }})"
+                            onchange="sessionStorage.setItem('selectedCurriculum', this.value); sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false'); sessionStorage.setItem(window.TESTS_VIEW_LOADED_KEY, 'false');">
+                            <!-- HTMX will replace this with the new options -->
+                            <option value="" disabled selected>Loading curriculums...</option>
+                        </select>
+                        <select class="form-select-compact ms-3 w-auto" id="grade-dropdown" name="grade-dropdown" hx-get="/api/grades" hx-trigger="load"
+                            hx-on::after-request="afterDropdownReq(this,
+                            {{ if .GradeID }}{{ .GradeID }}{{ else }}null{{ end }})"
+                            onchange="sessionStorage.setItem('selectedGrade', this.value); sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false'); sessionStorage.setItem(window.TESTS_VIEW_LOADED_KEY, 'false');">
+                            <!-- HTMX will replace this with the new options -->
+                            <option value="" disabled selected>Loading grades...</option>
+                        </select>
+                        <select class="form-select-compact ms-3 w-auto" id="subject-dropdown" name="subject-dropdown" hx-get="/api/subjects"
+                            hx-trigger="load"
+                            hx-on::after-request="afterDropdownReq(this, {{ if .SubjectID }}{{ .SubjectID }}{{ else }}null{{ end }})"
+                            onchange="sessionStorage.setItem('selectedSubject', this.value); sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false');">
+                            <!-- HTMX will replace this with the new options -->
+                            <option value="" disabled selected>Loading subjects...</option>
+                        </select>
+
+                        <!-- Logout button at far right -->
+                        <button hx-post="/logout"
+                            class="btn-secondary btn-sm ms-auto my-2">
+                            Sign out
+                        </button>
+                    </div>
+                </nav>
             </div>
-        </nav>
+        </header>
 
-        <div class="m-7" id="nav-tabContent">
+        <main class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8 py-6" id="nav-tabContent">
             <div id="content">
-                {{ block "content" . }}<p>Select a tab to load content.</p>{{ end }}
+                {{ block "content" . }}<p class="text-ink-muted">Select a tab to load content.</p>{{ end }}
             </div>
-        </div>
+        </main>
     </div>
 
     <!-- Modules (type="module") are scoped, meaning functions are not global by default.
@@ -203,12 +215,12 @@
 
                         if (allowDropdownChanges) {
                             // Unfreeze
-                            el.classList.remove("bg-gray-100", "cursor-not-allowed");
+                            el.classList.remove("bg-bg-card-alt", "cursor-not-allowed");
                             el.style.pointerEvents = "";
                             el.removeAttribute("tabindex");
                         } else {
                             // Freeze
-                            el.classList.add("bg-gray-100", "cursor-not-allowed");
+                            el.classList.add("bg-bg-card-alt", "cursor-not-allowed");
                             el.style.pointerEvents = "none";
                             el.setAttribute("tabindex", "-1");
                         }
@@ -318,8 +330,8 @@
 
             const toast = document.createElement("div");
             toast.className = `
-                px-4 py-2 rounded shadow-md text-white text-sm
-                ${type === "error" ? "bg-red-500" : "bg-green-500"}
+                px-4 py-2 rounded-lg shadow-card text-text-on-accent text-sm font-medium
+                ${type === "error" ? "bg-danger" : "bg-success"}
             `;
             toast.innerText = message;
 

--- a/web/html/input_tags.html
+++ b/web/html/input_tags.html
@@ -8,7 +8,7 @@
     </div>
     <!-- Autocomplete dropdown -->
     <div id="tagAutocomplete"
-        class="absolute top-full left-0 right-0 bg-white border border-gray-300 border-t-0 rounded-b-md shadow-lg max-h-40 overflow-y-auto z-10">
+        class="absolute top-full left-0 right-0 bg-bg-card border border-border border-t-0 rounded-b-md shadow-lg max-h-40 overflow-y-auto z-10">
         <!-- suggestions will be inserted here -->
     </div>
 </div>
@@ -71,10 +71,10 @@
 
             tags.forEach(tag => {
                 const chip = document.createElement('span');
-                chip.className = 'chip bg-blue-100 text-blue-800 text-sm px-2 py-1 rounded-full flex items-center gap-1';
+                chip.className = 'chip bg-brand-blue-bg text-accent-hover text-sm px-2 py-1 rounded-full flex items-center gap-1';
                 chip.innerHTML = `
                     ${tag}
-                    <button type="button" class="ml-1 text-blue-800 hover:text-blue-900 font-bold">&times;</button>
+                    <button type="button" class="ml-1 text-accent-hover hover:text-accent-hover font-bold">&times;</button>
                 `;
                 chip.querySelector('button').addEventListener('click', () => removeTag(tag));
                 container.insertBefore(chip, input);

--- a/web/html/login.html
+++ b/web/html/login.html
@@ -4,44 +4,51 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login - Avanti CMS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <link href="/web/static/css/output.css" rel="stylesheet">
 </head>
-<body class="flex items-center justify-center h-screen bg-gray-100">
-    <div class="bg-white p-8 rounded shadow-md w-96">
-        <h1 class="text-2xl font-bold mb-6 text-center">Avanti CMS</h1>
+<body class="flex items-center justify-center min-h-screen bg-bg text-ink px-4">
+    <div class="card card-pad w-full max-w-md">
+        <div class="flex flex-col items-center mb-6">
+            <img src="https://cdn.avantifellows.org/af_logos/avanti_logo_black_text.webp"
+                 alt="Avanti Fellows" class="h-10 mb-4">
+            <h1 class="page-title">Avanti CMS</h1>
+            <p class="mt-2 text-sm text-ink-muted">Sign in to continue</p>
+        </div>
 
         {{ if .Error }}
-        <div class="mb-4 px-3 py-2 rounded bg-red-50 text-red-700 text-sm text-center">{{ .Error }}</div>
+        <div class="mb-4 px-3 py-2 rounded-lg bg-danger-bg text-danger text-sm text-center font-medium">{{ .Error }}</div>
         {{ end }}
 
         {{ if .GoogleConfigured }}
         <a href="/auth/google/start"
-           class="flex items-center justify-center gap-2 w-full border border-gray-300 hover:bg-gray-50 py-2 rounded text-gray-700 font-medium">
+           class="btn-secondary w-full">
             <svg viewBox="0 0 48 48" class="h-5 w-5">
                 <path fill="#FFC107" d="M43.6 20.5H42V20H24v8h11.3c-1.6 4.7-6.1 8-11.3 8-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.9 1.2 8 3.1l5.7-5.7C34 6.1 29.3 4 24 4 12.9 4 4 12.9 4 24s8.9 20 20 20 20-8.9 20-20c0-1.2-.1-2.3-.4-3.5z"/>
                 <path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.7 16.1 19 13 24 13c3.1 0 5.9 1.2 8 3.1l5.7-5.7C34 6.1 29.3 4 24 4 16.2 4 9.5 8.5 6.3 14.7z"/>
                 <path fill="#4CAF50" d="M24 44c5.2 0 9.9-2 13.5-5.2l-6.2-5.3c-2.1 1.6-4.8 2.5-7.3 2.5-5.2 0-9.6-3.3-11.2-8l-6.5 5C9.4 39.4 16.1 44 24 44z"/>
                 <path fill="#1976D2" d="M43.6 20.5H42V20H24v8h11.3c-.8 2.3-2.3 4.3-4.3 5.6l6.2 5.3C40.7 35.4 44 30.2 44 24c0-1.2-.1-2.3-.4-3.5z"/>
             </svg>
-            Sign in with Google
+            <span>Sign in with Google</span>
         </a>
 
-        <p class="mt-4 text-xs text-gray-500 text-center">
+        <p class="mt-4 text-xs text-ink-muted text-center">
             Use your @avantifellows.org account. Access must be granted by an admin.
         </p>
         {{ else }}
-        <p class="px-3 py-2 rounded bg-yellow-50 text-yellow-800 text-sm text-center">
+        <p class="px-3 py-2 rounded-lg bg-warning-bg text-warning border border-warning-border text-sm text-center">
             Google sign-in not configured. Use dev login below.
         </p>
         {{ end }}
 
         {{ if .DevLoginEmail }}
-        <div class="mt-6 pt-4 border-t border-gray-200">
-            <p class="text-xs text-gray-500 text-center mb-2">Dev login (local only):</p>
-            <button hx-post="/dev-login"
-                    class="w-full bg-gray-200 hover:bg-gray-300 text-gray-700 py-2 rounded text-sm">
-                Sign in as {{ .DevLoginEmail }}
+        <div class="mt-6 pt-4 border-t border-border">
+            <p class="text-xs text-ink-muted text-center mb-2">Dev login (local only):</p>
+            <button hx-post="/dev-login" class="btn-secondary w-full">
+                Sign in as <span class="font-mono ms-1">{{ .DevLoginEmail }}</span>
             </button>
         </div>
         {{ end }}

--- a/web/html/move_problems_modal.html
+++ b/web/html/move_problems_modal.html
@@ -1,9 +1,9 @@
 <div id="move-problems-modal" data-problem-ids='{{.}}'
-    class="fixed inset-0 bg-gray-800 bg-opacity-50 flex justify-center items-center z-50">
-    <div class="bg-white p-6 rounded shadow-md w-full max-w-3xl">
+    class="fixed inset-0 bg-ink/40 flex justify-center items-center z-50 p-4">
+    <div class="card shadow-xl rounded-xl p-6 w-full max-w-3xl max-h-[90vh] overflow-y-auto">
 
-        <h2 class="text-lg font-semibold mb-2">Move Problems</h2>
-        <p class="text-sm text-gray-600 mb-6">
+        <h2 class="page-title mb-2">Move Problems</h2>
+        <p class="text-sm text-ink-muted mb-6">
             Select Curriculum, Grade & Subject in any order. Then select Chapter, and finally Topic.
         </p>
 
@@ -16,7 +16,7 @@
 
                 <!-- Curriculum -->
                 <select id="curriculum-dropdown" name="curriculum-dropdown" 
-                        class="border p-2 rounded w-full" hx-get="/api/curriculums"
+                        class="form-select" hx-get="/api/curriculums"
                         hx-trigger="load" hx-target="this" hx-swap="innerHTML"
                         hx-on::after-request="afterMoveProblemsDropdownReq(this)">
                     <option disabled selected>Loading curriculums...</option>
@@ -24,7 +24,7 @@
 
                 <!-- Grade -->
                 <select id="grade-dropdown" name="grade-dropdown" 
-                        class="border p-2 rounded w-full" hx-get="/api/grades"
+                        class="form-select" hx-get="/api/grades"
                         hx-trigger="load" hx-target="this" hx-swap="innerHTML"
                         hx-on::after-request="afterMoveProblemsDropdownReq(this)">
                     <option disabled selected>Loading grades...</option>
@@ -32,7 +32,7 @@
 
                 <!-- Subject -->
                 <select id="subject-dropdown" name="subject-dropdown" 
-                        class="border p-2 rounded w-full" hx-get="/api/subjects"
+                        class="form-select" hx-get="/api/subjects"
                         hx-trigger="load" hx-target="this" hx-swap="innerHTML"
                         hx-on::after-request="afterMoveProblemsDropdownReq(this)">
                     <option disabled selected>Loading subjects...</option>
@@ -40,7 +40,7 @@
 
                 <!-- Chapter -->
                 <select id="chapter-dropdown" name="chapter-dropdown" 
-                        class="border p-2 rounded w-full" hx-get="/api/chapters"
+                        class="form-select" hx-get="/api/chapters"
                         hx-target="this" hx-swap="innerHTML"
                         hx-trigger="loadChapters, change from:(#move-problems-modal #curriculum-dropdown, #move-problems-modal #grade-dropdown, #move-problems-modal #subject-dropdown)"
                         hx-include="#move-problems-modal #curriculum-dropdown, #move-problems-modal #grade-dropdown, #move-problems-modal #subject-dropdown"
@@ -50,7 +50,7 @@
                 </select>
 
                 <!-- Topic -->
-                <select id="topic-dropdown" name="topic_id" class="border p-2 rounded w-full"
+                <select id="topic-dropdown" name="topic_id" class="form-select"
                         hx-get="/api/topics?view=dropdown" hx-trigger="change from:#chapter-dropdown"
                         hx-target="this" hx-swap="innerHTML" onchange="toggleMoveButton()" 
                         hx-include="#chapter-dropdown" hx-on::after-swap="toggleMoveButton()"
@@ -62,21 +62,17 @@
             </div>
 
             <!-- Buttons -->
-            <div class="w-full flex justify-end space-x-2 pt-4">
-                <button type="button" onclick="closeMoveProblemsModal()" 
-                    class="bg-gray-300 px-4 py-2 rounded hover:bg-gray-400 transition">
+            <div class="flex justify-end gap-3 pt-4 border-t border-border">
+                <button type="button" onclick="closeMoveProblemsModal()" class="btn-secondary">
                     Cancel
                 </button>
 
                 <button id="move-problems-btn" type="submit" disabled
-                    class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition disabled:bg-gray-300 disabled:cursor-not-allowed">
-                    
+                    class="btn-primary disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-bg-card-alt disabled:text-ink-muted">
                     <!-- Normal text -->
                     <span class="btn-text">Move</span>
-
                     <!-- Loader -->
-                    <span class="btn-loader hidden">Moving...</span>
-
+                    <span class="btn-loader hidden">Moving…</span>
                 </button>
             </div>
 

--- a/web/html/move_resources_modal.html
+++ b/web/html/move_resources_modal.html
@@ -1,8 +1,8 @@
 <div id="move-resources-modal" data-resource-ids='{{.}}'
-    class="fixed inset-0 bg-gray-800 bg-opacity-50 flex justify-center items-center z-50">
-    <div class="bg-white p-6 rounded shadow-md w-full max-w-3xl">
-        <h2 class="text-lg font-semibold mb-2">Move Resource</h2>
-        <p class="text-sm text-gray-600 mb-6">
+    class="fixed inset-0 bg-ink/40 flex justify-center items-center z-50 p-4">
+    <div class="card shadow-xl rounded-xl p-6 w-full max-w-3xl max-h-[90vh] overflow-y-auto">
+        <h2 class="page-title mb-2">Move Resource</h2>
+        <p class="text-sm text-ink-muted mb-6">
             Select Curriculum, Grade and Subject in any order. Then select Chapter. Topic is optional.
         </p>
 
@@ -12,25 +12,25 @@
             hx-disabled-elt="#move-resources-modal button">
 
             <div class="grid grid-cols-3 gap-4">
-                <select id="curriculum-dropdown" name="curriculum-dropdown" class="border p-2 rounded w-full"
+                <select id="curriculum-dropdown" name="curriculum-dropdown" class="form-select"
                     hx-get="/api/curriculums" hx-trigger="load" hx-target="this" hx-swap="innerHTML"
                     hx-on::after-request="afterMoveResourcesDropdownReq(this)">
                     <option disabled selected>Loading curriculums...</option>
                 </select>
 
-                <select id="grade-dropdown" name="grade-dropdown" class="border p-2 rounded w-full"
+                <select id="grade-dropdown" name="grade-dropdown" class="form-select"
                     hx-get="/api/grades" hx-trigger="load" hx-target="this" hx-swap="innerHTML"
                     hx-on::after-request="afterMoveResourcesDropdownReq(this)">
                     <option disabled selected>Loading grades...</option>
                 </select>
 
-                <select id="subject-dropdown" name="subject-dropdown" class="border p-2 rounded w-full"
+                <select id="subject-dropdown" name="subject-dropdown" class="form-select"
                     hx-get="/api/subjects" hx-trigger="load" hx-target="this" hx-swap="innerHTML"
                     hx-on::after-request="afterMoveResourcesDropdownReq(this)">
                     <option disabled selected>Loading subjects...</option>
                 </select>
 
-                <select id="chapter-dropdown" name="chapter-dropdown" class="border p-2 rounded w-full"
+                <select id="chapter-dropdown" name="chapter-dropdown" class="form-select"
                     hx-get="/api/chapters" hx-target="this" hx-swap="innerHTML"
                     hx-trigger="loadChapters, change from:(#move-resources-modal #curriculum-dropdown, #move-resources-modal #grade-dropdown, #move-resources-modal #subject-dropdown)"
                     hx-include="#move-resources-modal #curriculum-dropdown, #move-resources-modal #grade-dropdown, #move-resources-modal #subject-dropdown"
@@ -39,7 +39,7 @@
                     <option disabled selected>Loading chapters...</option>
                 </select>
 
-                <select id="topic-dropdown" name="topic_id" class="border p-2 rounded w-full"
+                <select id="topic-dropdown" name="topic_id" class="form-select"
                     hx-get="/api/topics?view=dropdown-optional" hx-trigger="change from:#chapter-dropdown"
                     hx-target="this" hx-swap="innerHTML" hx-include="#chapter-dropdown"
                     hx-on::before-request="beforeMoveResourcesTopicsRequest()" hx-on::after-request="toggleMoveResourceButton()">
@@ -47,16 +47,15 @@
                 </select>
             </div>
 
-            <div class="w-full flex justify-end space-x-2 pt-4">
-                <button type="button" onclick="closeMoveResourcesModal()"
-                    class="bg-gray-300 px-4 py-2 rounded hover:bg-gray-400 transition">
+            <div class="flex justify-end gap-3 pt-4 border-t border-border">
+                <button type="button" onclick="closeMoveResourcesModal()" class="btn-secondary">
                     Cancel
                 </button>
 
                 <button id="move-resource-btn" type="submit" disabled
-                    class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition disabled:bg-gray-300 disabled:cursor-not-allowed">
+                    class="btn-primary disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-bg-card-alt disabled:text-ink-muted">
                     <span class="btn-text">Move</span>
-                    <span class="btn-loader hidden">Moving...</span>
+                    <span class="btn-loader hidden">Moving…</span>
                 </button>
             </div>
         </form>

--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -1,66 +1,56 @@
 {{ define "content" }}
 <div>
-    <div class="flex items-center">
-        <button class="action-button" onclick="window.history.back()">
+    <div class="flex items-center mb-4">
+        <button class="btn-ghost btn-sm" onclick="window.history.back()">
             <i class="fa-solid fa-chevron-left"></i> Back
         </button>
-        <h3 class="text-base font-semibold ml-4">{{.ProblemPtr.Code}}</h3>
+        <h3 class="ml-4 text-lg font-bold uppercase tracking-wide text-ink font-mono">{{.ProblemPtr.Code}}</h3>
         <div class="flex space-x-4 ml-auto pr-4">
-            <button class="action-button" 
+            <button class="action-button"
                 hx-get="/problems/edit-problem?id={{.ProblemPtr.ID}}&curriculum_id={{.ProblemPtr.CurriculumID}}&topic_id={{.ProblemPtr.TopicID}}"
-                hx-target="body" hx-push-url="true">
-                <i class="fa-solid fa-pen">
-                </i></button>
+                hx-target="body" hx-push-url="true" title="Edit problem">
+                <i class="fa-solid fa-pen"></i>
+            </button>
             <button class="action-button" hx-delete="/archive-problem?id={{.ProblemPtr.ID}}" hx-ext="goBackAfter"
-                hx-confirm="Are you sure you want to delete problem?">
-                <i class="fa-solid fa-trash">
-                </i></button>
+                hx-confirm="Are you sure you want to delete problem?" title="Delete problem">
+                <i class="fa-solid fa-trash"></i>
+            </button>
         </div>
     </div>
-    <div class="bg-white p-6 rounded-lg shadow-md" data-mathjax="true">
-        <h2 class="text-lg font-semibold">
-            STATEMENT/TEXT
-        </h2>
-        <p class="mt-2">
+    <div class="card card-pad" data-mathjax="true">
+        <h2 class="section-title">Statement / Text</h2>
+        <p class="mt-2 text-ink">
             {{.ProblemPtr.MetaData.Question}}
         </p>
         {{ if .ProblemPtr.Concepts }}
-        <h2 class="text-lg font-semibold mt-4">
-            CONCEPTS
-        </h2>
-        <p class="mt-2">
+        <h2 class="section-title mt-6">Concepts</h2>
+        <p class="mt-2 text-ink">
             {{- range $index, $concept := .ProblemPtr.Concepts -}}
                 {{- if $index }}, {{ end -}}{{ getName $concept "en" }}
             {{- end -}}
         </p>
         {{ end }}
-        <h2 class="text-lg font-semibold mt-4">
-            SKILL
-        </h2>
-        <p class="mt-2">
+        <h2 class="section-title mt-6">Skill</h2>
+        <p class="mt-2 text-ink">
             {{- range $index, $skill := .ProblemPtr.Skills -}}
                 {{- if $index }}, {{ end -}}{{ $skill.Name }}
             {{- end -}}
         </p>
         {{ if .ProblemPtr.MetaData.Options }}
-        <h2 class="text-lg font-semibold mt-4">
-            OPTIONS
-        </h2>
-        <div class="mt-2 border border-gray-300">
+        <h2 class="section-title mt-6">Options</h2>
+        <div class="mt-2 rounded-lg border border-border overflow-hidden">
             {{ range $index, $option := .ProblemPtr.MetaData.Options }}
-            <div class="flex items-center border-b border-gray-300 p-4">
-                <span class="mr-8 font-semibold">
+            <div class="flex items-center border-b border-border/40 p-4 last:border-b-0 bg-bg-card">
+                <span class="mr-6 font-mono font-bold text-accent w-6">
                     {{ printf "%c" (add 65 $index) }}    <!-- Convert ASCII to letter -->
                 </span>
-                <p>{{ $option }}</p>
+                <p class="text-ink">{{ $option }}</p>
             </div>
             {{ end }}
         </div>
         {{ end }}
-        <h2 class="text-lg font-semibold mt-4">
-            ANSWER
-        </h2>
-        <p class="mt-2">
+        <h2 class="section-title mt-6">Answer</h2>
+        <p class="mt-2 text-ink font-mono">
             {{ if or (eq .ProblemPtr.Subtype "mcq_single_answer") (eq .ProblemPtr.Subtype "matrix_match") }}
                 {{ range .ProblemPtr.MetaData.Answers }}
                     {{ printf "%c" (add 64 (stringToInt .)) }}
@@ -78,26 +68,22 @@
                 {{ end }}
             {{ end }}
         </p>
-        <h2 class="text-lg font-semibold mt-4">
-            SOLUTION
-        </h2>
-        <p class="mt-2">
+        <h2 class="section-title mt-6">Solution</h2>
+        <p class="mt-2 text-ink">
             {{ if gt (len .ProblemPtr.MetaData.Solutions) 0 }}
                 {{ (index .ProblemPtr.MetaData.Solutions 0).Value }}
             {{ else }}
-                No solution available.
+                <span class="text-ink-muted italic">No solution available.</span>
             {{ end }}
         </p>
-        <h2 class="text-lg font-semibold mt-4">
-            DIFFICULTY RATING
-        </h2>
-        <div class="mt-2 flex items-center text-yellow-400">
+        <h2 class="section-title mt-6">Difficulty</h2>
+        <div class="mt-2 flex items-center text-brand-gold">
             {{ range $i := seq 1 3 }}
                 {{ if le $i $.ProblemPtr.DisplayDifficulty }}
                     <!-- Filled star -->
                     <i class="fa-solid fa-star"></i>
                 {{ else }}
-                    <i class="fa-regular fa-star text-gray-300"></i>
+                    <i class="fa-regular fa-star text-ink-muted/40"></i>
                 {{ end }}
             {{ end }}
         </div>

--- a/web/html/problem_answer_numerical.html
+++ b/web/html/problem_answer_numerical.html
@@ -44,15 +44,15 @@
 
     <div id="singleInputDiv" class="{{ if $isRange }}hidden{{ end }}">
         <input type="text" name="singleAnswer" inputmode="decimal"
-            class="w-full border border-gray-300 rounded p-2" value="{{ $single }}">
+            class="w-full border border-border rounded p-2" value="{{ $single }}">
     </div>
 
     <div id="rangeInputDiv" class="flex gap-2 {{ if not $isRange }}hidden{{ end }}">
         <input type="text" name="minAnswer" placeholder="Min" value="{{ $min }}"
-            class="w-1/2 border border-gray-300 rounded p-2">
+            class="w-1/2 border border-border rounded p-2">
 
         <input type="text" name="maxAnswer" placeholder="Max" value="{{ $max }}"
-            class="w-1/2 border border-gray-300 rounded p-2">
+            class="w-1/2 border border-border rounded p-2">
     </div>
 </div>
 {{ end }}

--- a/web/html/problem_test_association_modal.html
+++ b/web/html/problem_test_association_modal.html
@@ -1,37 +1,35 @@
 <div id="problem-test-association-modal"
-    class="fixed inset-0 bg-gray-800 bg-opacity-50 flex justify-center items-center z-50"
+    class="fixed inset-0 bg-ink/40 flex justify-center items-center z-50 p-4"
     data-problem-ids="{{range $i, $p := .}}{{if $i}},{{end}}{{$p.ProblemID}}{{end}}">
 
-    <div class="bg-white p-6 rounded shadow-md w-full max-w-lg">
+    <div class="card shadow-xl rounded-xl w-full max-w-lg p-6 max-h-[90vh] flex flex-col">
 
         <!-- Title -->
-        <h2 class="text-lg font-semibold mb-2">
-            Problem Test Associations
-        </h2>
+        <h2 class="page-title mb-2">Problem Test Associations</h2>
 
         <!-- Description -->
-        <p class="text-sm text-gray-600 mb-4">
+        <p class="text-sm text-ink-muted mb-4">
             Please note that selected problems are associated with the following tests.
         </p>
-        
+
         <!-- Table -->
-        <div class="max-h-64 overflow-y-auto mb-6 border">
-            <table class="min-w-full text-sm">
-                <thead class="bg-gray-200 text-gray-600 sticky top-0">
+        <div class="card overflow-hidden flex-1 overflow-y-auto mb-6 max-h-64">
+            <table class="app-table">
+                <thead class="sticky top-0">
                     <tr>
-                        <th class="px-4 py-2 text-left">Problem Code</th>
-                        <th class="px-4 py-2 text-left">Associated Test IDs</th>
+                        <th>Problem Code</th>
+                        <th>Associated Test IDs</th>
                     </tr>
                 </thead>
                 <tbody>
                     {{range .}}
-                    <tr class="border-t">
-                        <td class="px-4 py-2">{{.ProblemCode}}</td>
-                        <td class="px-4 py-2">
+                    <tr class="border-b border-border/40">
+                        <td class="font-mono">{{.ProblemCode}}</td>
+                        <td class="font-mono">
                             {{if .Tests}}
                                 {{range $i, $t := .Tests}}{{if $i}}, {{end}}{{$t.TestCode}}{{end}}
                             {{else}}
-                                <span class="text-gray-500 italic">No tests found</span>
+                                <span class="text-ink-muted italic font-sans">No tests found</span>
                             {{end}}
                         </td>
                     </tr>
@@ -41,24 +39,22 @@
         </div>
 
         <!-- Buttons -->
-        <div class="w-full flex justify-end space-x-2">
-            <button type="button" class="bg-gray-300 px-4 py-2 rounded hover:bg-gray-400 transition" onclick="closeProblemTestAssociationModal()">
+        <div class="flex gap-3 justify-end">
+            <button type="button" class="btn-secondary" onclick="closeProblemTestAssociationModal()">
                 Close
             </button>
 
             <button type="button" hx-swap="outerHTML"
-                class="group flex items-center justify-center min-w-[90px] bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition"
+                class="btn-primary group min-w-[120px]"
                 hx-post="/problems/move-problems" hx-target="#problem-test-association-modal"
                 hx-vals='js:{problem_ids: event.target.closest("#problem-test-association-modal").dataset.problemIds}'>
-                
+
                 <!-- Text -->
-                <span class="group-[.htmx-request]:hidden">
-                    Move
-                </span>
+                <span class="group-[.htmx-request]:hidden">Move</span>
 
                 <!-- Spinner -->
                 <span class="hidden group-[.htmx-request]:inline-flex">
-                    <div class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+                    <div class="w-4 h-4 border-2 border-text-on-accent border-t-transparent rounded-full animate-spin"></div>
                 </span>
 
             </button>

--- a/web/html/problems.html
+++ b/web/html/problems.html
@@ -1,16 +1,16 @@
 {{ define "content" }}
 <div>
     <!-- Search + Subject Filter Row -->
-    <div class="flex items-center gap-4 mb-4">
+    <div class="flex flex-wrap items-center gap-3 mb-4">
 
         <input type="hidden" id="problems-restore-flag" value="fresh">
-        
+
         <!-- Search field -->
         <input type="text" id="problem-search" name="problem-search" placeholder="Search problems by question or code..."
-            class="border border-gray-400 p-2 rounded w-[19rem]">
+            class="form-input w-[19rem]">
 
         <!-- Subject Dropdown -->
-        <select class="border border-gray-400 p-2 rounded w-fit" id="problems-subject-dropdown" 
+        <select class="form-select-compact w-auto" id="problems-subject-dropdown"
             name="problems-subject-dropdown" hx-get="/api/subjects" hx-trigger="revealed" hx-swap="beforeend"
             onchange="
                 const input = document.getElementById('problem-search');
@@ -23,32 +23,34 @@
 
     </div>
 
-    <table class="w-full bg-white shadow-md table-fixed">
-        <colgroup>
-            <col class="w-[6rem]">   <!-- Code -->
-            <col>                   <!-- Text (flexes) -->
-            <col class="w-[6rem]">   <!-- Actions -->
-        </colgroup>
-        <thead>
-            <tr class="bg-gray-200 text-gray-600 text-sm">
-                <th class="py-4">Code</th>
-                <th>Text</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
+    <div class="card overflow-x-auto">
+        <table class="app-table table-fixed">
+            <colgroup>
+                <col class="w-[6rem]">   <!-- Code -->
+                <col>                   <!-- Text (flexes) -->
+                <col class="w-[6rem]">   <!-- Actions -->
+            </colgroup>
+            <thead>
+                <tr>
+                    <th>Code</th>
+                    <th>Text</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
 
-        <tbody id="problems-table-body" class="text-gray-600 text-sm" data-mathjax="true"
-            hx-ext="infinite-scroll" hx-get="/api/search-problems?limit=10&offset=0"
-            data-limit="10" data-offset="0" hx-sync="this:replace"
-            hx-trigger="keyup[event.target.value.length>=3] changed delay:500ms from:#problem-search, searchTriggered"
-            hx-include="#problem-search,#problems-subject-dropdown"
-            data-loader="#problems-search-loader" data-sentinel="#problems-table-sentinel">
-            <!-- Rows will be dynamically inserted here -->
-        </tbody>
-    </table>
+            <tbody id="problems-table-body" data-mathjax="true"
+                hx-ext="infinite-scroll" hx-get="/api/search-problems?limit=10&offset=0"
+                data-limit="10" data-offset="0" hx-sync="this:replace"
+                hx-trigger="keyup[event.target.value.length>=3] changed delay:500ms from:#problem-search, searchTriggered"
+                hx-include="#problem-search,#problems-subject-dropdown"
+                data-loader="#problems-search-loader" data-sentinel="#problems-table-sentinel">
+                <!-- Rows will be dynamically inserted here -->
+            </tbody>
+        </table>
+    </div>
     <div id="problems-table-sentinel"></div>
-    <div id="problems-search-loader" class="hidden flex justify-center py-4">
-        <div class="w-6 h-6 border-4 border-gray-300 border-t-blue-600 rounded-full animate-spin"></div>
+    <div id="problems-search-loader" class="hidden justify-center py-4">
+        <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
     </div>
 </div>
 <script>

--- a/web/html/resource_row.html
+++ b/web/html/resource_row.html
@@ -1,10 +1,10 @@
 {{ range . }}
-<tr class="border-b hover:bg-gray-100">
+<tr class="border-b border-border/40 hover:bg-bg-hover transition-colors">
     <td class="py-4 px-6">{{.Code}}</td>
     <td class="px-6">{{ getName . "en" }}</td>
     <td class="px-6">{{.Type}}</td>
     <td class="px-6">{{.Subtype}}</td>
-    <td class="px-6 text-blue-500 hover:underline">
+    <td class="px-6 text-accent hover:text-accent-hover hover:underline font-medium">
         {{ if .TypeParams.SrcLink }}
         <a href="{{ .TypeParams.SrcLink }}" target="_blank" rel="noopener noreferrer">
             {{ .TypeParams.SrcLink }}

--- a/web/html/resources.html
+++ b/web/html/resources.html
@@ -1,14 +1,14 @@
 <div>
-    <div class="shadow-md overflow-x-auto">
-        <table class="min-w-full bg-white">
+    <div class="card overflow-x-auto">
+        <table class="app-table">
             <thead>
-                <tr class="bg-gray-200 text-gray-600 text-sm">
-                    <th class="py-4 px-6 text-left">Code</th>
-                    <th class="px-6 text-left">Name</th>
-                    <th class="px-6 text-left">Type</th>
-                    <th class="px-6 text-left">Subtype</th>
-                    <th class="px-6 text-left">URL</th>
-                    <th class="px-6 text-center">Actions</th>
+                <tr>
+                    <th>Code</th>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Subtype</th>
+                    <th>URL</th>
+                    <th class="text-center">Actions</th>
                 </tr>
             </thead>
             <!-- Reason of using delay:150ms, change from:(#curriculum-dropdown, #grade-dropdown) here:
@@ -20,7 +20,7 @@
              so you should see only one /api/resources call with the correct params when returning with Resources tab active. 
              eg - Click edit on any resource -> Back. It should invoke /api/resources only once
              -->
-            <tbody id="resourceTableBody" class="text-gray-600 text-sm"
+            <tbody id="resourceTableBody" class="text-ink-muted text-sm"
                 {{ if .TopicId }}
                     hx-get="/api/resources?topic_id={{.TopicId}}"
                 {{ else }}
@@ -35,9 +35,9 @@
 
     <!-- Form to add new resource -->
     <div class="mt-4">
-        <h4 id="addResourceLink" class="text-sm font-semibold text-blue-500 hover:underline"
+        <h4 id="addResourceLink" class="add-new-link"
             onclick="toggleResourceForm(event, '{{.ChapterId}}', '{{.TopicId}}')">
-            <a href="#">Add New Resource</a>
+            <a href="#">+ Add New Resource</a>
         </h4>
     </div>
 </div>

--- a/web/html/search_problem_row.html
+++ b/web/html/search_problem_row.html
@@ -2,7 +2,7 @@
 <tr class="border-b">
     <!-- hx-params="none" is added to prevent extra query parameters (curriculum-dropdown
          and subject-dropdown) going from its parent topic_problems.html file's problemTableBody -->
-    <td class="p-2 text-center whitespace-nowrap text-blue-500 hover:underline"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
+    <td class="p-2 text-center whitespace-nowrap text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
             hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-params="none" hx-target="body"
             hx-push-url="true">{{.Code}}
         </a></td>

--- a/web/html/src_problem_row.html
+++ b/web/html/src_problem_row.html
@@ -1,11 +1,11 @@
 {{ define "src_problem_row" }}
 {{ range . }}
 <tr class="border-b">
-    <td class="p-2 text-blue-500 hover:underline"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" 
+    <td class="p-2 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" 
         hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body" hx-push-url="true">{{.Code}}
     </a></td>
     <td class="p-2">{{.MetaData.Question}}</td>
-    <td class="p-2 text-center"><button class="px-2 bg-green-500 text-white rounded" data-id="{{.ID}}"
+    <td class="p-2 text-center"><button class="px-2 bg-success text-white rounded" data-id="{{.ID}}"
             data-subject="{{.Subject.ID}}" data-subtype="{{.Subtype}}" data-difficulty="{{.DifficultyLevel}}"
             data-curriculum="{{.CurriculumID}}" data-subject-parent="{{if .Subject.ParentID}}{{.Subject.ParentID}}{{end}}" 
             hx-on:click="addQuestionToTest(this)">+</button>

--- a/web/html/tag_row.html
+++ b/web/html/tag_row.html
@@ -1,3 +1,3 @@
 {{ range . }}
-<div class="px-3 py-2 cursor-pointer hover:bg-gray-100" onclick='addTag("{{.Name}}")'>{{.Name}}</div>
+<div class="px-3 py-2 cursor-pointer hover:bg-bg-card-alt" onclick='addTag("{{.Name}}")'>{{.Name}}</div>
 {{ end }}

--- a/web/html/test.html
+++ b/web/html/test.html
@@ -1,36 +1,40 @@
 {{ define "content" }}
-<div class="bg-white mb-4">
-    <div class="flex justify-between items-center">
-        <button class="action-button" onclick="window.history.back()">
+<div class="card card-pad mb-4">
+    <div class="flex flex-wrap items-center gap-y-2 mb-4">
+        <button class="btn-ghost btn-sm" onclick="window.history.back()">
             <i class="fa-solid fa-chevron-left"></i> Back
         </button>
-        <h3 class="text-base font-semibold ml-4">{{ (index .TestPtr.Name 0).Resource }}</h3>
-        <div class="text-right">
-            <span class="block">
-                Duration: {{.TestPtr.TypeParams.Duration}} min
-            </span>
-            <span class="block">
-                Marks: {{.TestPtr.TypeParams.Marks}}
-            </span>
+        <h3 class="ml-4 text-lg font-bold uppercase tracking-wide text-ink">{{ (index .TestPtr.Name 0).Resource }}</h3>
+        <div class="ml-auto flex items-center gap-6 text-sm">
+            <div>
+                <span class="form-label mb-0">Duration</span>
+                <span class="font-mono text-ink">{{.TestPtr.TypeParams.Duration}} min</span>
+            </div>
+            <div>
+                <span class="form-label mb-0">Marks</span>
+                <span class="font-mono text-ink">{{.TestPtr.TypeParams.Marks}}</span>
+            </div>
         </div>
     </div>
     {{ range $index, $subject := .TestPtr.TypeParams.Subjects }}
-    <h2 class="text-xl font-bold text-center bg-gray-200 p-3 rounded capitalize">
+    <h2 class="text-lg font-bold uppercase tracking-wide text-ink bg-bg-card-alt border-l-4 border-brand-amber p-3 rounded-lg mt-6 mb-3 capitalize">
         {{$subject.Name}}
     </h2>
-    <table class="min-w-full shadow-md">
-        <thead>
-            <tr class="border-b text-sm">
-                <th class="w-16 py-2 px-4">S.No.</th>
-                <th class="w-32 px-4">Code</th>
-                <th class="w-auto px-4">Text</th>
-            </tr>
-        </thead>
-        <tbody hx-get="/api/test/problems?id={{$.TestPtr.ID}}&curriculum_id={{(index $.TestPtr.CurriculumGrades 0).CurriculumID}}&subject_id={{$subject.SubjectID}}" 
-            hx-trigger="load" data-mathjax="true">
-            <!-- Rows will be dynamically inserted here -->
-        </tbody>
-    </table>
+    <div class="card overflow-hidden">
+        <table class="app-table">
+            <thead>
+                <tr>
+                    <th class="w-16">S.No.</th>
+                    <th class="w-32">Code</th>
+                    <th class="w-auto">Text</th>
+                </tr>
+            </thead>
+            <tbody hx-get="/api/test/problems?id={{$.TestPtr.ID}}&curriculum_id={{(index $.TestPtr.CurriculumGrades 0).CurriculumID}}&subject_id={{$subject.SubjectID}}"
+                hx-trigger="load" data-mathjax="true">
+                <!-- Rows will be dynamically inserted here -->
+            </tbody>
+        </table>
+    </div>
     {{ end }}
 </div>
 {{ end }}

--- a/web/html/test_chip_editor.html
+++ b/web/html/test_chip_editor.html
@@ -6,7 +6,7 @@
 
     <label class="font-semibold">{{ $label }}</label>
     <div class="flex items-center border rounded p-2 w-full">
-        <span class="text-gray-500">{{ if eq $label "Award" }}+{{ else }}-{{ end }}</span>
+        <span class="text-ink-muted">{{ if eq $label "Award" }}+{{ else }}-{{ end }}</span>
         <div id="chip-box" class="chip-box ml-2 w-full" onclick="focusEditable(this)">
             <div id="{{ $id }}"
                 contenteditable="{{ if $readonly }}false{{ else }}true{{ end }}"

--- a/web/html/test_instructions_modal.html
+++ b/web/html/test_instructions_modal.html
@@ -1,26 +1,26 @@
 {{ define "test_instructions_modal" }}
 <div id="test-instructions-modal"
-    class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    class="hidden fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4"
     onclick="if (event.target === this) closeInstructionsModal()">
-    <div class="bg-white rounded-lg shadow-lg w-full max-w-5xl mx-4 p-4">
-        <div class="flex items-center justify-between border-b pb-2">
-            <h2 class="text-lg font-semibold">Test Instructions</h2>
-            <button type="button" class="text-gray-500 hover:text-gray-700"
+    <div class="card shadow-xl rounded-xl w-full max-w-5xl p-6 max-h-[90vh] flex flex-col">
+        <div class="flex items-center justify-between border-b border-border pb-3 mb-3">
+            <h2 class="page-title">Test Instructions</h2>
+            <button type="button" class="action-button p-2" aria-label="Close"
                 onclick="closeInstructionsModal()">
                 <i class="fa-solid fa-xmark"></i>
             </button>
         </div>
 
-        <div id="test-instructions-editor-wrapper" class="mt-3">
+        <div id="test-instructions-editor-wrapper" class="flex-1 overflow-y-auto">
             {{ template "editor" }}
         </div>
 
-        <div class="mt-4 flex justify-end gap-2">
-            <button type="button" class="px-4 py-2 border rounded hover:bg-gray-100"
+        <div class="mt-4 flex justify-end gap-3">
+            <button type="button" class="btn-secondary"
                 onclick="closeInstructionsModal()">
                 Cancel
             </button>
-            <button type="button" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+            <button type="button" class="btn-primary"
                 onclick="saveInstructionsModal()">
                 Save Instructions
             </button>

--- a/web/html/test_problem_row.html
+++ b/web/html/test_problem_row.html
@@ -1,8 +1,8 @@
 {{ range $index, $item := . }}
-<tr class="border-b hover:bg-gray-100 text-center">
+<tr class="border-b hover:bg-bg-card-alt text-center">
     <!-- add is a custom function registered in test_handler.go -->
     <td class="w-16 py-2 px-4">{{ add $index 1 }}</td>
-    <td class="w-32 px-4 text-blue-500 hover:underline"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
+    <td class="w-32 px-4 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
             hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body"
             hx-push-url="true">{{.Code}}</a>
     </td>

--- a/web/html/test_row.html
+++ b/web/html/test_row.html
@@ -2,12 +2,12 @@
 {{ $curriculumGrade := (index .CurriculumGrades 0) }}
 {{ $curriculumId := $curriculumGrade.CurriculumID }}
 {{ $gradeId := $curriculumGrade.GradeID }}
-<tr class="border-b hover:bg-gray-100">
+<tr class="border-b border-border/40 hover:bg-bg-hover transition-colors">
     <td class="py-4 px-6">{{.Code}}</td>
-    <td class="px-6 text-blue-500 hover:underline"><a href="/test?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}" 
+    <td class="px-6 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/test?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}" 
         hx-get="/test?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}" hx-target="body"
         hx-push-url="true">{{ (index .Name 0).Resource }}</a></td>
-    <td class="px-6 text-center text-blue-500 hover:underline">{{.ProblemCount}}</td>
+    <td class="px-6 text-center text-accent hover:text-accent-hover hover:underline font-medium">{{.ProblemCount}}</td>
     <td class="text-center">{{.TypeParams.Marks}}</td>
     <td class="text-center">{{.TypeParams.Duration}}</td>
     <td></td>

--- a/web/html/test_search_row.html
+++ b/web/html/test_search_row.html
@@ -17,12 +17,12 @@
         {{ $curriculumId := $cg.CurriculumID }}
         {{ $gradeId := $cg.GradeID }}
 
-        <tr class="border-b hover:bg-gray-100" hx-swap="outerHTML">
+        <tr class="border-b border-border/40 hover:bg-bg-hover transition-colors" hx-swap="outerHTML">
             {{ if eq $i 0 }}
                 <!-- Show code and name only for first curriculum-grade -->
                 <td class="py-4 px-6" rowspan="{{ $total }}">{{ $test.Code }}</td>
 
-                <td class="px-6 text-blue-500 hover:underline" rowspan="{{ $total }}">
+                <td class="px-6 text-accent hover:text-accent-hover hover:underline font-medium" rowspan="{{ $total }}">
                     <a href="/test?id={{ $test.ID }}&curriculum_id={{ $curriculumId }}&grade_id={{ $gradeId }}"
                        hx-get="/test?id={{ $test.ID }}&curriculum_id={{ $curriculumId }}&grade_id={{ $gradeId }}"
                        hx-target="body" hx-push-url="true">

--- a/web/html/tests.html
+++ b/web/html/tests.html
@@ -1,14 +1,14 @@
 {{ define "content" }}
 <div>
-    <div class="flex justify-between items-center mb-4">
+    <div class="flex flex-wrap justify-between items-center gap-y-3 mb-4">
 
         <!-- Left side: Test type dropdown + Search -->
-        <div class="flex items-center space-x-4">
+        <div class="flex flex-wrap items-center gap-3">
 
-            <!-- hx-trigger="onLoaded from:(#curriculum-dropdown, #grade-dropdown)" is added to load tests on 
+            <!-- hx-trigger="onLoaded from:(#curriculum-dropdown, #grade-dropdown)" is added to load tests on
             coming back from single test to tests list screen -->
-            <select id="testtype-dropdown" name="testtype-dropdown" hx-ext="tests-view-loader" 
-                class="border border-gray-400 p-2 rounded" hx-get="/tests?mode=filter"
+            <select id="testtype-dropdown" name="testtype-dropdown" hx-ext="tests-view-loader"
+                class="form-select-compact w-auto" hx-get="/tests?mode=filter"
                 hx-trigger="change, change from:(#curriculum-dropdown, #grade-dropdown), onLoaded from:(#curriculum-dropdown, #grade-dropdown)"
                 hx-target="#test-table-wrapper" hx-include="#curriculum-dropdown, #grade-dropdown, #testtype-dropdown"
                 onchange="sessionStorage.setItem('selectedTesttype', this.value); sessionStorage.setItem(window.TESTS_VIEW_LOADED_KEY, 'false');">
@@ -17,24 +17,24 @@
 
             <!-- Search field -->
             <input type="text" id="test-search" name="search" placeholder="Search tests by code or name..."
-                class="border border-gray-400 p-2 rounded w-64" hx-get="/tests?mode=search" hx-ext="search-store"
+                class="form-input w-72" hx-get="/tests?mode=search" hx-ext="search-store"
                 hx-trigger="keyup[this.value.length>=3] delay:500ms" hx-target="#test-table-wrapper">
 
         </div>
 
         <!-- Add New Test Link -->
-        <h4 class="text-sm font-semibold text-blue-500 hover:underline ml-4">
-            <a href="#" 
-                hx-get="/tests/add-test-dialog" 
-                hx-target="body" 
+        <h4 class="add-new-link ml-4">
+            <a href="#"
+                hx-get="/tests/add-test-dialog"
+                hx-target="body"
                 hx-push-url="true"
-                hx-swap="beforeend">Add New Test</a>
+                hx-swap="beforeend">+ Add New Test</a>
         </h4>
     </div>
 
     <!-- Content Area -->
     <div id="subcontent">
-        <div id="test-table-wrapper" class="shadow-md my-6 overflow-x-auto">
+        <div id="test-table-wrapper" class="card overflow-x-auto my-6">
             <!-- Table content will be loaded here based on mode filter or search -->
         </div>
     </div>

--- a/web/html/tests_filter_view.html
+++ b/web/html/tests_filter_view.html
@@ -1,47 +1,47 @@
-<table class="min-w-full bg-white" hx-ext="table-sort,tests-loader" data-sort-scope="tests" >
-    <!-- common hx-target and hx-include for all th tags -->    
+<table class="app-table" hx-ext="table-sort,tests-loader" data-sort-scope="tests">
+    <!-- common hx-target and hx-include for all th tags -->
     <thead hx-target="#test-table-body" hx-include="#curriculum-dropdown, #grade-dropdown, #testtype-dropdown">
-        <tr class="bg-gray-200 text-gray-600 text-sm">
-            <th class="py-4 px-6 text-left">
-                <a href="#" hx-get="/api/tests?col=1">
+        <tr>
+            <th>
+                <a href="#" class="hover:text-accent" hx-get="/api/tests?col=1">
                     Code <i class="fas fa-sort"></i>
                 </a>
             </th>
-            <th class="px-6 text-left">
-                <a href="#" hx-get="/api/tests?col=2">
+            <th>
+                <a href="#" class="hover:text-accent" hx-get="/api/tests?col=2">
                     Name <i class="fas fa-sort"></i>
                 </a>
             </th>
-            <th class="px-6 text-center">
-                <a href="#" hx-get="/api/tests?col=3">
+            <th class="text-center">
+                <a href="#" class="hover:text-accent" hx-get="/api/tests?col=3">
                     # of questions <i class="fas fa-sort"></i>
                 </a>
             </th>
-            <th class="px-6 text-center">
-                <a href="#" hx-get="/api/tests?col=4">
+            <th class="text-center">
+                <a href="#" class="hover:text-accent" hx-get="/api/tests?col=4">
                     Marks <i class="fas fa-sort"></i>
                 </a>
             </th>
-            <th class="px-6 text-center">
-                <a href="#" hx-get="/api/tests?col=5">
+            <th class="text-center">
+                <a href="#" class="hover:text-accent" hx-get="/api/tests?col=5">
                     Duration <i class="fas fa-sort"></i>
                 </a>
             </th>
-            <th class="px-6 text-center">
-                <a href="#" hx-get="/api/tests?col=6">
+            <th class="text-center">
+                <a href="#" class="hover:text-accent" hx-get="/api/tests?col=6">
                     Set <i class="fas fa-sort"></i>
                 </a>
             </th>
-            <th class="px-6 text-center">Actions</th>
+            <th class="text-center">Actions</th>
         </tr>
     </thead>
-    <tbody id="test-table-body" class="text-gray-600 text-sm" hx-get="/api/tests" hx-trigger="load"
+    <tbody id="test-table-body" hx-get="/api/tests" hx-trigger="load"
         hx-include="#curriculum-dropdown, #grade-dropdown, #testtype-dropdown">
         <!-- Rows will be dynamically inserted here -->
     </tbody>
 </table>
 <div id="loader" class="hidden flex justify-center py-4">
-    <div class="w-6 h-6 border-4 border-gray-300 border-t-blue-600 rounded-full animate-spin"></div>
+    <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
 </div>
 <script>
     (function () {

--- a/web/html/tests_search_view.html
+++ b/web/html/tests_search_view.html
@@ -1,37 +1,33 @@
-<table class="min-w-full bg-white" hx-ext="table-sort,infinite-scroll" data-sort-scope="search-tests">
+<table class="app-table" hx-ext="table-sort,infinite-scroll" data-sort-scope="search-tests">
     <thead hx-target="#test-table-body" hx-include="#test-search">
-        <tr class="bg-gray-200 text-gray-600 text-sm">
-            <th class="py-4 px-6 text-left">
-                <a href="#" hx-get="/api/search-tests?col=1&limit=10&offset=0">
+        <tr>
+            <th>
+                <a href="#" class="hover:text-accent" hx-get="/api/search-tests?col=1&limit=10&offset=0">
                     Code <i class="fas fa-sort"></i>
                 </a>
             </th>
-            <th class="px-6 text-left">
-                <a href="#" hx-get="/api/search-tests?col=2&limit=10&offset=0">
+            <th>
+                <a href="#" class="hover:text-accent" hx-get="/api/search-tests?col=2&limit=10&offset=0">
                     Name <i class="fas fa-sort"></i>
                 </a>
             </th>
-            <th class="px-6 text-center">
-                Curriculum 
-            </th>
-            <th class="px-6 text-center">
-                Grade 
-            </th>
-            <th class="px-6 text-center">
-                <a href="#" hx-get="/api/search-tests?col=5&limit=10&offset=0">
+            <th class="text-center">Curriculum</th>
+            <th class="text-center">Grade</th>
+            <th class="text-center">
+                <a href="#" class="hover:text-accent" hx-get="/api/search-tests?col=5&limit=10&offset=0">
                     Test Type <i class="fas fa-sort"></i>
                 </a>
             </th>
-            <th class="px-6 text-center">Actions</th>
+            <th class="text-center">Actions</th>
         </tr>
     </thead>
-    <tbody id="test-table-body" class="text-gray-600 text-sm" hx-get="/api/search-tests?limit=10&offset=0"
-        hx-trigger="load" data-limit="10" data-offset="0" hx-include="#test-search" 
+    <tbody id="test-table-body" hx-get="/api/search-tests?limit=10&offset=0"
+        hx-trigger="load" data-limit="10" data-offset="0" hx-include="#test-search"
         data-loader="#search-loader" data-sentinel="#tests-table-sentinel">
         <!-- Rows will be dynamically inserted here -->
     </tbody>
 </table>
 <div id="tests-table-sentinel"></div>
-<div id="search-loader" class="hidden flex justify-center py-4">
-    <div class="w-6 h-6 border-4 border-gray-300 border-t-blue-600 rounded-full animate-spin"></div>
+<div id="search-loader" class="hidden justify-center py-4">
+    <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
 </div>

--- a/web/html/topic.html
+++ b/web/html/topic.html
@@ -1,12 +1,12 @@
 {{ define "content" }}
-<div id="topic-div" class="bg-white mb-4">
-    <div class="flex items-center">
-        <button class="action-button" onclick="window.history.back()">
+<div id="topic-div" class="card card-pad mb-4">
+    <div class="flex items-center mb-4">
+        <button class="btn-ghost btn-sm" onclick="window.history.back()">
             <i class="fa-solid fa-chevron-left"></i> Back
         </button>
-        <h3 class="text-base font-semibold ml-4">{{ getName .TopicPtr "en" }}</h3>
+        <h3 class="ml-4 text-lg font-bold uppercase tracking-wide text-ink">{{ getName .TopicPtr "en" }}</h3>
     </div>
-    <div class="flex space-x-4 py-4">
+    <div class="flex flex-wrap gap-3 py-2 border-b border-border">
         <button id="topic-concepts-tab" data-toggle="sub-tab" class="sub-tab active" onclick="onTopicTabClick(this)"
             hx-trigger="click, load" hx-get="/concepts" hx-target="#subContent">Concepts</button>
         <button id="topic-problems-tab" data-toggle="sub-tab" class="sub-tab" onclick="onTopicTabClick(this)"
@@ -14,9 +14,9 @@
         <button id="resources-tab" data-toggle="sub-tab" class="sub-tab" onclick="onTopicTabClick(this)"
             hx-get="/topic/resources?topicId={{.TopicPtr.ID}}&chapterId={{.TopicPtr.ChapterID}}" hx-target="#subContent">Resources</button>
     </div>
-    <div id="sub-tabContent">
+    <div id="sub-tabContent" class="pt-4">
         <div id="subContent">
-            <p>Select a tab to load content.</p>
+            <p class="text-ink-muted">Select a tab to load content.</p>
         </div>
     </div>
 </div>

--- a/web/html/topic_problem_row.html
+++ b/web/html/topic_problem_row.html
@@ -6,7 +6,7 @@
 
     <!-- hx-params="none" is added to prevent extra query parameters (curriculum-dropdown
          and subject-dropdown) going from its parent topic_problems.html file's problemTableBody -->
-    <td class="p-2 text-center whitespace-nowrap text-blue-500 hover:underline"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
+    <td class="p-2 text-center whitespace-nowrap text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
             hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-params="none" hx-target="body"
             hx-push-url="true">{{.Code}}
         </a></td>

--- a/web/html/topic_problems.html
+++ b/web/html/topic_problems.html
@@ -1,28 +1,26 @@
 <div>
-    <div class="flex gap-4 mb-4">
-        <button class="px-3 py-1 text-sm bg-blue-500 hover:bg-blue-600 text-white rounded" hx-target="body"
-            hx-get="/topic/add-problem?topic_id={{.}}" hx-push-url="true">Add New Problem
+    <div class="flex flex-wrap gap-3 mb-4">
+        <button class="btn-primary btn-sm" hx-target="body"
+            hx-get="/topic/add-problem?topic_id={{.}}" hx-push-url="true">+ Add New Problem
         </button>
 
         <button id="move-problems-btn" hx-include='input[name="select-problem"]:checked'
-            class="group flex items-center justify-center min-w-[120px] px-3 py-1 text-sm bg-blue-500 hover:bg-blue-600 text-white rounded disabled:bg-gray-300 disabled:cursor-not-allowed"
-            hx-post="/problems/test-associations" hx-target="body" 
+            class="btn-primary btn-sm group min-w-[140px] disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-bg-card-alt disabled:text-ink-muted"
+            hx-post="/problems/test-associations" hx-target="body"
             hx-swap="beforeend" disabled>
-            
-            <span class="group-[.htmx-request]:hidden">
-                Move Problems
-            </span>
-        
+
+            <span class="group-[.htmx-request]:hidden">Move Problems</span>
+
             <span class="hidden group-[.htmx-request]:inline-flex">
-                <div class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+                <div class="w-4 h-4 border-2 border-text-on-accent border-t-transparent rounded-full animate-spin"></div>
             </span>
-        
+
         </button>
 
     </div>
 
-    <div class="shadow-md">
-        <table class="min-w-full bg-white">
+    <div class="card overflow-hidden">
+        <table class="app-table">
             <colgroup>
                 <col class="w-[2rem]">   <!-- Checkbox -->
                 <col class="w-[6rem]">   <!-- Code -->
@@ -30,16 +28,16 @@
                 <col class="w-[6rem]">   <!-- Actions -->
             </colgroup>
             <thead>
-                <tr class="bg-gray-200 text-gray-600 text-sm">
-                    <th class="py-4 text-center">
-                        <input type="checkbox" id="select-all">
+                <tr>
+                    <th class="text-center">
+                        <input type="checkbox" id="select-all" class="accent-accent">
                     </th>
-                    <th class="py-4">Code</th>
+                    <th>Code</th>
                     <th>Text</th>
                     <th>Actions</th>
                 </tr>
             </thead>
-            <tbody id="problemTableBody" class="text-gray-600 text-sm" hx-trigger="load, refreshProblems"
+            <tbody id="problemTableBody" class="text-ink-muted text-sm" hx-trigger="load, refreshProblems"
                 hx-get="/api/topic/problems?topic-dropdown={{.}}" hx-include="#curriculum-dropdown, #subject-dropdown"
                 hx-indicator="#topic-problems-loader"
                 hx-on::before-request="this.innerHTML=''"
@@ -49,7 +47,7 @@
         </table>
     </div>
     <div id="topic-problems-loader" class="flex justify-center py-4">
-        <div class="w-6 h-6 border-4 border-gray-300 border-t-blue-600 rounded-full animate-spin"></div>
+        <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
     </div>
 </div>
 <script>

--- a/web/html/topic_row.html
+++ b/web/html/topic_row.html
@@ -1,7 +1,7 @@
 {{ range . }}
-<tr class="border-b hover:bg-gray-100">
+<tr class="border-b border-border/40 hover:bg-bg-hover transition-colors">
     <td class="py-4 px-6">{{.Code}}</td>
-    <td class="px-6 text-blue-500 hover:underline"><a href="/topic?id={{.ID}}" hx-get="/topic?id={{.ID}}"
+    <td class="px-6 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/topic?id={{.ID}}" hx-get="/topic?id={{.ID}}"
             hx-target="body" hx-push-url="true" hx-include="#curriculum-dropdown, #grade-dropdown, #subject-dropdown">
             {{ getName . "en" }}</a></td>
     <td></td>

--- a/web/html/topics.html
+++ b/web/html/topics.html
@@ -1,31 +1,30 @@
 <div>
-    <div class="shadow-md overflow-x-auto" hx-ext="table-sort" data-sort-scope="topics">
-        <table class="min-w-full bg-white">
+    <div class="card overflow-x-auto" hx-ext="table-sort" data-sort-scope="topics">
+        <table class="app-table">
             <thead>
-                <tr class="bg-gray-200 text-gray-600 text-sm">
-                    <th class="py-4 px-6 text-left">
-                        <a href="#" hx-get="/topics?id={{.ChapterID}}" hx-target="#subContent"
+                <tr>
+                    <th>
+                        <a href="#" class="hover:text-accent" hx-get="/topics?id={{.ChapterID}}" hx-target="#subContent"
                             hx-on:click="updateTableSortState('1', 'topics');">
                             Code <i class="fas fa-sort"></i>
                         </a>
                     </th>
-                    <th class="px-6 text-left">
-                        <a href="#" hx-get="/topics?id={{.ChapterID}}" hx-target="#subContent"
+                    <th>
+                        <a href="#" class="hover:text-accent" hx-get="/topics?id={{.ChapterID}}" hx-target="#subContent"
                             hx-on:click="updateTableSortState('2', 'topics');">
                             Name <i class="fas fa-sort"></i>
                         </a>
                     </th>
-                    <th class="px-6 text-center">ICTs</th>
-                    <th class="px-6 text-center">V1 TLP</th>
-                    <th class="px-6 text-center">V2 TLP</th>
-                    <th class="px-6 text-center">Feedbacks</th>
-                    <th class="px-6 text-center">Modules</th>
-                    <th class="px-6 text-center">Status</th>
-                    <th class="px-6 text-center">Actions</th>
+                    <th class="text-center">ICTs</th>
+                    <th class="text-center">V1 TLP</th>
+                    <th class="text-center">V2 TLP</th>
+                    <th class="text-center">Feedbacks</th>
+                    <th class="text-center">Modules</th>
+                    <th class="text-center">Status</th>
+                    <th class="text-center">Actions</th>
                 </tr>
             </thead>
-            <tbody id="topicTableBody" class="text-gray-600 text-sm" hx-get="/api/topics?view=list&id={{.ChapterID}}"
-                hx-trigger="load">
+            <tbody id="topicTableBody" hx-get="/api/topics?view=list&id={{.ChapterID}}" hx-trigger="load">
                 <!-- Rows will be dynamically inserted here -->
             </tbody>
         </table>
@@ -33,8 +32,8 @@
 
     <!-- Form to add new topic -->
     <div class="mt-4">
-        <h4 id="addTopicLink" class="text-sm font-semibold text-blue-500 hover:underline" onclick="toggleForm(event, {{.ChapterID}})">
-            <a href="#">Add New Topic</a>
+        <h4 id="addTopicLink" class="add-new-link" onclick="toggleForm(event, {{.ChapterID}})">
+            <a href="#">+ Add New Topic</a>
         </h4>
     </div>
 </div>

--- a/web/html/update_success.html
+++ b/web/html/update_success.html
@@ -1,4 +1,6 @@
-<div id="message">{{.}} updated successfully! Taking you back to {{.}}s screen</div>
+<div id="message" class="card card-pad-sm bg-success-bg border border-success/30 text-success text-sm">
+    {{.}} updated successfully — taking you back to {{.}}s screen…
+</div>
 
 <script>
     goBackAfterDelay(3000);

--- a/web/static/css/output.css
+++ b/web/static/css/output.css
@@ -23,7 +23,7 @@
   --tw-ring-inset:  ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-color: rgba(173, 47, 47, 0.5);
   --tw-ring-offset-shadow: 0 0 #0000;
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
@@ -77,7 +77,7 @@
   --tw-ring-inset:  ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-color: rgba(173, 47, 47, 0.5);
   --tw-ring-offset-shadow: 0 0 #0000;
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
@@ -124,7 +124,7 @@
   /* 2 */
   border-style: solid;
   /* 2 */
-  border-color: #e5e7eb;
+  border-color: rgba(38, 20, 16, 0.15);
   /* 2 */
 }
 
@@ -154,7 +154,7 @@ html,
   -o-tab-size: 4;
      tab-size: 4;
   /* 3 */
-  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
@@ -243,7 +243,7 @@ code,
 kbd,
 samp,
 pre {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   /* 1 */
   font-feature-settings: normal;
   /* 2 */
@@ -554,6 +554,27 @@ video {
   display: none;
 }
 
+html {
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+  color: #261410;
+  background-color: #f5efe8;
+}
+
+body {
+  min-height: 100vh;
+  --tw-bg-opacity: 1;
+  background-color: rgb(245 239 232 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(38 20 16 / var(--tw-text-opacity));
+}
+
+/* Numeric data — codes, counts, dates, emails — uses a monospace face for a data-rich feel. */
+
+.font-mono,
+    .font-mono * {
+  font-feature-settings: 'tnum' 1, 'lnum' 1;
+}
+
 .\!container {
   width: 100% !important;
 }
@@ -612,6 +633,8 @@ video {
   }
 }
 
+/* --- Nav (top tab bar) ------------------------------------------------ */
+
 .nav {
   margin-bottom: 0px;
   display: flex;
@@ -622,120 +645,109 @@ video {
 
 .nav-tabs {
   border-bottom-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+  border-color: rgba(38, 20, 16, 0.15);
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 250 245 / var(--tw-bg-opacity));
 }
 
 .nav-link {
-  display: block;
+  display: inline-flex;
+  align-items: center;
+  border-bottom-width: 2px;
+  border-color: transparent;
   padding-left: 1rem;
   padding-right: 1rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
   --tw-text-opacity: 1;
-  color: rgb(37 99 235 / var(--tw-text-opacity));
+  color: rgb(104 88 81 / var(--tw-text-opacity));
   text-decoration-line: none;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-duration: 150ms;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.nav-link:focus {
+.nav-link:focus,
+    .nav-link:hover {
+  border-color: rgb(173 47 47 / 0.4);
   --tw-text-opacity: 1;
-  color: rgb(29 78 216 / var(--tw-text-opacity));
-}
-
-.nav-link:hover {
-  --tw-text-opacity: 1;
-  color: rgb(29 78 216 / var(--tw-text-opacity));
+  color: rgb(38 20 16 / var(--tw-text-opacity));
 }
 
 .nav-tabs .nav-link {
   margin-bottom: -1px;
-  border-top-left-radius: 0.375rem;
-  border-top-right-radius: 0.375rem;
-  border-width: 1px;
-  border-color: transparent;
-}
-
-.nav-tabs .nav-link:focus {
-  isolation: isolate;
-  border-top-width: 1px;
-  border-right-width: 1px;
-  border-bottom-width: 1px;
-  border-left-width: 1px;
-  border-top-color: rgb(243 244 246 / var(--tw-border-opacity));
-  border-right-color: rgb(243 244 246 / var(--tw-border-opacity));
-  border-bottom-color: rgb(229 231 235 / var(--tw-border-opacity));
-  --tw-border-opacity: 1;
-  border-left-color: rgb(243 244 246 / var(--tw-border-opacity));
-}
-
-.nav-tabs .nav-link:hover {
-  isolation: isolate;
-  border-top-width: 1px;
-  border-right-width: 1px;
-  border-bottom-width: 1px;
-  border-left-width: 1px;
-  border-top-color: rgb(243 244 246 / var(--tw-border-opacity));
-  border-right-color: rgb(243 244 246 / var(--tw-border-opacity));
-  border-bottom-color: rgb(229 231 235 / var(--tw-border-opacity));
-  --tw-border-opacity: 1;
-  border-left-color: rgb(243 244 246 / var(--tw-border-opacity));
+  border-radius: 0px;
 }
 
 .nav-tabs .nav-link.active {
-  border-width: 1px;
-  border-top-color: rgb(229 231 235 / var(--tw-border-opacity));
-  border-right-color: rgb(229 231 235 / var(--tw-border-opacity));
-  border-bottom-color: rgb(255 255 255 / var(--tw-border-opacity));
+  border-bottom-width: 2px;
   --tw-border-opacity: 1;
-  border-left-color: rgb(229 231 235 / var(--tw-border-opacity));
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  border-color: rgb(173 47 47 / var(--tw-border-opacity));
+  background-color: transparent;
   --tw-text-opacity: 1;
-  color: rgb(75 85 99 / var(--tw-text-opacity));
+  color: rgb(38 20 16 / var(--tw-text-opacity));
 }
 
+/* --- Sub-tabs (used inside chapter / topic detail) ------------------- */
+
 .sub-tab {
+  display: inline-flex;
+  min-height: 40px;
   cursor: pointer;
+  align-items: center;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-color: rgba(38, 20, 16, 0.15);
   --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  background-color: rgb(255 250 245 / var(--tw-bg-opacity));
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
   --tw-text-opacity: 1;
-  color: rgb(75 85 99 / var(--tw-text-opacity));
+  color: rgb(104 88 81 / var(--tw-text-opacity));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
 }
 
-.sub-tab:focus {
-  border-radius: 0.25rem;
+.sub-tab:focus,
+    .sub-tab:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(138 37 37 / var(--tw-border-opacity));
   --tw-bg-opacity: 1;
-  background-color: rgb(248 113 113 / var(--tw-bg-opacity));
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
-.sub-tab:hover {
-  border-radius: 0.25rem;
-  --tw-bg-opacity: 1;
-  background-color: rgb(248 113 113 / var(--tw-bg-opacity));
+  background-color: rgb(138 37 37 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
 .sub-tab.active {
-  border-radius: 0.25rem;
+  --tw-border-opacity: 1;
+  border-color: rgb(173 47 47 / var(--tw-border-opacity));
   --tw-bg-opacity: 1;
-  background-color: rgb(239 68 68 / var(--tw-bg-opacity));
+  background-color: rgb(173 47 47 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+/* --- Row action buttons (pencil, trash, copy, download icons) -------- */
+
 .action-button {
   --tw-text-opacity: 1;
-  color: rgb(59 130 246 / var(--tw-text-opacity));
+  color: rgb(104 88 81 / var(--tw-text-opacity));
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
 }
 
 .action-button:hover {
@@ -743,20 +755,27 @@ video {
   --tw-scale-y: 1.1;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
   --tw-text-opacity: 1;
-  color: rgb(239 68 68 / var(--tw-text-opacity));
+  color: rgb(173 47 47 / var(--tw-text-opacity));
 }
+
+/* --- Chips (filter tags inside inputs) ------------------------------- */
 
 .chip {
   display: inline-block;
-  border-radius: 0.25rem;
+  border-radius: 9999px;
+  border-width: 1px;
+  border-color: rgba(38, 20, 16, 0.15);
   --tw-bg-opacity: 1;
-  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
+  background-color: rgb(243 236 229 / var(--tw-bg-opacity));
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   padding-top: 0.125rem;
   padding-bottom: 0.125rem;
   font-size: 0.75rem;
   line-height: 1rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(38 20 16 / var(--tw-text-opacity));
 }
 
 .chip-box {
@@ -764,10 +783,11 @@ video {
   min-height: 2rem;
   flex-wrap: wrap;
   gap: 0.25rem;
-  border-radius: 0.25rem;
+  border-radius: 0.5rem;
   border-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+  border-color: rgba(38, 20, 16, 0.15);
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
 }
@@ -779,12 +799,33 @@ video {
   outline-offset: 2px;
 }
 
+/* Concept chips (rich-text editor) */
+
+.concept-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(154 196 250 / var(--tw-border-opacity));
+  background-color: rgba(154, 196, 250, 0.15);
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  --tw-text-opacity: 1;
+  color: rgb(38 20 16 / var(--tw-text-opacity));
+}
+
+/* --- Rich-text editor surface --------------------------------------- */
+
 .\!editor {
-  font-family: Arial, sans-serif !important;
+  font-family: 'Inter', system-ui, -apple-system, Arial, sans-serif !important;
 }
 
 .editor {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, Arial, sans-serif;
 }
 
 .\!editor ul {
@@ -811,19 +852,15 @@ video {
 
 .\!editor hr {
   margin: 1rem;
-  border-width: 0px;
   border-top-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(75 85 99 / var(--tw-border-opacity));
+  border-color: rgba(38, 20, 16, 0.15);
 }
 
 .editor hr,
     .output hr {
   margin: 1rem;
-  border-width: 0px;
   border-top-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(75 85 99 / var(--tw-border-opacity));
+  border-color: rgba(38, 20, 16, 0.15);
 }
 
 .editor-fullscreen {
@@ -836,7 +873,7 @@ video {
   width: 100vw;
   flex-direction: column;
   --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  background-color: rgb(255 250 245 / var(--tw-bg-opacity));
 }
 
 .editor-fullscreen #editor {
@@ -844,18 +881,19 @@ video {
   overflow-y: auto;
 }
 
+/* --- MCQ tabs inside the problem editor ----------------------------- */
+
 .mcq-tab {
   position: relative;
   display: flex;
   cursor: pointer;
   align-items: center;
-  border-top-left-radius: 0.25rem;
-  border-top-right-radius: 0.25rem;
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
   border-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+  border-color: rgba(38, 20, 16, 0.15);
   --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  background-color: rgb(255 250 245 / var(--tw-bg-opacity));
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0.25rem;
@@ -866,12 +904,12 @@ video {
   font-size: 0.875rem;
   line-height: 1.25rem;
   --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity));
+  color: rgb(104 88 81 / var(--tw-text-opacity));
 }
 
 .mcq-tab button:hover {
   --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity));
+  color: rgb(173 47 47 / var(--tw-text-opacity));
 }
 
 .mcq-tab-add {
@@ -880,74 +918,501 @@ video {
   width: 2rem;
   align-items: center;
   justify-content: center;
-  border-radius: 0.25rem;
+  border-radius: 0.5rem;
   border-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+  border-color: rgba(38, 20, 16, 0.15);
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 250 245 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity));
+  color: rgb(104 88 81 / var(--tw-text-opacity));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
 }
 
 .mcq-tab-add:hover {
   --tw-bg-opacity: 1;
-  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+  background-color: rgb(243 236 229 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
-  color: rgb(37 99 235 / var(--tw-text-opacity));
+  color: rgb(173 47 47 / var(--tw-text-opacity));
 }
 
 .mcq-tab.active {
-  border-top-width: 1px;
-  border-left-width: 1px;
-  border-right-width: 1px;
   border-bottom-width: 0px;
-  --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
   --tw-bg-opacity: 1;
-  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+  background-color: rgb(243 236 229 / var(--tw-bg-opacity));
 }
 
 .answer-pdf-table-row {
   border-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+  border-color: rgba(38, 20, 16, 0.15);
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
 }
 
-.concept-chip {
-  display: flex;
+/* ====================================================================
+     * Shared "design system" component classes used by the template restyles.
+     * Treat these as the building blocks the af_lms UI Style Guide calls out.
+     * ==================================================================== */
+
+/* --- Buttons -------------------------------------------------------- */
+
+.btn {
+  display: inline-flex;
+  min-height: 44px;
   align-items: center;
-  gap: 0.25rem;
-  border-radius: 0.25rem;
-  --tw-bg-opacity: 1;
-  background-color: rgb(219 234 254 / var(--tw-bg-opacity));
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.btn:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-color: rgb(173 47 47 / 0.4);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.btn-sm {
+  min-height: 36px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.btn-lg {
+  min-height: 48px;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.btn-primary {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.btn-primary:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-color: rgb(173 47 47 / 0.4);
+}
+
+.btn-primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.btn-primary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(173 47 47 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
-  color: rgb(30 64 175 / var(--tw-text-opacity));
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-/* Loader is hidden by default */
+.btn-primary:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(138 37 37 / var(--tw-bg-opacity));
+}
 
-#search-btn-loader {
+.btn-primary:active {
+  --tw-bg-opacity: 1;
+  background-color: rgb(138 37 37 / var(--tw-bg-opacity));
+}
+
+.btn-secondary {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.btn-secondary:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-color: rgb(173 47 47 / 0.4);
+}
+
+.btn-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.btn-secondary {
+  border-width: 2px;
+  border-color: rgba(38, 20, 16, 0.15);
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 250 245 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(38 20 16 / var(--tw-text-opacity));
+}
+
+.btn-secondary:hover {
+  border-color: rgb(173 47 47 / 0.4);
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 236 229 / var(--tw-bg-opacity));
+}
+
+.btn-ghost {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.btn-ghost:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-color: rgb(173 47 47 / 0.4);
+}
+
+.btn-ghost:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.btn-ghost {
+  background-color: transparent;
+  --tw-text-opacity: 1;
+  color: rgb(173 47 47 / var(--tw-text-opacity));
+}
+
+.btn-ghost:hover {
+  background-color: rgba(173, 47, 47, 0.06);
+  --tw-text-opacity: 1;
+  color: rgb(138 37 37 / var(--tw-text-opacity));
+}
+
+/* "Add new <X>" link rendered as a soft accent button. */
+
+.add-new-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  --tw-text-opacity: 1;
+  color: rgb(173 47 47 / var(--tw-text-opacity));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.add-new-link:hover {
+  --tw-text-opacity: 1;
+  color: rgb(138 37 37 / var(--tw-text-opacity));
+}
+
+/* --- Cards / Panels ------------------------------------------------- */
+
+.card {
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-color: rgba(38, 20, 16, 0.15);
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 250 245 / var(--tw-bg-opacity));
+  --tw-shadow: 0 1px 2px 0 rgba(38, 20, 16, 0.05), 0 1px 3px 0 rgba(38, 20, 16, 0.08);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color), 0 1px 3px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.card-pad {
+  padding: 1.5rem;
+}
+
+.card-pad-sm {
+  padding: 1rem;
+}
+
+/* --- Form inputs ---------------------------------------------------- */
+
+.form-input,
+    .form-select {
+  min-height: 44px;
+  width: 100%;
+  border-radius: 0.5rem;
+  border-width: 2px;
+  border-color: rgba(38, 20, 16, 0.15);
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  --tw-text-opacity: 1;
+  color: rgb(38 20 16 / var(--tw-text-opacity));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.form-input::-moz-placeholder, .form-select::-moz-placeholder {
+  color: rgb(104 88 81 / 0.7);
+}
+
+.form-input::placeholder,
+    .form-select::placeholder {
+  color: rgb(104 88 81 / 0.7);
+}
+
+.form-input:focus,
+    .form-select:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(173 47 47 / var(--tw-border-opacity));
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-color: rgb(173 47 47 / 0.2);
+}
+
+.form-input:disabled,
+    .form-select:disabled {
+  cursor: not-allowed;
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 236 229 / var(--tw-bg-opacity));
+}
+
+/* Compact variant used inside the nav bar so dropdowns don't dominate. */
+
+.form-select-compact {
+  height: 2.5rem;
+  min-height: 0px;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-color: rgba(38, 20, 16, 0.15);
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  --tw-text-opacity: 1;
+  color: rgb(38 20 16 / var(--tw-text-opacity));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.form-select-compact:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(173 47 47 / var(--tw-border-opacity));
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-color: rgb(173 47 47 / 0.2);
+}
+
+.form-label {
+  margin-bottom: 0.25rem;
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  --tw-text-opacity: 1;
+  color: rgb(104 88 81 / var(--tw-text-opacity));
+}
+
+/* --- Tables --------------------------------------------------------- */
+
+.app-table {
+  min-width: 100%;
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 250 245 / var(--tw-bg-opacity));
+}
+
+.app-table thead tr {
+  border-bottom-width: 2px;
+  --tw-border-opacity: 1;
+  border-color: rgb(173 47 47 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 236 229 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(104 88 81 / var(--tw-text-opacity));
+}
+
+.app-table th {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  text-align: left;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  --tw-text-opacity: 1;
+  color: rgb(104 88 81 / var(--tw-text-opacity));
+}
+
+.app-table td {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  --tw-text-opacity: 1;
+  color: rgb(38 20 16 / var(--tw-text-opacity));
+}
+
+.app-table tbody tr {
+  border-bottom-width: 1px;
+  border-color: rgba(38, 20, 16, 0.4);
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.app-table tbody tr:hover {
+  background-color: rgba(173, 47, 47, 0.06);
+}
+
+/* --- Badges --------------------------------------------------------- */
+
+/* --- Page chrome ---------------------------------------------------- */
+
+.page-title {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.025em;
+  --tw-text-opacity: 1;
+  color: rgb(38 20 16 / var(--tw-text-opacity));
+}
+
+@media (min-width: 640px) {
+  .page-title {
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+}
+
+.section-title {
+  margin-bottom: 1rem;
+  border-bottom-width: 2px;
+  --tw-border-opacity: 1;
+  border-color: rgb(173 47 47 / var(--tw-border-opacity));
+  padding-bottom: 0.5rem;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  --tw-text-opacity: 1;
+  color: rgb(38 20 16 / var(--tw-text-opacity));
+}
+
+/* HTMX loader visibility helpers ------------------------------------ */
+
+#search-btn-loader,
+    #searched-test-loader,
+    #question-bank-loader,
+    #topic-problems-loader {
   display: none;
 }
 
-/* HTMX makes the loader visible during request */
-
-#search-btn-loader.htmx-request {
-  display: flex;
-}
-
-#searched-test-loader {
-  display: none;
-}
-
-#searched-test-loader.htmx-request {
+#search-btn-loader.htmx-request,
+    #searched-test-loader.htmx-request,
+    #question-bank-loader.htmx-request,
+    #topic-problems-loader.htmx-request {
   display: flex;
 }
 
@@ -955,26 +1420,8 @@ video {
   display: block;
 }
 
-/* Hide results during request */
-
 #searched-test-results.htmx-request {
   display: none;
-}
-
-#question-bank-loader {
-  display: none;
-}
-
-#question-bank-loader.htmx-request {
-  display: flex;
-}
-
-#topic-problems-loader {
-  display: none;
-}
-
-#topic-problems-loader.htmx-request {
-  display: flex;
 }
 
 /* When form is making request */
@@ -1063,27 +1510,25 @@ video {
   z-index: 9999;
 }
 
+.col-span-2 {
+  grid-column: span 2 / span 2;
+}
+
+.col-span-3 {
+  grid-column: span 3 / span 3;
+}
+
+.col-span-5 {
+  grid-column: span 5 / span 5;
+}
+
 .m-5 {
   margin: 1.25rem;
-}
-
-.m-7 {
-  margin: 1.75rem;
-}
-
-.mx-4 {
-  margin-left: 1rem;
-  margin-right: 1rem;
 }
 
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
-}
-
-.my-1 {
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
 }
 
 .my-2 {
@@ -1100,8 +1545,8 @@ video {
   margin-top: -1px;
 }
 
-.mb-1 {
-  margin-bottom: 0.25rem;
+.mb-0 {
+  margin-bottom: 0px;
 }
 
 .mb-2 {
@@ -1122,10 +1567,6 @@ video {
 
 .mb-6 {
   margin-bottom: 1.5rem;
-}
-
-.me-2 {
-  margin-inline-end: 0.5rem;
 }
 
 .ml-1 {
@@ -1156,16 +1597,20 @@ video {
   margin-right: 1rem;
 }
 
-.mr-8 {
-  margin-right: 2rem;
+.mr-6 {
+  margin-right: 1.5rem;
+}
+
+.ms-1 {
+  margin-inline-start: 0.25rem;
+}
+
+.ms-3 {
+  margin-inline-start: 0.75rem;
 }
 
 .ms-4 {
   margin-inline-start: 1rem;
-}
-
-.ms-8 {
-  margin-inline-start: 2rem;
 }
 
 .ms-auto {
@@ -1236,12 +1681,16 @@ video {
   height: 2.5rem;
 }
 
-.h-20 {
-  height: 5rem;
+.h-24 {
+  height: 6rem;
 }
 
 .h-4 {
   height: 1rem;
+}
+
+.h-5 {
+  height: 1.25rem;
 }
 
 .h-52 {
@@ -1276,8 +1725,16 @@ video {
   max-height: 16rem;
 }
 
+.max-h-\[90vh\] {
+  max-height: 90vh;
+}
+
 .min-h-\[44px\] {
   min-height: 44px;
+}
+
+.min-h-screen {
+  min-height: 100vh;
 }
 
 .w-1\/2 {
@@ -1312,20 +1769,24 @@ video {
   width: 10rem;
 }
 
+.w-48 {
+  width: 12rem;
+}
+
+.w-5 {
+  width: 1.25rem;
+}
+
 .w-6 {
   width: 1.5rem;
 }
 
-.w-64 {
-  width: 16rem;
+.w-72 {
+  width: 18rem;
 }
 
 .w-8 {
   width: 2rem;
-}
-
-.w-96 {
-  width: 24rem;
 }
 
 .w-\[19rem\] {
@@ -1348,11 +1809,6 @@ video {
   width: auto;
 }
 
-.w-fit {
-  width: -moz-fit-content;
-  width: fit-content;
-}
-
 .w-full {
   width: 100%;
 }
@@ -1360,10 +1816,6 @@ video {
 .w-max {
   width: -moz-max-content;
   width: max-content;
-}
-
-.min-w-56 {
-  min-width: 14rem;
 }
 
 .min-w-\[100px\] {
@@ -1374,12 +1826,20 @@ video {
   min-width: 120px;
 }
 
-.min-w-\[90px\] {
-  min-width: 90px;
+.min-w-\[140px\] {
+  min-width: 140px;
 }
 
-.min-w-full {
-  min-width: 100%;
+.min-w-\[200px\] {
+  min-width: 200px;
+}
+
+.min-w-\[240px\] {
+  min-width: 240px;
+}
+
+.max-w-2xl {
+  max-width: 42rem;
 }
 
 .max-w-3xl {
@@ -1388,6 +1848,14 @@ video {
 
 .max-w-5xl {
   max-width: 64rem;
+}
+
+.max-w-6xl {
+  max-width: 72rem;
+}
+
+.max-w-\[1600px\] {
+  max-width: 1600px;
 }
 
 .max-w-full {
@@ -1407,6 +1875,10 @@ video {
 }
 
 .flex-shrink-0 {
+  flex-shrink: 0;
+}
+
+.shrink-0 {
   flex-shrink: 0;
 }
 
@@ -1475,6 +1947,10 @@ video {
   grid-template-columns: repeat(10, minmax(0, 1fr));
 }
 
+.grid-cols-12 {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+
 .grid-cols-2 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -1495,10 +1971,6 @@ video {
   grid-template-columns: auto 1fr auto 1fr;
 }
 
-.flex-row {
-  flex-direction: row;
-}
-
 .flex-col {
   flex-direction: column;
 }
@@ -1509,6 +1981,10 @@ video {
 
 .items-start {
   align-items: flex-start;
+}
+
+.items-end {
+  align-items: flex-end;
 }
 
 .items-center {
@@ -1543,6 +2019,10 @@ video {
   gap: 0.5rem;
 }
 
+.gap-3 {
+  gap: 0.75rem;
+}
+
 .gap-4 {
   gap: 1rem;
 }
@@ -1560,10 +2040,12 @@ video {
   row-gap: 0.25rem;
 }
 
-.space-x-2 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-x-reverse: 0;
-  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
-  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
+.gap-y-2 {
+  row-gap: 0.5rem;
+}
+
+.gap-y-3 {
+  row-gap: 0.75rem;
 }
 
 .space-x-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1634,6 +2116,10 @@ video {
   border-radius: 0.5rem;
 }
 
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
 .rounded-b-md {
   border-bottom-right-radius: 0.375rem;
   border-bottom-left-radius: 0.375rem;
@@ -1655,8 +2141,16 @@ video {
   border-bottom-width: 1px;
 }
 
+.border-b-0 {
+  border-bottom-width: 0px;
+}
+
 .border-b-2 {
   border-bottom-width: 2px;
+}
+
+.border-l-4 {
+  border-left-width: 4px;
 }
 
 .border-r {
@@ -1679,14 +2173,27 @@ video {
   border-style: none;
 }
 
+.border-accent {
+  --tw-border-opacity: 1;
+  border-color: rgb(173 47 47 / var(--tw-border-opacity));
+}
+
 .border-black {
   --tw-border-opacity: 1;
   border-color: rgb(0 0 0 / var(--tw-border-opacity));
 }
 
-.border-blue-600 {
+.border-border {
+  border-color: rgba(38, 20, 16, 0.15);
+}
+
+.border-border\/40 {
+  border-color: rgba(38, 20, 16, 0.4);
+}
+
+.border-brand-amber {
   --tw-border-opacity: 1;
-  border-color: rgb(37 99 235 / var(--tw-border-opacity));
+  border-color: rgb(255 183 99 / var(--tw-border-opacity));
 }
 
 .border-gray-200 {
@@ -1699,14 +2206,22 @@ video {
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
 }
 
-.border-gray-400 {
-  --tw-border-opacity: 1;
-  border-color: rgb(156 163 175 / var(--tw-border-opacity));
+.border-success\/30 {
+  border-color: rgb(30 107 75 / 0.3);
 }
 
-.border-white {
+.border-text-on-accent {
   --tw-border-opacity: 1;
   border-color: rgb(255 255 255 / var(--tw-border-opacity));
+}
+
+.border-transparent {
+  border-color: transparent;
+}
+
+.border-warning-border {
+  --tw-border-opacity: 1;
+  border-color: rgb(140 90 29 / var(--tw-border-opacity));
 }
 
 .border-b-gray-300 {
@@ -1714,9 +2229,9 @@ video {
   border-bottom-color: rgb(209 213 219 / var(--tw-border-opacity));
 }
 
-.border-t-blue-600 {
+.border-t-accent {
   --tw-border-opacity: 1;
-  border-top-color: rgb(37 99 235 / var(--tw-border-opacity));
+  border-top-color: rgb(173 47 47 / var(--tw-border-opacity));
 }
 
 .border-t-gray-500 {
@@ -1728,18 +2243,42 @@ video {
   border-top-color: transparent;
 }
 
-.bg-black\/50 {
-  background-color: rgb(0 0 0 / 0.5);
+.bg-accent {
+  --tw-bg-opacity: 1;
+  background-color: rgb(173 47 47 / var(--tw-bg-opacity));
 }
 
-.bg-blue-100 {
+.bg-bg {
   --tw-bg-opacity: 1;
-  background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+  background-color: rgb(245 239 232 / var(--tw-bg-opacity));
 }
 
-.bg-blue-500 {
+.bg-bg-card {
   --tw-bg-opacity: 1;
-  background-color: rgb(59 130 246 / var(--tw-bg-opacity));
+  background-color: rgb(255 250 245 / var(--tw-bg-opacity));
+}
+
+.bg-bg-card-alt {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 236 229 / var(--tw-bg-opacity));
+}
+
+.bg-bg-input {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.bg-brand-blue-bg {
+  background-color: rgba(154, 196, 250, 0.15);
+}
+
+.bg-danger {
+  --tw-bg-opacity: 1;
+  background-color: rgb(173 47 47 / var(--tw-bg-opacity));
+}
+
+.bg-danger-bg {
+  background-color: rgba(173, 47, 47, 0.08);
 }
 
 .bg-gray-100 {
@@ -1752,48 +2291,35 @@ video {
   background-color: rgb(229 231 235 / var(--tw-bg-opacity));
 }
 
-.bg-gray-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
-}
-
 .bg-gray-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity));
 }
 
-.bg-gray-800 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+.bg-ink\/40 {
+  background-color: rgb(38 20 16 / 0.4);
 }
 
-.bg-green-100 {
+.bg-success {
   --tw-bg-opacity: 1;
-  background-color: rgb(220 252 231 / var(--tw-bg-opacity));
+  background-color: rgb(30 107 75 / var(--tw-bg-opacity));
 }
 
-.bg-green-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(34 197 94 / var(--tw-bg-opacity));
+.bg-success-bg {
+  background-color: rgba(30, 107, 75, 0.12);
 }
 
-.bg-red-100 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 226 226 / var(--tw-bg-opacity));
+.bg-transparent {
+  background-color: transparent;
 }
 
-.bg-red-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(239 68 68 / var(--tw-bg-opacity));
+.bg-warning-bg {
+  background-color: rgba(140, 90, 29, 0.08);
 }
 
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
-}
-
-.bg-opacity-50 {
-  --tw-bg-opacity: 0.5;
 }
 
 .p-0 {
@@ -1824,10 +2350,6 @@ video {
   padding: 1.5rem;
 }
 
-.p-8 {
-  padding: 2rem;
-}
-
 .px-2 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
@@ -1848,6 +2370,11 @@ video {
   padding-right: 1.5rem;
 }
 
+.py-0\.5 {
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+}
+
 .py-1 {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
@@ -1858,18 +2385,18 @@ video {
   padding-bottom: 0.5rem;
 }
 
-.py-3 {
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-}
-
 .py-4 {
   padding-top: 1rem;
   padding-bottom: 1rem;
 }
 
-.pb-2 {
-  padding-bottom: 0.5rem;
+.py-6 {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.pb-3 {
+  padding-bottom: 0.75rem;
 }
 
 .pl-11 {
@@ -1886,6 +2413,10 @@ video {
 
 .pr-4 {
   padding-right: 1rem;
+}
+
+.pt-2 {
+  padding-top: 0.5rem;
 }
 
 .pt-4 {
@@ -1908,13 +2439,12 @@ video {
   vertical-align: middle;
 }
 
-.font-sans {
-  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
-.text-2xl {
-  font-size: 1.5rem;
-  line-height: 2rem;
+.font-sans {
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
 }
 
 .text-\[14px\] {
@@ -1936,11 +2466,6 @@ video {
   line-height: 1.25rem;
 }
 
-.text-xl {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
-}
-
 .text-xs {
   font-size: 0.75rem;
   line-height: 1rem;
@@ -1958,6 +2483,10 @@ video {
   font-weight: 600;
 }
 
+.uppercase {
+  text-transform: uppercase;
+}
+
 .capitalize {
   text-transform: capitalize;
 }
@@ -1966,64 +2495,61 @@ video {
   font-style: italic;
 }
 
-.text-black {
-  --tw-text-opacity: 1;
-  color: rgb(0 0 0 / var(--tw-text-opacity));
+.tracking-wide {
+  letter-spacing: 0.025em;
 }
 
-.text-blue-500 {
+.text-accent {
   --tw-text-opacity: 1;
-  color: rgb(59 130 246 / var(--tw-text-opacity));
+  color: rgb(173 47 47 / var(--tw-text-opacity));
 }
 
-.text-blue-600 {
+.text-accent-hover {
   --tw-text-opacity: 1;
-  color: rgb(37 99 235 / var(--tw-text-opacity));
+  color: rgb(138 37 37 / var(--tw-text-opacity));
 }
 
-.text-blue-700 {
+.text-brand-gold {
   --tw-text-opacity: 1;
-  color: rgb(29 78 216 / var(--tw-text-opacity));
+  color: rgb(255 208 99 / var(--tw-text-opacity));
 }
 
-.text-blue-800 {
+.text-danger {
   --tw-text-opacity: 1;
-  color: rgb(30 64 175 / var(--tw-text-opacity));
+  color: rgb(173 47 47 / var(--tw-text-opacity));
 }
 
-.text-gray-300 {
+.text-ink {
   --tw-text-opacity: 1;
-  color: rgb(209 213 219 / var(--tw-text-opacity));
+  color: rgb(38 20 16 / var(--tw-text-opacity));
 }
 
-.text-gray-500 {
+.text-ink-muted {
   --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity));
+  color: rgb(104 88 81 / var(--tw-text-opacity));
 }
 
-.text-gray-600 {
-  --tw-text-opacity: 1;
-  color: rgb(75 85 99 / var(--tw-text-opacity));
+.text-ink-muted\/40 {
+  color: rgb(104 88 81 / 0.4);
 }
 
-.text-gray-700 {
-  --tw-text-opacity: 1;
-  color: rgb(55 65 81 / var(--tw-text-opacity));
+.text-ink-muted\/70 {
+  color: rgb(104 88 81 / 0.7);
 }
 
-.text-green-600 {
+.text-success {
   --tw-text-opacity: 1;
-  color: rgb(22 163 74 / var(--tw-text-opacity));
+  color: rgb(30 107 75 / var(--tw-text-opacity));
 }
 
-.text-red-500 {
+.text-text-on-accent {
   --tw-text-opacity: 1;
-  color: rgb(239 68 68 / var(--tw-text-opacity));
+  color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-.text-red-600 {
+.text-warning {
   --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity));
+  color: rgb(140 90 29 / var(--tw-text-opacity));
 }
 
 .text-white {
@@ -2031,13 +2557,12 @@ video {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-.text-yellow-400 {
-  --tw-text-opacity: 1;
-  color: rgb(250 204 21 / var(--tw-text-opacity));
-}
-
 .underline {
   text-decoration-line: underline;
+}
+
+.accent-accent {
+  accent-color: #ad2f2f;
 }
 
 .opacity-50 {
@@ -2050,15 +2575,21 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.shadow-card {
+  --tw-shadow: 0 1px 2px 0 rgba(38, 20, 16, 0.05), 0 1px 3px 0 rgba(38, 20, 16, 0.08);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color), 0 1px 3px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .shadow-lg {
   --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.shadow-md {
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -2071,15 +2602,18 @@ video {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
-.transition {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
 
-/* Custom styles using @apply */
+/* ===========================================================
+ * Avanti Fellows — Warm Professional
+ * Tokens live in tailwind.config.js (accent/bg/ink/brand/border).
+ * Use the @theme tokens via Tailwind classes in templates;
+ * the @apply rules below keep legacy component classes working.
+ * =========================================================== */
 
 /* Wrap MathJax formulae to next line */
 
@@ -2093,9 +2627,37 @@ mjx-container[jax="CHTML"] mjx-math:has(mjx-mtable) {
   white-space: nowrap !important;
 }
 
-.hover\:bg-blue-100:hover {
+.last\:border-b-0:last-child {
+  border-bottom-width: 0px;
+}
+
+.focus-within\:border-accent:focus-within {
+  --tw-border-opacity: 1;
+  border-color: rgb(173 47 47 / var(--tw-border-opacity));
+}
+
+.focus-within\:ring-2:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\:ring-accent\/20:focus-within {
+  --tw-ring-color: rgb(173 47 47 / 0.2);
+}
+
+.hover\:bg-accent:hover {
   --tw-bg-opacity: 1;
-  background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+  background-color: rgb(173 47 47 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-bg-card-alt:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 236 229 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-bg-hover:hover {
+  background-color: rgba(173, 47, 47, 0.06);
 }
 
 .hover\:bg-blue-400:hover {
@@ -2103,43 +2665,27 @@ mjx-container[jax="CHTML"] mjx-math:has(mjx-mtable) {
   background-color: rgb(96 165 250 / var(--tw-bg-opacity));
 }
 
-.hover\:bg-blue-600:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(37 99 235 / var(--tw-bg-opacity));
-}
-
-.hover\:bg-gray-100:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
-}
-
-.hover\:bg-gray-400:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(156 163 175 / var(--tw-bg-opacity));
+.hover\:bg-brand-blue-bg:hover {
+  background-color: rgba(154, 196, 250, 0.15);
 }
 
 .hover\:font-bold:hover {
   font-weight: 700;
 }
 
-.hover\:text-blue-800:hover {
+.hover\:text-accent:hover {
   --tw-text-opacity: 1;
-  color: rgb(30 64 175 / var(--tw-text-opacity));
+  color: rgb(173 47 47 / var(--tw-text-opacity));
 }
 
-.hover\:text-blue-900:hover {
+.hover\:text-accent-hover:hover {
   --tw-text-opacity: 1;
-  color: rgb(30 58 138 / var(--tw-text-opacity));
+  color: rgb(138 37 37 / var(--tw-text-opacity));
 }
 
-.hover\:text-gray-700:hover {
+.hover\:text-ink:hover {
   --tw-text-opacity: 1;
-  color: rgb(55 65 81 / var(--tw-text-opacity));
-}
-
-.hover\:text-gray-800:hover {
-  --tw-text-opacity: 1;
-  color: rgb(31 41 55 / var(--tw-text-opacity));
+  color: rgb(38 20 16 / var(--tw-text-opacity));
 }
 
 .hover\:underline:hover {
@@ -2150,9 +2696,18 @@ mjx-container[jax="CHTML"] mjx-math:has(mjx-mtable) {
   cursor: not-allowed;
 }
 
-.disabled\:bg-gray-300:disabled {
+.disabled\:bg-bg-card-alt:disabled {
   --tw-bg-opacity: 1;
-  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
+  background-color: rgb(243 236 229 / var(--tw-bg-opacity));
+}
+
+.disabled\:text-ink-muted:disabled {
+  --tw-text-opacity: 1;
+  color: rgb(104 88 81 / var(--tw-text-opacity));
+}
+
+.disabled\:opacity-50:disabled {
+  opacity: 0.5;
 }
 
 .group.htmx-request .group-\[\.htmx-request\]\:inline-flex {
@@ -2163,8 +2718,53 @@ mjx-container[jax="CHTML"] mjx-math:has(mjx-mtable) {
   display: none;
 }
 
+.has-\[\:checked\]\:border-accent:has(:checked) {
+  --tw-border-opacity: 1;
+  border-color: rgb(173 47 47 / var(--tw-border-opacity));
+}
+
+.has-\[\:checked\]\:bg-accent:has(:checked) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(173 47 47 / var(--tw-bg-opacity));
+}
+
+.has-\[\:checked\]\:text-text-on-accent:has(:checked) {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+@media (min-width: 640px) {
+  .sm\:mr-6 {
+    margin-right: 1.5rem;
+  }
+
+  .sm\:ms-6 {
+    margin-inline-start: 1.5rem;
+  }
+
+  .sm\:h-9 {
+    height: 2.25rem;
+  }
+
+  .sm\:px-6 {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 1024px) {
   .lg\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lg\:px-8 {
+    padding-left: 2rem;
+    padding-right: 2rem;
   }
 }

--- a/web/static/css/output.css
+++ b/web/static/css/output.css
@@ -2286,11 +2286,6 @@ body {
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
 }
 
-.bg-gray-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
-}
-
 .bg-gray-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity));
@@ -2658,11 +2653,6 @@ mjx-container[jax="CHTML"] mjx-math:has(mjx-mtable) {
 
 .hover\:bg-bg-hover:hover {
   background-color: rgba(173, 47, 47, 0.06);
-}
-
-.hover\:bg-blue-400:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(96 165 250 / var(--tw-bg-opacity));
 }
 
 .hover\:bg-brand-blue-bg:hover {

--- a/web/static/js/editor-math.js
+++ b/web/static/js/editor-math.js
@@ -2,7 +2,7 @@
 function insertMath(editor) {
     const mathfield = document.createElement('math-field');
 
-    mathfield.setAttribute('style', 'display:inline-block; min-width:9em; border: 1px solid #d1d5db;');
+    mathfield.setAttribute('style', 'display:inline-block; min-width:9em; border: 1px solid rgba(38, 20, 16, 0.15);');
     mathfield.setAttribute('virtual-keyboard-target', '#math-keyboard');
 
     // Insert at caret position

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -158,7 +158,7 @@ document.querySelectorAll('.container').forEach(container => {
     // Create 10x10 grid cells
     for (let i = 1; i <= 100; i++) {
         const cell = document.createElement("div");
-        cell.className = "w-4 h-4 bg-gray-200 hover:bg-blue-400";
+        cell.className = "w-4 h-4 bg-bg-card-alt hover:bg-accent";
         cell.dataset.row = Math.ceil(i / 10);
         cell.dataset.col = i % 10 === 0 ? 10 : i % 10;
 
@@ -180,7 +180,7 @@ document.querySelectorAll('.container').forEach(container => {
             [...gridContainer.children].forEach(cell => {
                 const r = parseInt(cell.dataset.row);
                 const c = parseInt(cell.dataset.col);
-                cell.style.backgroundColor = (r <= selectedRows && c <= selectedCols) ? '#60a5fa' : '#e5e7eb';
+                cell.style.backgroundColor = (r <= selectedRows && c <= selectedCols) ? '#ad2f2f' : '#f3ece5';
             });
         }
     });


### PR DESCRIPTION
## Summary

Adopts the design tokens from the [af_lms UI Style Guide](https://github.com/avantifellows/af_lms/blob/main/docs/UI-Style-Guide.md) — Avanti brand maroon, warm beige page bg, cream cards, brown text, Inter font — so this CMS matches the look of hr-feedback.avantifellows.org and af_lms.

**Foundation**
- `tailwind.config.js` — AF brand palette as design tokens (`accent`, `bg.card`, `ink`, `brand-coral/gold/amber/blue`, semantic `success/warning/danger/info`); Inter as default `font-sans`; bare `border`/`ring` defaults point to brand tints.
- `input.css` — legacy component classes (`.nav-link`, `.sub-tab`, `.action-button`, `.chip`, `.mcq-tab`, `.editor`) reskinned onto tokens. New shared component layer: `.btn-primary/-secondary/-ghost/-danger`, `.card`, `.form-input`/`.form-select`/`.form-label`, `.app-table`, `.badge-*`, `.page-title`, `.add-new-link`.

**Hand-tuned pages**
- `home.html` — Inter, AF CDN logo, cream header card, accent nav.
- `login.html` — cream card on beige bg with logo and semantic alert styles.
- `chapters`/`tests`/`problems` list pages — `.app-table` inside `.card`, brand inputs.
- `chapter`/`topic`/`test`/`problem` detail pages — back as `.btn-ghost`, page-title, mono codes, semantic dividers.
- `admin_users` + row — page-title, card form, `.app-table`, semantic status pills.
- `add_*`/`edit_*` forms — card-wrapped, `.form-label/.form-input/.form-select`, Cancel + Save action bars.
- All modals (add_test, add_concept, move_problems, move_resources, problem_test_association, test_instructions) adopt the elevation-xl modal shell.
- Editor toolbar uses brand tokens.

**Bulk-substituted** stock greys/blues/reds/greens/yellows across the remaining ~50 row and small partials, mapping to brand semantic tokens.

**Intentionally untouched** — PDF templates (`answer_sheet`, `question_paper`, `question_paper_with_answers`, `test_pdf_shared`) print on white paper.

## Test plan

- [ ] \`npm run build:css\` — completes cleanly (verified locally).
- [ ] \`go build ./...\` — passes (verified locally).
- [ ] All 75 templates parse syntactically (verified locally via \`text/template/parse\` with \`SkipFuncCheck\`).
- [ ] Run \`go run ./cmd/server\` locally and walk through:
  - [ ] Login screen renders with logo + cream card on beige bg.
  - [ ] Top nav shows logo, uppercase tabs with maroon active border, dropdowns in compact form-select style, Sign-out as secondary button.
  - [ ] Chapters list: table inside card, accent links, sort icons render.
  - [ ] Tests list: filter dropdown + search both work and look unified.
  - [ ] Problems list: infinite-scroll spinner uses accent color.
  - [ ] Chapter / Topic / Test / Problem detail pages — back button, page-title, content readable, MathJax still renders.
  - [ ] Add Problem: difficulty radio chips toggle, options editor, submit works.
  - [ ] Add Test: left panel card, right form, full create flow.
  - [ ] Move Problems / Move Resources modals open, dropdowns cascade, Move button enables on selection.
  - [ ] Admin → CMS Users: create/list/role-change/deactivate flow.
  - [ ] PDF download for a test still renders on white paper (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)