### PR TITLE
Production release: ci(prod): mirror staging env vars into deploy-prod; drop obsolete CMS basic-auth

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,8 +21,11 @@ env:
   TF_VAR_repo_branch: ${{ github.ref_name }}
   TF_VAR_db_service_endpoint: ${{ 'https://db.avantifellows.org/api/' }}
   TF_VAR_db_service_token: ${{ secrets.TF_VAR_DB_SERVICE_TOKEN_PROD }}
-  TF_VAR_cms_username: ${{ secrets.TF_VAR_CMS_USERNAME }}
-  TF_VAR_cms_password: ${{ secrets.TF_VAR_CMS_PASSWORD }}
+  TF_VAR_database_url: ${{ secrets.TF_VAR_DATABASE_URL_PROD }}
+  TF_VAR_session_secret: ${{ secrets.TF_VAR_SESSION_SECRET_PROD }}
+  TF_VAR_google_client_id: ${{ secrets.TF_VAR_GOOGLE_CLIENT_ID }}
+  TF_VAR_google_client_secret: ${{ secrets.TF_VAR_GOOGLE_CLIENT_SECRET }}
+  TF_VAR_oauth_redirect_url: ${{ secrets.TF_VAR_OAUTH_REDIRECT_URL_PROD }}
   TF_VAR_instance_type: ${{ 't4g.medium' }}
   TF_VAR_key_pair_name: ${{ secrets.TF_VAR_KEY_PAIR_NAME }}
 


### PR DESCRIPTION
Includes following PR:
[ci(prod): mirror staging env vars into deploy-prod; drop obsolete CMS basic-auth](https://github.com/avantifellows/nex-gen-cms/pull/108)