### PR TITLE
Production release: 🛠️ Fix chapter & topic creation issue after cms_status_id addition for archiving chapter & topic

### DIFF
--- a/internal/models/chapter.go
+++ b/internal/models/chapter.go
@@ -7,7 +7,7 @@ type Chapter struct {
 	CurriculumID int16         `json:"curriculum_id"`
 	GradeID      int8          `json:"grade_id"`
 	SubjectID    int8          `json:"subject_id"`
-	StatusID     int8          `json:"cms_status_id"`
+	StatusID     int8          `json:"cms_status_id,omitempty"`
 	/**
 	 * []*Topic is used instead of []Topic so that updates applied in centrally cached Topic objects
 	 * are also visible inside these Topic objects

--- a/internal/models/topic.go
+++ b/internal/models/topic.go
@@ -6,7 +6,7 @@ type Topic struct {
 	Code         string      `json:"code"`
 	ChapterID    int16       `json:"chapter_id"`
 	CurriculumID int16       `json:"curriculum_id"`
-	StatusID     int8        `json:"cms_status_id"`
+	StatusID     int8        `json:"cms_status_id,omitempty"`
 }
 
 type TopicLang struct {


### PR DESCRIPTION
## 🐞 Issue
Chapter and topic creation was failing after introduction of the new `cms_status_id` column.

The field was being serialized with default value `0`, which is not a valid `cms_status_id`.

## ✅ Fix
Added `omitempty` to `cms_status_id` so the field is excluded from payload when not explicitly set.

## 📌 Impact
- Chapter creation works correctly again
- Topic creation works correctly again
- Prevents invalid `cms_status_id = 0` from being sent

## Note
- Deploying on production directly from this `bugfix` branch instead of `main`, because `main` branch has other changes and this fix is required right now on live so that chapters & topics can be added.