### PR TITLE
Rich-text editor: inline math shortcut, ordered-list types, and image editing

### DIFF
--- a/input.css
+++ b/input.css
@@ -177,9 +177,101 @@
   }
 
   /* --- Rich-text editor surface --------------------------------------- */
+  .editor-wrapper {
+    position: relative; /* anchor for image toolbar & resize overlay */
+  }
+
   .editor {
     font-family: var(--font-sans);
   }
+
+  /* Image — show pointer to hint it's clickable */
+  .editor img { cursor: pointer; }
+  .editor img.img-selected { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+
+  /* Floated image: text beside, then full width below image (clearfix on paragraph) */
+  .editor p.editor-img-float,
+  .output p.editor-img-float {
+    margin: 0.5em 0;
+    overflow: visible;
+  }
+  .editor p.editor-img-float::after,
+  .output p.editor-img-float::after {
+    content: '';
+    display: table;
+    clear: both;
+  }
+  .editor p.editor-img-justify,
+  .output p.editor-img-justify {
+    margin: 0.5em 0;
+  }
+  .editor p.editor-img-justify > img,
+  .output p.editor-img-justify > img {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    margin: 0.5em 0;
+    float: none;
+  }
+
+  /* --- Image editing toolbar (appears above selected image) ----------- */
+  .img-edit-toolbar {
+    display: none;
+    position: absolute;
+    z-index: 200;
+    align-items: center;
+    gap: 2px;
+    padding: 3px 4px;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    box-shadow: var(--shadow-card);
+    white-space: nowrap;
+  }
+  .img-edit-toolbar.active { display: flex; }
+
+  .img-edit-toolbar button {
+    @apply px-2 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg rounded-sm;
+    border: none;
+    cursor: pointer;
+    line-height: 1;
+  }
+  .img-edit-toolbar .img-delete-btn { @apply text-danger hover:bg-danger-bg; }
+
+  .img-edit-sep {
+    display: inline-block;
+    width: 1px;
+    height: 16px;
+    background: var(--color-border);
+    margin: 0 2px;
+    vertical-align: middle;
+  }
+
+  /* --- Resize overlay (border + corner handles) ----------------------- */
+  .img-resize-overlay {
+    display: none;
+    position: absolute;
+    z-index: 199;
+    border: 2px solid var(--color-accent);
+    box-sizing: border-box;
+    pointer-events: none; /* clicks pass through to editor; handles re-enable */
+  }
+  .img-resize-overlay.active { display: block; }
+
+  .img-resize-handle {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background: var(--color-bg-card);
+    border: 2px solid var(--color-accent);
+    border-radius: 2px;
+    box-sizing: border-box;
+    pointer-events: all;
+  }
+  .img-resize-nw { top: -5px; left: -5px;   cursor: nw-resize; }
+  .img-resize-ne { top: -5px; right: -5px;  cursor: ne-resize; }
+  .img-resize-se { bottom: -5px; right: -5px; cursor: se-resize; }
+  .img-resize-sw { bottom: -5px; left: -5px;  cursor: sw-resize; }
   .editor ul,
   .output ul { @apply list-disc ml-6; }
   .editor ol,

--- a/input.css
+++ b/input.css
@@ -184,6 +184,14 @@
   .output ul { @apply list-disc ml-6; }
   .editor ol,
   .output ol { @apply list-decimal ml-6; }
+  .editor ol[data-ol-style="a"],
+  .output ol[data-ol-style="a"] { list-style-type: lower-alpha; }
+  .editor ol[data-ol-style="A"],
+  .output ol[data-ol-style="A"] { list-style-type: upper-alpha; }
+  .editor ol[data-ol-style="i"],
+  .output ol[data-ol-style="i"] { list-style-type: lower-roman; }
+  .editor ol[data-ol-style="I"],
+  .output ol[data-ol-style="I"] { list-style-type: upper-roman; }
   .editor hr,
   .output hr { @apply m-4 border-t border-border; }
   .editor-fullscreen {

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -1083,10 +1083,6 @@
             };
         }
 
-        if (window.initializeRichTextEditors) {
-            window.initializeRichTextEditors(document.querySelector('form.card'));
-        }
-
         function buildProblemJson(topicId, chapterId) {
             const subtype = document.getElementById('problem-type-dropdown').value;
 
@@ -1149,6 +1145,32 @@
                 tags: getTagsForSection(mainTagsRoot),
             });
         }
+
+        // editor.js may still be loading when this inline script runs (common on HTMX body swap)
+        function bootRichTextEditors() {
+            const form = document.querySelector('form.card');
+            if (!form?.querySelector('.container')) return false;
+            if (!window.initializeRichTextEditors) return false;
+            window.initializeRichTextEditors(form);
+            return true;
+        }
+
+        function scheduleEditorBoot() {
+            if (bootRichTextEditors()) return;
+
+            const editorScript = document.querySelector('script[src*="editor.js"]');
+            if (editorScript) {
+                const run = () => { bootRichTextEditors(); };
+                if (window.initializeRichTextEditors) {
+                    run();
+                } else {
+                    editorScript.addEventListener('load', run, { once: true });
+                }
+            } else {
+                requestAnimationFrame(scheduleEditorBoot);
+            }
+        }
+        scheduleEditorBoot();
     })();
 </script>
 {{ end }}

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -707,7 +707,7 @@
 
         function saveCurrentContent() {
             tabContent[activeIndex] = {
-                html: editor.innerHTML,
+                html: getEditorHtml(editor),
                 preview: preview.innerHTML
             };
         }
