### PR TITLE
Fix test PDF download issues: large HTML load, white background, and MathJax timing

### DIFF
--- a/context_for_ai/PROJECT_OVERVIEW.md
+++ b/context_for_ai/PROJECT_OVERVIEW.md
@@ -214,7 +214,7 @@ DTOs:
 
 - Renders template (`question_paper.html` or `answer_sheet.html`) to an HTML string.
 - Inlines Tailwind CSS by reading `web/static/css/output.css` and injecting a `<style>` tag.
-- Navigates a headless Chrome page to `data:text/html,<html>` and ensures MathJax completes typesetting.
+- Loads HTML into headless Chrome via `about:blank` and `Page.setDocumentContent` (avoids Chrome's ~2MB `data:` URL limit for large papers), then ensures MathJax completes typesetting.
 - Prints to A4 PDF with custom header/footer and margins; streams the PDF as the HTTP response.
 
 

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/avantifellows/nex-gen-cms/internal/views"
 	"github.com/avantifellows/nex-gen-cms/utils"
 	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 	"github.com/thoas/go-funk"
 )
@@ -994,23 +995,33 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 			}
 			return page.SetDocumentContent(tree.Frame.ID, htmlContent).Do(ctx)
 		}),
-		// Wait for MathJax to finish rendering
-		chromedp.ActionFunc(func(ctx context.Context) error {
-			for i := 0; i < 100; i++ {
-				var doneText string
-				chromedp.Evaluate(`document.getElementById('mathjax-done') ? document.getElementById('mathjax-done').textContent : ''`, &doneText).Do(ctx)
+		// Wait for deferred scripts (e.g. MathJax CDN) before polling typeset completion.
+		chromedp.Evaluate(`new Promise(resolve => {
+			if (document.readyState === 'complete') resolve();
+			else window.addEventListener('load', resolve, {once: true});
+		})`, nil, evalAwaitPromise),
 
+		// mathjax-done is set in pageReady after defaultPageReady() (initial typeset) finishes.
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			const maxPolls = 500
+			for i := 0; i < maxPolls; i++ {
+				var doneText string
+				if err := chromedp.Evaluate(`document.getElementById('mathjax-done') ? document.getElementById('mathjax-done').textContent : ''`, &doneText).Do(ctx); err != nil {
+					return err
+				}
 				if doneText == "true" {
 					return nil
 				}
 				time.Sleep(100 * time.Millisecond)
 			}
-			log.Printf("MathJax timeout after 100 polls (pdf type=%s)", pdfType)
-			return nil // timeout, proceed anyway
+			return fmt.Errorf("MathJax typeset did not complete within %ds (pdf type=%s)", maxPolls/10, pdfType)
 		}),
 
-		// Wait for fonts/rendering to complete
-		chromedp.Sleep(500 * time.Millisecond),
+		// Flush web fonts and layout after MathJax mutates the DOM.
+		chromedp.Evaluate(`(async () => {
+			await document.fonts.ready;
+			await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+		})()`, nil, evalAwaitPromise),
 
 		// Generate PDF using CDP low-level API
 		chromedp.ActionFunc(func(ctx context.Context) error {
@@ -1052,6 +1063,10 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 	responseWriter.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s - %s.pdf"`,
 		selectedTestPtr.GetNameByLang("en"), pdfSuffix))
 	_, _ = responseWriter.Write(pdfData)
+}
+
+func evalAwaitPromise(p *runtime.EvaluateParams) *runtime.EvaluateParams {
+	return p.WithAwaitPromise(true)
 }
 
 func optionLabels() []string {

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -935,7 +935,9 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 		http.Error(responseWriter, "CSS read error: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	htmlContent = strings.Replace(htmlContent, "</head>", "<style>"+string(cssBytes)+"</style></head>", 1)
+	// output.css sets html/body to the app warm beige; question papers need a white page.
+	pdfPageStyle := `<style>html,body{background:#fff!important;background-color:#fff!important;min-height:auto!important}</style>`
+	htmlContent = strings.Replace(htmlContent, "</head>", "<style>"+string(cssBytes)+"</style>"+pdfPageStyle+"</head>", 1)
 
 	headerHTML := fmt.Sprintf(`
 		<div style="width:100%%; font-size:12px; font-family:Arial; text-align:center; padding:0 40px;">
@@ -980,10 +982,18 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 
 	var pdfData []byte
 
+	// Load HTML via CDP SetDocumentContent instead of a data: URL. Chrome aborts navigation
+	// (net::ERR_ABORTED) when the encoded data URL exceeds ~2MB;
 	tasks := chromedp.Tasks{
+		chromedp.Navigate("about:blank"),
 		// Set page content
-		chromedp.Navigate("data:text/html," + url.PathEscape(htmlContent)),
-
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			tree, err := page.GetFrameTree().Do(ctx)
+			if err != nil {
+				return fmt.Errorf("get frame tree: %w", err)
+			}
+			return page.SetDocumentContent(tree.Frame.ID, htmlContent).Do(ctx)
+		}),
 		// Wait for MathJax to finish rendering
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			for i := 0; i < 100; i++ {
@@ -995,7 +1005,7 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 				}
 				time.Sleep(100 * time.Millisecond)
 			}
-			log.Printf("MathJax timeout after 100 polls")
+			log.Printf("MathJax timeout after 100 polls (pdf type=%s)", pdfType)
 			return nil // timeout, proceed anyway
 		}),
 

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -2,9 +2,10 @@
 <script>
 window.MathJax = {
   startup: {
-    ready: () => {
-      MathJax.startup.defaultReady();
-      document.getElementById('mathjax-done').textContent = 'true';
+    pageReady: () => {
+      return MathJax.startup.defaultPageReady().then(() => {
+        document.getElementById('mathjax-done').textContent = 'true';
+      });
     }
   },
   chtml: {


### PR DESCRIPTION
## Summary

Fixes unreliable PDF generation majorly happening for `type=questions_with_answers` (combined question paper with answers) and improves rendering logic for all test PDF downloads.

- **Large combined PDFs** — Replaces `data:text/html,...` navigation with `about:blank` + `Page.setDocumentContent` so Chrome no longer aborts navigation (`net::ERR_ABORTED`) when the encoded URL exceeds ~2MB.
- **Page background** — Overrides inlined `output.css` global `html`/`body` warm beige so printed papers use a white background.
- **First-download rendering** — Waits for MathJax to finish initial typesetting (not just script load), then flushes fonts/layout before `PrintToPDF`, so MCQ options and math render correctly on cold CDN loads.

## Problem

| Issue | Cause |
|-------|--------|
| Combined PDF fails immediately | `questions_with_answers` HTML (~2.2MB data URL) exceeds Chrome’s navigation limit; `questions` (~1.1MB) still works |
| PDF page looks beige | Inlined Tailwind applies app `bg-bg` (`#f5efe8`) to `html`/`body` |
| First download incomplete; second OK | `mathjax-done` was set in `startup.ready` before typesetting; fixed 500ms sleep was too short on first MathJax CDN fetch |

## Changes

- `internal/handlers/test_handler.go` — `SetDocumentContent` load path, white page style injection, `window` `load` + MathJax poll (up to 50s) + `document.fonts.ready` before print
- `web/html/test_pdf_shared.html` — Signal PDF readiness in `pageReady` after `defaultPageReady()` completes
- `context_for_ai/PROJECT_OVERVIEW.md` — Document PDF load approach

## Test plan

- [x] Download **Question Paper** (`type=questions`) for a test with ~25 problems — PDF succeeds, white background, math/options visible on **first** download
- [x] Download **Question Paper with Answers** (`type=questions_with_answers`) for the same test — no `ERR_ABORTED`, full content on **first** download (no retry needed)
- [x] Download **Answer Sheet** (`type=answers`) — still works as before
- [x] Open combined PDF: verify MCQ option grids, MathJax equations, answer/solution blocks, header/footer
- [ ] (Optional) Test on EC2/Playwright Chromium path if applicable