### PR TITLE
ci(prod): mirror staging env vars into deploy-prod; drop obsolete CMS basic-auth

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,8 +21,11 @@ env:
   TF_VAR_repo_branch: ${{ github.ref_name }}
   TF_VAR_db_service_endpoint: ${{ 'https://db.avantifellows.org/api/' }}
   TF_VAR_db_service_token: ${{ secrets.TF_VAR_DB_SERVICE_TOKEN_PROD }}
-  TF_VAR_cms_username: ${{ secrets.TF_VAR_CMS_USERNAME }}
-  TF_VAR_cms_password: ${{ secrets.TF_VAR_CMS_PASSWORD }}
+  TF_VAR_database_url: ${{ secrets.TF_VAR_DATABASE_URL_PROD }}
+  TF_VAR_session_secret: ${{ secrets.TF_VAR_SESSION_SECRET_PROD }}
+  TF_VAR_google_client_id: ${{ secrets.TF_VAR_GOOGLE_CLIENT_ID }}
+  TF_VAR_google_client_secret: ${{ secrets.TF_VAR_GOOGLE_CLIENT_SECRET }}
+  TF_VAR_oauth_redirect_url: ${{ secrets.TF_VAR_OAUTH_REDIRECT_URL_PROD }}
   TF_VAR_instance_type: ${{ 't4g.medium' }}
   TF_VAR_key_pair_name: ${{ secrets.TF_VAR_KEY_PAIR_NAME }}
 


### PR DESCRIPTION
## Why
The prod deploy currently fails at `terraform plan`: the Google-OAuth auth model added **required** Terraform variables (`database_url`, `session_secret`, `google_client_id`, `google_client_secret`, `oauth_redirect_url`) that `deploy-staging.yml` passes but `deploy-prod.yml` never did. It also still passes `TF_VAR_cms_username/password`, which are no longer declared in `terraform/variables.tf` (replaced by OAuth).

## Change
`deploy-prod.yml` env block now mirrors staging, using prod-specific secrets, and drops the obsolete CMS basic-auth vars.

## Secrets (GitHub → repo)
Created as part of this work:
- ✅ `TF_VAR_OAUTH_REDIRECT_URL_PROD` = `https://new-cms.avantifellows.org/auth/google/callback` (derived from the prod subdomain in `main.tf`)
- ✅ `TF_VAR_SESSION_SECRET_PROD` = freshly generated random key

Already existed (shared / prod): `TF_VAR_DB_SERVICE_TOKEN_PROD`, `TF_VAR_GOOGLE_CLIENT_ID`, `TF_VAR_GOOGLE_CLIENT_SECRET`.

## ⚠️ Still required before a prod deploy works
1. **Set `TF_VAR_DATABASE_URL_PROD`** — the prod Postgres DSN (`postgres://user:pass@host:5432/db?sslmode=require`) for `cms_user_permission`. I don't have prod DB creds; set it via repo secrets or `gh secret set TF_VAR_DATABASE_URL_PROD`.
2. **GCP OAuth client** — add `https://new-cms.avantifellows.org/auth/google/callback` to the client's Authorized redirect URIs (manual console step).

## Optional cleanup
The now-unused `TF_VAR_CMS_USERNAME` / `TF_VAR_CMS_PASSWORD` repo secrets can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)