@@ -804,7 +804,7 @@
             // Edit comprehension: same PATCH body as other types, plus paragraph for the API.
             if (isEditPage && subtype === 'comprehension') {
                 const paragraphEditor = paragraphDiv.querySelector('.editor');
-                const paragraph = paragraphEditor ? paragraphEditor.innerHTML.trim() : '';
+                const paragraph = paragraphEditor ? getEditorHtml(paragraphEditor) : '';
                 payload = { ...payload, paragraph };
             }
 
@@ -968,7 +968,7 @@
 
         function buildComprehensionProblemsPayload(topicId, chapterId) {
             const paragraphEditor = paragraphDiv.querySelector('.editor');
-            const paragraph = paragraphEditor ? paragraphEditor.innerHTML.trim() : '';
+            const paragraph = paragraphEditor ? getEditorHtml(paragraphEditor) : '';
 
             const problems = [];
             problems.push(buildProblemJson(topicId, chapterId));
@@ -998,7 +998,8 @@
 
             const difficulty = problemBlock.querySelector(`input[name="additional-difficulty-${idx}"]:checked`)?.value;
 
-            const question = problemBlock.querySelector('.additional-question .editor')?.innerHTML?.trim() ?? '';
+            const questionEditor = problemBlock.querySelector('.additional-question .editor');
+            const question = questionEditor ? getEditorHtml(questionEditor) : '';
 
             const selectedType = problemBlock.querySelector(`input[name="additional-numType-${idx}"]:checked`)?.value;
             let answers = [];
@@ -1011,7 +1012,8 @@
                 ];
             }
 
-            const solution = problemBlock.querySelector('.additional-solution .editor')?.innerHTML?.trim() ?? '';
+            const solutionEditor = problemBlock.querySelector('.additional-solution .editor');
+            const solution = solutionEditor ? getEditorHtml(solutionEditor) : '';
 
             const tags = getTagsForSection(problemBlock.querySelector('.problem-tags-section'));
 
@@ -1095,7 +1097,7 @@
 
             const difficulty = document.querySelector('input[name="difficulty"]:checked').value;
 
-            const question = document.getElementById('questionDiv').querySelector('.editor').innerHTML.trim();
+            const question = getEditorHtml(document.getElementById('questionDiv').querySelector('.editor'));
 
             let options = null;
             let answers = [];
@@ -1123,7 +1125,7 @@
                 // integer_type
                 answers = [document.getElementById("answerInput").value];
             }
-            const solution = document.getElementById('solutionDiv').querySelector('.editor').innerHTML.trim();
+            const solution = getEditorHtml(document.getElementById('solutionDiv').querySelector('.editor'));
 
             const conceptsDropdown = document.getElementById("concepts-dropdown");
             const selectedConceptIds = Array.from(conceptsDropdown.selectedOptions).map(opt => parseInt(opt.value, 10));

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -1083,6 +1083,10 @@
             };
         }
 
