### PR TITLE
Correct multi-curriculum topic filtering and chapter count refresh

### DIFF
--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -64,6 +64,10 @@ func (h *ChaptersHandler) GetChapters(responseWriter http.ResponseWriter, reques
 		return c.StatusID != constants.StatusArchived
 	}).([]*models.Chapter)
 
+	for _, chapterPtr := range *chapters {
+		chapterPtr.CurriculumID = curriculumId
+	}
+
 	h.getTopics(responseWriter, *chapters)
 
 	sortColumn := urlVals.Get("sortColumn")
@@ -112,7 +116,8 @@ func associateTopicsWithChapters(chapterPtrs []*models.Chapter, topicPtrs []*mod
 
 	// Loop through each topic and assign it to the corresponding chapter
 	for _, topicPtr := range topicPtrs {
-		if chapterPtr, exists := chapterPtrsMap[topicPtr.ChapterID]; exists {
+		if chapterPtr, exists := chapterPtrsMap[topicPtr.ChapterID]; exists &&
+			topicPtr.HasCurriculumID(chapterPtr.CurriculumID) {
 			chapterPtr.Topics = append(chapterPtr.Topics, topicPtr)
 		}
 	}
@@ -344,15 +349,20 @@ func (h *ChaptersHandler) GetTopics(responseWriter http.ResponseWriter, request 
 		}
 		return
 	}
-	if len(selectedChapterPtr.Topics) == 0 {
-		h.getTopics(responseWriter, []*models.Chapter{selectedChapterPtr})
+	// Use a local copy so we never mutate the cached chapter pointer.
+	localChapter := *selectedChapterPtr
+	localChapter.Topics = nil
+	curriculumId, _, _ := getCurriculumGradeSubjectIds(urlVals)
+	if curriculumId != 0 {
+		localChapter.CurriculumID = curriculumId
 	}
+	h.getTopics(responseWriter, []*models.Chapter{&localChapter})
 
 	sortColumn := urlVals.Get("sortColumn")
 	sortOrder := urlVals.Get("sortOrder")
-	sortTopics(selectedChapterPtr.Topics, sortColumn, sortOrder)
+	sortTopics(localChapter.Topics, sortColumn, sortOrder)
 
-	views.ExecuteTemplate(filename, responseWriter, selectedChapterPtr.Topics, template.FuncMap{
+	views.ExecuteTemplate(filename, responseWriter, localChapter.Topics, template.FuncMap{
 		"getName": getTopicName,
 	})
 }

--- a/internal/handlers/topic_handler.go
+++ b/internal/handlers/topic_handler.go
@@ -72,6 +72,11 @@ func (h *TopicsHandler) AddTopic(responseWriter http.ResponseWriter, request *ht
 		http.Error(responseWriter, fmt.Sprintf("Error adding topic: %v", err), http.StatusInternalServerError)
 		return
 	}
+	// The POST response may include curriculums from all curricula the topic belongs to.
+	// AddObject appended this to the cache alongside the existing GET-cached entry for the
+	// same topic, creating a duplicate. Invalidate so the next read fetches a clean list.
+	h.service.InvalidateCache(handlerutils.TopicsKey)
+	newTopicPtr.NormalizeCurriculums()
 
 	topicPtrs := []*models.Topic{newTopicPtr}
 	views.ExecuteTemplate(topicRowTemplate, responseWriter, topicPtrs, template.FuncMap{

--- a/internal/models/topic.go
+++ b/internal/models/topic.go
@@ -1,12 +1,19 @@
 package models
 
 type Topic struct {
-	ID           int16       `json:"id"`
-	Name         []TopicLang `json:"name"`
-	Code         string      `json:"code"`
-	ChapterID    int16       `json:"chapter_id"`
-	CurriculumID int16       `json:"curriculum_id"`
-	StatusID     int8        `json:"cms_status_id,omitempty"`
+	ID           int16             `json:"id"`
+	Name         []TopicLang       `json:"name"`
+	Code         string            `json:"code"`
+	ChapterID    int16             `json:"chapter_id"`
+	CurriculumID int16             `json:"curriculum_id,omitempty"` // create API only
+	Curriculums  []TopicCurriculum `json:"curriculums,omitempty"`   // get API only
+	StatusID     int8              `json:"cms_status_id,omitempty"`
+}
+
+type TopicCurriculum struct {
+	Priority     *int16  `json:"priority"`
+	CurriculumID int16   `json:"curriculum_id"`
+	PriorityText *string `json:"priority_text"`
 }
 
 type TopicLang struct {
@@ -21,6 +28,27 @@ func NewTopic(code string, name string, chapter_id int16, curriculum_id int16) *
 		ChapterID:    chapter_id,
 		CurriculumID: curriculum_id,
 	}
+}
+
+// NormalizeCurriculums fills Curriculums from CurriculumID when the create API
+// response omits the curriculums array (GET responses include curriculums).
+func (t *Topic) NormalizeCurriculums() {
+	if len(t.Curriculums) > 0 {
+		return
+	}
+	if t.CurriculumID != 0 {
+		t.Curriculums = []TopicCurriculum{{CurriculumID: t.CurriculumID}}
+	}
+}
+
+func (t *Topic) HasCurriculumID(curriculumID int16) bool {
+	t.NormalizeCurriculums()
+	for _, curriculum := range t.Curriculums {
+		if curriculum.CurriculumID == curriculumID {
+			return true
+		}
+	}
+	return false
 }
 
 func (topicPtr *Topic) BuildMap(code string, name string) map[string]any {

--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -135,6 +135,10 @@ func (s *Service[T]) AddObject(body any, cacheKey string, urlEndPoint string) (*
 	return objPtr, nil
 }
 
+func (s *Service[T]) InvalidateCache(cacheKey string) {
+	s.cacheRepository.Delete(cacheKey)
+}
+
 func (s *Service[T]) DeleteObject(objIdStr string, objKeepingPredicate func(*T) bool, cacheKey string,
 	urlEndPoint string) error {
 	_, err := s.apiRepository.CallAPI(urlEndPoint+"/"+objIdStr, http.MethodDelete, nil)

--- a/web/html/add_concept_modal.html
+++ b/web/html/add_concept_modal.html
@@ -64,7 +64,7 @@
                     <!-- Topic -->
                     <select id="topic-dropdown" name="topic_id"
                             class="form-select w-40" hx-get="/api/topics?view=dropdown" 
-                            hx-trigger="change from:#chapter-dropdown" hx-include="#chapter-dropdown"
+                            hx-trigger="change from:#chapter-dropdown" hx-include="#chapter-dropdown, #curriculum-dropdown"
                             hx-on::before-request="beforeTopicsRequest();">
                         <option disabled selected>Select a chapter first</option>
                     </select>

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -435,7 +435,8 @@
                 return Promise.resolve(topicsOptionsHtml);
             }
 
-            return fetchText(`/api/topics?view=dropdown&chapter-dropdown=${encodeURIComponent(currentChapterId)}`)
+            const curriculumId = document.getElementById('curriculum-dropdown')?.value || '';
+            return fetchText(`/api/topics?view=dropdown&chapter-dropdown=${encodeURIComponent(currentChapterId)}&curriculum-dropdown=${encodeURIComponent(curriculumId)}`)
                 .then(html => {
                     topicsOptionsHtml = getUnselectedOptionsHtml(html);
                     return topicsOptionsHtml;

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -75,7 +75,7 @@
                     </select>
                     <select id="topic-dropdown" name="topic-dropdown" hx-ext="cascade-clear" class="form-select"
                         hx-get="/api/topics?view=dropdown" hx-trigger="change from:#chapter-dropdown"
-                        hx-include="#chapter-dropdown" onchange="if (this.value) sessionStorage.setItem('selectedTopic', this.value);"
+                        hx-include="#chapter-dropdown, #curriculum-dropdown" onchange="if (this.value) sessionStorage.setItem('selectedTopic', this.value);"
                         hx-on::after-request="onDropdownLoaded(this, 'selectedTopic')">
                         <option value="">Select Topic</option>
                     </select>

--- a/web/html/add_topic.html
+++ b/web/html/add_topic.html
@@ -1,8 +1,7 @@
 <!-- Form to add new topic -->
 <form id="addTopicForm" class="card card-pad-sm mt-3 flex flex-wrap items-end gap-3"
-    hx-post="/create-topic?chapter_id={{.}}" hx-target="#topicTableBody"
-    hx-swap="beforeend" hx-include="#curriculum-dropdown"
-    hx-on::after-request="if(event.detail.successful) this.reset()">
+    hx-post="/create-topic?chapter_id={{.}}" hx-swap="none" hx-include="#curriculum-dropdown"
+    hx-on::after-request="if(event.detail.successful) { this.reset(); sessionStorage.setItem(window.CHAPTERS_LOADED_KEY, 'false'); document.body.dispatchEvent(new Event('topicAdded')); }">
     <div>
         <label class="form-label" for="add-topic-code">Code</label>
         <input id="add-topic-code" type="text" name="code" placeholder="Topic code" class="form-input w-48 font-mono">

--- a/web/html/move_problems_modal.html
+++ b/web/html/move_problems_modal.html
@@ -53,7 +53,7 @@
                 <select id="topic-dropdown" name="topic_id" class="form-select"
                         hx-get="/api/topics?view=dropdown" hx-trigger="change from:#chapter-dropdown"
                         hx-target="this" hx-swap="innerHTML" onchange="toggleMoveButton()" 
-                        hx-include="#chapter-dropdown" hx-on::after-swap="toggleMoveButton()"
+                        hx-include="#chapter-dropdown, #curriculum-dropdown" hx-on::after-swap="toggleMoveButton()"
                         hx-on::before-request="beforeMoveProblemsTopicsRequest()"
                         hx-on::after-request="toggleMoveButton()">
                     <option value="" disabled selected>Select a chapter first</option>

--- a/web/html/move_resources_modal.html
+++ b/web/html/move_resources_modal.html
@@ -41,7 +41,7 @@
 
                 <select id="topic-dropdown" name="topic_id" class="form-select"
                     hx-get="/api/topics?view=dropdown-optional" hx-trigger="change from:#chapter-dropdown"
-                    hx-target="this" hx-swap="innerHTML" hx-include="#chapter-dropdown"
+                    hx-target="this" hx-swap="innerHTML" hx-include="#chapter-dropdown, #curriculum-dropdown"
                     hx-on::before-request="beforeMoveResourcesTopicsRequest()" hx-on::after-request="toggleMoveResourceButton()">
                     <option value="" selected hidden>Select Topic (Optional)</option>
                 </select>

--- a/web/html/topics.html
+++ b/web/html/topics.html
@@ -24,7 +24,9 @@
                     <th class="text-center">Actions</th>
                 </tr>
             </thead>
-            <tbody id="topicTableBody" hx-get="/api/topics?view=list&id={{.ChapterID}}" hx-trigger="load">
+            <tbody id="topicTableBody" hx-get="/api/topics?view=list&id={{.ChapterID}}"
+                hx-trigger="load, topicAdded from:body"
+                hx-include="#curriculum-dropdown, #grade-dropdown, #subject-dropdown">
                 <!-- Rows will be dynamically inserted here -->
             </tbody>
         </table>


### PR DESCRIPTION
## Summary

The GET topic API now returns a `curriculums` array (one entry per curriculum the topic belongs to), while POST/PATCH still accept a single `curriculum_id`. This PR updates the CMS to handle that contract and fixes the resulting filtering, caching, and UI refresh bugs.

## Changes

### Model (`internal/models/topic.go`)
- Add `Curriculums []TopicCurriculum` field (populated from GET responses) alongside the existing `CurriculumID int16` field (used only for POST/PATCH).
- Add `TopicCurriculum` struct (`curriculum_id`, `priority`, `priority_text`).
- Add `NormalizeCurriculums()` — backfills `Curriculums` from `CurriculumID` for topics returned by the create API (which omits the array).
- Add `HasCurriculumID(id)` — checks curriculum membership, calling `NormalizeCurriculums` first to handle both response shapes uniformly.

### Chapter handler (`internal/handlers/chapter_handler.go`)
- `GetChapters`: stamp each fetched chapter with its `CurriculumID` from the URL params before topic association, so the filter has the right context.
- `associateTopicsWithChapters`: use `HasCurriculumID` instead of a direct equality check to support the multi-curriculum array.
- `GetTopics`: work on a **local copy** of the cached chapter struct so the per-request `CurriculumID` override never mutates the shared cache pointer.

### Topic handler (`internal/handlers/topic_handler.go`)
- After `AddObject` succeeds, call `InvalidateCache` on the topics key. The POST response includes all curricula the topic belongs to, so `AddObject`'s blind append would create a duplicate entry next to the existing GET-cached record for the same topic — causing it to appear in every curriculum it matches. Invalidating forces a clean API fetch on the next read.
- Call `NormalizeCurriculums` on the returned pointer so the row rendered in the immediate response has its `Curriculums` slice populated.

### Service (`internal/services/service.go`)
- Add `InvalidateCache(cacheKey)` to expose cache eviction to handlers.

### Templates
- `web/html/add_topic.html`: on successful create, reset `CHAPTERS_LOADED_KEY` in `sessionStorage` (so the `chaptersLoader` extension re-fetches chapter rows and their topic counts on next visit) and dispatch a `topicAdded` event on `document.body`.
- `web/html/topics.html`: add `hx-include` for the three filter dropdowns on the topic table body so `GetTopics` always receives the active curriculum/grade/subject; add `topicAdded from:body` to `hx-trigger` so the table reloads reliably after a topic is created.

## Test plan
- [x] Add a topic to chapter X under curriculum C2. Verify it appears immediately in the topic list under C2.
- [x] Go back to the chapter list (C2). Verify the topic count for chapter X is now 1, not 0.
- [x] Switch the curriculum dropdown to C1. Verify chapter X shows only the C1 topic(s) and the newly created C2 topic does not appear.
- [x] Switch back to C2. Verify only the C2 topic is shown.
- [x] Add a topic that already exists in C1 to C2 as well. Verify it appears in both C1 and C2 topic lists (each showing it once, not duplicated).
- [x] Refresh the page and verify counts and topic lists remain correct after a hard reload (no cache).