+        if (window.initializeRichTextEditors) {
+            window.initializeRichTextEditors(document.querySelector('form.card'));
+        }
+
         function buildProblemJson(topicId, chapterId) {
             const subtype = document.getElementById('problem-type-dropdown').value;
 

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -60,15 +60,46 @@
                 </label>
             </div>
 
-            <!-- Ordered and Unordered List Buttons -->
-            <div class="flex gap-0 border border-border rounded-sm overflow-hidden">
-                <button title="Unordered List" type="button"
-                    class="ulBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg border-r border-border">
-                    <i class="fas fa-list-ul"></i>
-                </button>
-                <button title="Ordered List" type="button" class="olBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg">
-                    <i class="fas fa-list-ol"></i>
-                </button>
+            <!-- Ordered and Unordered List Buttons + Ordered List Type Dropdown -->
+            <div class="relative shrink-0">
+                <div class="flex gap-0 border border-border rounded-sm overflow-hidden">
+                    <button title="Unordered List" type="button"
+                        class="ulBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg border-r border-border">
+                        <i class="fas fa-list-ul"></i>
+                    </button>
+                    <button title="Ordered List" type="button"
+                        class="olBtn px-3 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg border-r border-border">
+                        <i class="fas fa-list-ol"></i>
+                    </button>
+                    <button title="Ordered List Type" type="button"
+                        class="olTypeDropdownBtn px-2 py-1 text-sm bg-bg-card hover:bg-brand-blue-bg">
+                        <i class="fas fa-caret-down text-xs"></i>
+                    </button>
+                </div>
+
+                <div
+                    class="olTypeDropdownMenu absolute left-0 mt-1 hidden bg-bg-card border border-border rounded-sm shadow-card p-2 grid grid-cols-1 gap-1 w-28 z-50">
+                    <button type="button" data-ol-type="1"
+                        class="px-2 py-1 text-left hover:bg-brand-blue-bg rounded-sm" title="1, 2, 3">
+                        1, 2, 3
+                    </button>
+                    <button type="button" data-ol-type="a"
+                        class="px-2 py-1 text-left hover:bg-brand-blue-bg rounded-sm" title="a, b, c">
+                        a, b, c
+                    </button>
+                    <button type="button" data-ol-type="A"
+                        class="px-2 py-1 text-left hover:bg-brand-blue-bg rounded-sm" title="A, B, C">
+                        A, B, C
+                    </button>
+                    <button type="button" data-ol-type="i"
+                        class="px-2 py-1 text-left hover:bg-brand-blue-bg rounded-sm" title="i, ii, iii">
+                        i, ii, iii
+                    </button>
+                    <button type="button" data-ol-type="I"
+                        class="px-2 py-1 text-left hover:bg-brand-blue-bg rounded-sm" title="I, II, III">
+                        I, II, III
+                    </button>
+                </div>
             </div>
 
             <!-- Paragraph Formatting Dropdown -->

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -208,6 +208,26 @@
         <pre contenteditable="true"
             class="codeView whitespace-pre-wrap text-sm p-2 h-52 bg-bg-card-alt border border-border rounded-sm overflow-y-auto hidden"></pre>
 
+        <!-- Image editing UI (positioned over the editor by JS) -->
+        <div class="img-edit-toolbar" role="toolbar" aria-label="Image options">
+            <button type="button" data-img-align="left" title="Align Left"><i class="fas fa-align-left"></i></button>
+            <button type="button" data-img-align="justify" title="Justify"><i class="fas fa-align-justify"></i></button>
+            <button type="button" data-img-align="right" title="Align Right"><i class="fas fa-align-right"></i></button>
+            <span class="img-edit-sep"></span>
+            <button type="button" data-img-size="25" title="25% width">25%</button>
+            <button type="button" data-img-size="50" title="50% width">50%</button>
+            <button type="button" data-img-size="75" title="75% width">75%</button>
+            <button type="button" data-img-size="100" title="Full width">100%</button>
+            <span class="img-edit-sep"></span>
+            <button type="button" class="img-delete-btn" title="Remove image"><i class="fas fa-trash-alt"></i></button>
+        </div>
+        <div class="img-resize-overlay" aria-hidden="true">
+            <div class="img-resize-handle img-resize-nw" data-dir="nw"></div>
+            <div class="img-resize-handle img-resize-ne" data-dir="ne"></div>
+            <div class="img-resize-handle img-resize-se" data-dir="se"></div>
+            <div class="img-resize-handle img-resize-sw" data-dir="sw"></div>
+        </div>
+
     </div>
 
     <div class="output w-1/2 self-end bg-bg-card-alt border border-border p-2 h-52 overflow-y-auto">

--- a/web/html/test_instructions_modal.html
+++ b/web/html/test_instructions_modal.html
@@ -29,6 +29,13 @@
 </div>
 <script src="/web/static/js/editor.js"></script>
 <script>
+    (function () {
+        const wrapper = document.getElementById("test-instructions-editor-wrapper");
+        if (window.initializeRichTextEditors && wrapper) {
+            window.initializeRichTextEditors(wrapper);
+        }
+    })();
+
     function getCurrentInstructions() {
         const hiddenInput = document.getElementById("test-instructions");
         return hiddenInput?.value || "";

--- a/web/html/test_instructions_modal.html
+++ b/web/html/test_instructions_modal.html
@@ -70,7 +70,7 @@
     function saveInstructionsModal() {
         const hiddenInput = document.getElementById("test-instructions");
         const editor = getInstructionsEditor();
-        hiddenInput.value = editor ? editor.innerHTML.trim() : "";
+        hiddenInput.value = editor ? getEditorHtml(editor) : "";
         closeInstructionsModal();
     }
 </script>

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -215,18 +215,26 @@ function ensureImageBlock(img, editor) {
     return block;
 }
 
+/** Zero-width space lets the caret sit after a floated image; stripped before save. */
+const IMAGE_CARET_MARKER = '\u200B';
+const IMAGE_CARET_MARKER_ENTITY = `&#${IMAGE_CARET_MARKER.charCodeAt(0)};`;
+
 function ensureTextAfterImage(img) {
     const next = img.nextSibling;
     if (next?.nodeType === Node.TEXT_NODE) {
-        if (!next.textContent.includes('\u200B')) {
-            next.textContent = '\u200B' + next.textContent;
+        if (!next.textContent.includes(IMAGE_CARET_MARKER)) {
+            next.textContent = IMAGE_CARET_MARKER + next.textContent;
         }
         return next;
     }
 
-    const textNode = document.createTextNode('\u200B');
+    const textNode = document.createTextNode(IMAGE_CARET_MARKER);
     img.after(textNode);
     return textNode;
+}
+
+function stripImageCaretMarkers(html) {
+    return html.replaceAll(IMAGE_CARET_MARKER, '').replaceAll(IMAGE_CARET_MARKER_ENTITY, '');
 }
 
 function placeCaretAfterImage(img) {

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -6,23 +6,288 @@ function insertImage(event, editor) {
     reader.onload = function (e) {
         const img = document.createElement('img');
         img.src = e.target.result;
-        img.style.maxWidth = '100%';
-        img.style.display = 'block';
-        img.style.margin = '0.5em 0';
 
         const range = window.getSelection().getRangeAt(0);
-        range.insertNode(img);
-        range.setStartAfter(img);
-        range.setEndAfter(img);
+        const block = buildFloatBlock(img, 'left', editor);
+        applyImageSize(img, 100);
 
-        const selection = window.getSelection();
-        selection.removeAllRanges();
-        selection.addRange(range);
+        range.insertNode(block);
+        placeCaretAfterImage(img);
 
-        renderMath(editor); // let preview show images too
+        renderMath(editor);
     };
     reader.readAsDataURL(file);
 
-    // Reset input so same file can be selected again
     event.target.value = '';
+}
+
+function initImageEditing(editor, editorWrapper) {
+    const imgToolbar = editorWrapper.querySelector('.img-edit-toolbar');
+    const resizeOverlay = editorWrapper.querySelector('.img-resize-overlay');
+    if (!imgToolbar || !resizeOverlay) return;
+
+    let selectedImg = null;
+
+    function positionUI(img) {
+        const wRect = editorWrapper.getBoundingClientRect();
+        const iRect = img.getBoundingClientRect();
+
+        resizeOverlay.style.top    = (iRect.top - wRect.top) + 'px';
+        resizeOverlay.style.left   = (iRect.left - wRect.left) + 'px';
+        resizeOverlay.style.width  = iRect.width + 'px';
+        resizeOverlay.style.height = iRect.height + 'px';
+
+        const toolbarH = imgToolbar.offsetHeight || 32;
+        const top = iRect.top - wRect.top;
+        const toolbarTop = top - toolbarH - 4;
+        imgToolbar.style.top  = (toolbarTop < 0 ? top + iRect.height + 4 : toolbarTop) + 'px';
+        imgToolbar.style.left = (iRect.left - wRect.left) + 'px';
+    }
+
+    function selectImage(img) {
+        selectedImg = img;
+        img.classList.add('img-selected');
+        resizeOverlay.classList.add('active');
+        imgToolbar.classList.add('active');
+        positionUI(img);
+    }
+
+    function deselectImage() {
+        if (selectedImg) selectedImg.classList.remove('img-selected');
+        selectedImg = null;
+        resizeOverlay.classList.remove('active');
+        imgToolbar.classList.remove('active');
+    }
+
+    editor.addEventListener('click', (e) => {
+        if (e.target.tagName === 'IMG') {
+            selectImage(e.target);
+        } else {
+            deselectImage();
+        }
+    });
+
+    editor.addEventListener('mousedown', (e) => {
+        if (e.target.tagName === 'IMG') return;
+
+        for (const img of editor.querySelectorAll('img')) {
+            const float = img.style.float;
+            if (float !== 'left' && float !== 'right') continue;
+
+            const rect = img.getBoundingClientRect();
+            const besideVertically = e.clientY >= rect.top && e.clientY <= rect.bottom;
+            const besideLeft  = float === 'right' && e.clientX < rect.left;
+            const besideRight = float === 'left' && e.clientX > rect.right;
+
+            if (besideVertically && (besideLeft || besideRight)) {
+                placeCaretAfterImage(img);
+                e.preventDefault();
+                return;
+            }
+        }
+    });
+
+    editor.addEventListener('scroll', () => {
+        if (selectedImg) positionUI(selectedImg);
+    });
+
+    imgToolbar.addEventListener('mousedown', (e) => e.preventDefault());
+    imgToolbar.addEventListener('click', (e) => {
+        if (!selectedImg) return;
+        const btn = e.target.closest('button');
+        if (!btn) return;
+
+        if (btn.dataset.imgAlign) {
+            applyImageAlign(selectedImg, btn.dataset.imgAlign, editor);
+        } else if (btn.dataset.imgSize) {
+            applyImageSize(selectedImg, parseInt(btn.dataset.imgSize));
+        } else if (btn.classList.contains('img-delete-btn')) {
+            const block = getImageBlock(selectedImg);
+            if (block) block.remove();
+            else selectedImg.remove();
+            deselectImage();
+            renderMath(editor);
+            return;
+        }
+
+        requestAnimationFrame(() => {
+            if (selectedImg) positionUI(selectedImg);
+        });
+    });
+
+    resizeOverlay.addEventListener('mousedown', (e) => {
+        const handle = e.target.closest('.img-resize-handle');
+        if (!handle || !selectedImg) return;
+        e.preventDefault();
+
+        const dir = handle.dataset.dir;
+        const startX = e.clientX;
+        const startW = selectedImg.getBoundingClientRect().width;
+
+        const onMouseMove = (ev) => {
+            const dx = ev.clientX - startX;
+            const newW = Math.max(30, dir.includes('e') ? startW + dx : startW - dx);
+            selectedImg.style.width = newW + 'px';
+            selectedImg.style.maxWidth = newW + 'px';
+            selectedImg.style.height = 'auto';
+            positionUI(selectedImg);
+        };
+
+        const onMouseUp = () => {
+            window.removeEventListener('mousemove', onMouseMove);
+            window.removeEventListener('mouseup', onMouseUp);
+        };
+
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('mouseup', onMouseUp);
+    });
+
+    const closeScope = editorWrapper.closest('form') || editorWrapper.closest('#content') || editorWrapper;
+    closeScope.addEventListener('click', (e) => {
+        if (!editorWrapper.contains(e.target)) {
+            deselectImage();
+        }
+    });
+}
+
+function getImageBlock(img) {
+    return img.closest('.editor-img-float, .editor-img-row, .editor-img-justify');
+}
+
+/** Unwrap legacy flex span so text flows naturally in the paragraph. */
+function flattenTextSpan(block) {
+    const span = block.querySelector('.editor-img-text');
+    if (!span) return;
+
+    while (span.firstChild) {
+        block.insertBefore(span.firstChild, span);
+    }
+    span.remove();
+    block.classList.remove('editor-img-row', 'editor-img-left', 'editor-img-right');
+    block.style.display = '';
+    block.style.flexDirection = '';
+}
+
+function buildFloatBlock(img, align, editor) {
+    const block = document.createElement('p');
+    block.className = 'editor-img-float';
+    block.classList.add(align === 'right' ? 'editor-img-right' : 'editor-img-left');
+
+    const parent = img.parentElement;
+    if (parent && parent !== block) {
+        parent.insertBefore(block, img);
+        block.appendChild(img);
+        if (parent !== editor && parent.childNodes.length === 0 && parent.tagName === 'P') {
+            parent.remove();
+        }
+    } else {
+        block.appendChild(img);
+    }
+
+    applyFloatStyles(img, align);
+    ensureTextAfterImage(img);
+    return block;
+}
+
+function ensureImageBlock(img, editor) {
+    let block = getImageBlock(img);
+    if (block) {
+        flattenTextSpan(block);
+        return block;
+    }
+
+    block = document.createElement('p');
+    block.className = 'editor-img-float';
+    block.style.margin = '0.5em 0';
+
+    const parent = img.parentElement;
+    if (parent === editor) {
+        editor.insertBefore(block, img);
+        block.appendChild(img);
+    } else if (parent) {
+        parent.insertBefore(block, img);
+        block.appendChild(img);
+        if (parent !== editor && parent.childNodes.length === 0 && parent.tagName === 'P') {
+            parent.remove();
+        }
+    }
+
+    return block;
+}
+
+function ensureTextAfterImage(img) {
+    const next = img.nextSibling;
+    if (next?.nodeType === Node.TEXT_NODE) {
+        if (!next.textContent.includes('\u200B')) {
+            next.textContent = '\u200B' + next.textContent;
+        }
+        return next;
+    }
+
+    const textNode = document.createTextNode('\u200B');
+    img.after(textNode);
+    return textNode;
+}
+
+function placeCaretAfterImage(img) {
+    const textNode = ensureTextAfterImage(img);
+    const offset = Math.max(textNode.textContent.length, 1);
+    const range = document.createRange();
+    const sel = window.getSelection();
+    range.setStart(textNode, Math.min(offset, textNode.textContent.length));
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+function applyFloatStyles(img, align) {
+    img.style.flexBasis = '';
+    img.style.display = 'block';
+
+    if (align === 'left') {
+        img.style.float = 'left';
+        img.style.margin = '0 0.75em 0.5em 0';
+    } else if (align === 'right') {
+        img.style.float = 'right';
+        img.style.margin = '0 0 0.5em 0.75em';
+    }
+}
+
+function applyImageAlign(img, align, editor) {
+    if (align === 'justify') {
+        let block = getImageBlock(img);
+        flattenTextSpan(block || img.parentElement);
+
+        if (!block || !block.classList.contains('editor-img-justify')) {
+            block = ensureImageBlock(img, editor);
+            block.className = 'editor-img-justify';
+            block.style.margin = '0.5em 0';
+        }
+
+        img.style.float = 'none';
+        img.style.width = '100%';
+        img.style.maxWidth = '100%';
+        img.style.display = 'block';
+        img.style.margin = '0.5em 0';
+        return;
+    }
+
+    const block = buildFloatBlock(img, align, editor);
+    block.className = 'editor-img-float';
+    block.classList.toggle('editor-img-left', align === 'left');
+    block.classList.toggle('editor-img-right', align === 'right');
+
+    if (!img.style.width) {
+        applyImageSize(img, 100);
+    }
+
+    applyFloatStyles(img, align);
+    placeCaretAfterImage(img);
+}
+
+function applyImageSize(img, percent) {
+    img.style.width = percent + '%';
+    img.style.maxWidth = percent + '%';
+    img.style.height = 'auto';
+    img.style.flexBasis = '';
 }

--- a/web/static/js/editor-math.js
+++ b/web/static/js/editor-math.js
@@ -1,3 +1,36 @@
+// Insert \( \) delimiters at the cursor so LaTeX can be typed directly.
+function insertInlineMathDelimiters(editor) {
+    const selection = window.getSelection();
+    if (!selection.rangeCount) return;
+
+    const range = selection.getRangeAt(0);
+    const open = '\\(';
+    const close = '\\)';
+
+    if (!range.collapsed) {
+        const textNode = document.createTextNode(open + range.toString() + close);
+        range.deleteContents();
+        range.insertNode(textNode);
+
+        const after = document.createRange();
+        after.setStartAfter(textNode);
+        after.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(after);
+    } else {
+        const textNode = document.createTextNode(open + close);
+        range.insertNode(textNode);
+
+        const inside = document.createRange();
+        inside.setStart(textNode, open.length);
+        inside.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(inside);
+    }
+
+    renderMath(editor);
+}
+
 // Insert an editable inline math field at the cursor
 function insertMath(editor) {
     const mathfield = document.createElement('math-field');

--- a/web/static/js/editor-math.js
+++ b/web/static/js/editor-math.js
@@ -71,5 +71,7 @@ function renderMath(editor) {
     const container = editor.closest('.container');
     const output = container.querySelector('.output');
     output.innerHTML = editor.innerHTML;
-    MathJax.typesetPromise([output]);
+    if (window.MathJax?.typesetPromise) {
+        MathJax.typesetPromise([output]).catch(console.error);
+    }
 }

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -1,3 +1,12 @@
+function getEditorHtml(editor) {
+    let html = editor.innerHTML;
+    if (typeof stripImageCaretMarkers === 'function') {
+        html = stripImageCaretMarkers(html);
+    }
+    return html.trim();
+}
+window.getEditorHtml = getEditorHtml;
+
 window.initializeRichTextEditors = function (root = document) {
     root.querySelectorAll('.container').forEach(container => {
     if (container.dataset.editorInitialized === 'true') return;
@@ -478,7 +487,7 @@ window.initializeRichTextEditors = function (root = document) {
 
     function toggleCodeView() {
         if (codeView.classList.contains("hidden")) {
-            codeView.textContent = formatHTML(editor.innerHTML); // Show formatted HTML
+            codeView.textContent = formatHTML(getEditorHtml(editor)); // Show formatted HTML
             codeView.classList.remove("hidden");
             editor.classList.add("hidden");
         } else {

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -365,8 +365,18 @@ window.initializeRichTextEditors = function (root = document) {
         return result.trim();
     }
 
-    toolbar.querySelector('.mathBtn').addEventListener('click', (event) => {
-        insertMath(editor, event);
+    toolbar.querySelector('.mathBtn').addEventListener('click', () => {
+        insertMath(editor);
+    });
+
+    editor.addEventListener('keydown', (e) => {
+        if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'h') {
+            e.preventDefault();
+            const selection = window.getSelection();
+            if (!selection.rangeCount) return;
+            if (!editor.contains(selection.anchorNode)) return;
+            insertInlineMathDelimiters(editor);
+        }
     });
 });
 };

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -1,17 +1,21 @@
 window.initializeRichTextEditors = function (root = document) {
     root.querySelectorAll('.container').forEach(container => {
     if (container.dataset.editorInitialized === 'true') return;
-    container.dataset.editorInitialized = 'true';
 
+    try {
     const editorWrapper = container.querySelector(".editor-wrapper");
     const output = container.querySelector('.output');
 
     const editor = editorWrapper.querySelector(".editor");
 
     // for edit problem screen update preview on opening page itself, because content must already be there in editor
-    const latex = editor.innerHTML;
-    if (latex) {
-        renderMath(editor);
+    const latex = editor.innerHTML.trim();
+    if (latex && typeof renderMath === 'function') {
+        try {
+            renderMath(editor);
+        } catch (err) {
+            console.error('Editor preview render failed', err);
+        }
     }
 
     // listener to display preview
@@ -67,18 +71,54 @@ window.initializeRichTextEditors = function (root = document) {
 
     function saveSelection() {
         const sel = window.getSelection();
-        if (sel.rangeCount > 0) {
+        if (sel.rangeCount > 0 && editor.contains(sel.anchorNode)) {
             savedRange = sel.getRangeAt(0);
         }
     }
 
-    function restoreSelection() {
-        if (savedRange) {
-            const sel = window.getSelection();
+    function ensureSelectionInEditor() {
+        const sel = window.getSelection();
+        if (!sel) return;
+
+        // If we already have a saved range inside this editor, use it.
+        if (
+            savedRange &&
+            editor.contains(savedRange.commonAncestorContainer)
+        ) {
             sel.removeAllRanges();
             sel.addRange(savedRange);
+            editor.focus();
+            return;
         }
+
+        // Otherwise, force a caret at the end of this editor so toolbar actions
+        // always apply to the correct editor instance.
+        const range = document.createRange();
+        range.selectNodeContents(editor);
+        range.collapse(false);
+        savedRange = range;
+        sel.removeAllRanges();
+        sel.addRange(range);
+        editor.focus();
     }
+
+    function restoreSelection() {
+        ensureSelectionInEditor();
+    }
+
+    function execCommandInEditor(command, value = null) {
+        restoreSelection();
+        return document.execCommand(command, false, value);
+    }
+
+    // Keep focus/selection in the editor when using toolbar buttons
+    toolbar.addEventListener('mousedown', (e) => {
+        if (e.target.closest('input[type="color"], input[type="file"], select')) return;
+        if (e.target.closest('button, label.foreColorLabel, label.backColorLabel')) {
+            saveSelection();
+            e.preventDefault();
+        }
+    });
 
     toolbar.querySelector('.foreColor').addEventListener('input', function () {
         restoreSelection();
@@ -90,13 +130,110 @@ window.initializeRichTextEditors = function (root = document) {
         document.execCommand('hiliteColor', false, this.value);
     });
 
+    // Keep selection saved as user moves caret in editor (toolbar clicks steal focus)
+    editor.addEventListener('keyup', saveSelection);
+    editor.addEventListener('mouseup', saveSelection);
+    editor.addEventListener('touchend', saveSelection);
+
     toolbar.querySelector(".ulBtn").addEventListener("click", function () {
-        document.execCommand("insertUnorderedList", false, null);
+        execCommandInEditor("insertUnorderedList");
     });
 
-    toolbar.querySelector(".olBtn").addEventListener("click", function () {
+    let activeOrderedListType = '1';
+
+    function closestElement(node, tagName) {
+        if (!node) return null;
+        const upper = tagName.toUpperCase();
+        let cur = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+        while (cur) {
+            if (cur.tagName === upper) return cur;
+            cur = cur.parentElement;
+        }
+        return null;
+    }
+
+    function getActiveOrderedList() {
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0) return null;
+        const anchor = sel.anchorNode;
+        if (!anchor || !editor.contains(anchor)) return null;
+        return closestElement(anchor, 'ol');
+    }
+
+    const ORDERED_LIST_STYLES = {
+        '1': null,
+        'a': 'lower-alpha',
+        'A': 'upper-alpha',
+        'i': 'lower-roman',
+        'I': 'upper-roman',
+    };
+
+    function setTypeOnOl(ol, type) {
+        if (!ol) return;
+        const listStyleType = ORDERED_LIST_STYLES[type];
+        if (!listStyleType) {
+            ol.removeAttribute('type');
+            ol.removeAttribute('data-ol-style');
+            ol.style.removeProperty('list-style-type');
+            return;
+        }
+        // Browsers normalize <ol type="a"> to type="A" in the DOM, so use data-ol-style + inline style.
+        ol.setAttribute('data-ol-style', type);
+        ol.style.listStyleType = listStyleType;
+        ol.setAttribute('type', type);
+    }
+
+    function applyOrderedListType(type, { ensureList = false } = {}) {
+        if (!type) return;
+        activeOrderedListType = type;
+
+        let ol = getActiveOrderedList();
+        if (!ol && ensureList) {
+            execCommandInEditor("insertOrderedList");
+            ol = getActiveOrderedList();
+        }
+        if (!ol) return;
+
+        setTypeOnOl(ol, type);
+    }
+
+    const olBtn = toolbar.querySelector(".olBtn");
+    olBtn.addEventListener("click", function () {
+        restoreSelection();
+        const wasInOl = !!getActiveOrderedList();
         document.execCommand("insertOrderedList", false, null);
+
+        // If toggled off ("unlist"), don't recreate the list by applying subtype.
+        const nowInOl = !!getActiveOrderedList();
+        if (!wasInOl && nowInOl && activeOrderedListType && activeOrderedListType !== '1') {
+            applyOrderedListType(activeOrderedListType, { ensureList: false });
+        } else if (wasInOl && nowInOl && activeOrderedListType && activeOrderedListType !== '1') {
+            applyOrderedListType(activeOrderedListType, { ensureList: false });
+        }
     });
+
+    const olTypeDropdownBtn = toolbar.querySelector('.olTypeDropdownBtn');
+    const olTypeDropdownMenu = toolbar.querySelector('.olTypeDropdownMenu');
+
+    if (olTypeDropdownBtn && olTypeDropdownMenu) {
+        // Save selection before focus moves to toolbar
+        olTypeDropdownBtn.addEventListener('mousedown', saveSelection);
+
+        olTypeDropdownBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            olTypeDropdownMenu.classList.toggle('hidden');
+        });
+
+        olTypeDropdownMenu.querySelectorAll('button[data-ol-type]').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                restoreSelection();
+                applyOrderedListType(btn.dataset.olType, { ensureList: true });
+                olTypeDropdownMenu.classList.add('hidden');
+            });
+        });
+    }
 
     const dropdownBtn = toolbar.querySelector('.paragraphDropdownBtn');
     const dropdownMenu = toolbar.querySelector('.paragraphDropdownMenu');
@@ -108,9 +245,33 @@ window.initializeRichTextEditors = function (root = document) {
 
     dropdownMenu.querySelectorAll('button[data-cmd]').forEach(btn => {
         btn.addEventListener('click', () => {
-            document.execCommand(btn.dataset.cmd);
+            execCommandInEditor(btn.dataset.cmd);
             dropdownMenu.classList.add('hidden');
         });
+    });
+
+    function closeToolbarMenus() {
+        dropdownMenu.classList.add('hidden');
+        if (olTypeDropdownMenu) olTypeDropdownMenu.classList.add('hidden');
+    }
+
+    // Close dropdowns when clicking outside this editor within the page form/content area
+    const menuCloseScope = container.closest('form') || container.closest('#content') || container;
+    menuCloseScope.addEventListener('click', (e) => {
+        if (!container.contains(e.target)) {
+            closeToolbarMenus();
+            return;
+        }
+        if (!toolbar.contains(e.target)) {
+            closeToolbarMenus();
+            return;
+        }
+        if (olTypeDropdownMenu && !olTypeDropdownMenu.contains(e.target) && !olTypeDropdownBtn?.contains(e.target)) {
+            olTypeDropdownMenu.classList.add('hidden');
+        }
+        if (!dropdownMenu.contains(e.target) && !dropdownBtn.contains(e.target)) {
+            dropdownMenu.classList.add('hidden');
+        }
     });
 
     toolbar.querySelector('.lineHeightSelector').addEventListener('change', function () {
@@ -378,7 +539,10 @@ window.initializeRichTextEditors = function (root = document) {
             insertInlineMathDelimiters(editor);
         }
     });
-});
-};
 
-window.initializeRichTextEditors();
+    container.dataset.editorInitialized = 'true';
+    } catch (err) {
+        console.error('Failed to initialize rich text editor', err);
+    }
+    });
+};

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -426,6 +426,10 @@ window.initializeRichTextEditors = function (root = document) {
         insertImage(event, editor);
     });
 
+    if (typeof initImageEditing === 'function') {
+        initImageEditing(editor, editorWrapper);
+    }
+
     const fullscreenBtn = toolbar.querySelector(".fullscreenBtn");
     let isFullscreen = false;
     let isPreviewVisible = true;


### PR DESCRIPTION
## Summary

Merges `feat/editor-requirements` into `main` with three editor enhancements for problem/content authoring:

### 1. Inline math delimiters (`b866c137`)
- **Ctrl+Shift+H** inserts `\(` `\)` at the caret (or wraps the current selection).
- New `insertInlineMathDelimiters()` in `editor-math.js`; caret lands inside delimiters for empty selection.
- Triggers MathJax preview render after insert.

### 2. Ordered lists & editor fixes (`405cdf8f`)
- **Ordered list subtypes** via toolbar dropdown: decimal (1, 2, 3), lower/upper alpha, lower/upper roman.
- Uses `data-ol-style` + `list-style-type` so browsers don’t normalize `type="a"` incorrectly.
- **Unlist toggle**: clicking ordered list again removes the list without re-applying the last subtype.
- Selection handling improved (`keyup` / `mouseup` / `touchend`) so toolbar commands apply at the saved caret.
- OL, UL apply to the **correct editor**: When **multiple** editors exist on the same page

### 3. Inline image editing (`953ed4aa`)
- Floating **image toolbar** on select: align left / justify (full width) / align right, width presets (25–100%), delete.
- **Resize handles** on selected images; caret placement beside floated images.
- New `editor-image.js`; markup in `editor.html`; styles in `input.css` (rebuilt `output.css`); wired from `editor.js`.

## Scope note

`main` has moved ahead since this branch was cut. Rebase or merge latest `main` before merging if CI or conflicts appear.

## Test plan

- [x] **Math shortcut**: In any editor field, Ctrl+Shift+H with and without selection; preview shows rendered math.
- [x] **Ordered lists**: Create list, switch subtypes (a, A, i, I); toggle OL off (unlist).
- [x] **Unordered list** still works independently.
- [x] **Images**: Upload image, select it, try align left/right/justify, size presets, corner resize, delete.
- [x] **Add/Edit Problem**: Paragraph, question, solutions, and dynamic option editors all initialize and save HTML correctly.
- [ ] Save/reload content: list styles, math delimiters, and image layout persist in stored HTML.