### PR TITLE
🐛 Surface actual errors when saving problems

### DIFF
--- a/internal/repositories/remote/api_repository.go
+++ b/internal/repositories/remote/api_repository.go
@@ -61,15 +61,17 @@ func (r *APIRepository) CallAPI(urlEndPoint string, method string, body any) ([]
 	}
 	defer resp.Body.Close()
 
-	// Check for non-2xx status codes
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("received non-success status code: %d", resp.StatusCode)
-	}
-
-	// Read the response body
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response: %v", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyStr := string(bodyBytes)
+		if bodyStr != "" {
+			return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, bodyStr)
+		}
+		return nil, fmt.Errorf("received non-success status code: %d", resp.StatusCode)
 	}
 
 	return bodyBytes, nil

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -454,13 +454,18 @@
             });
         }
 
-        function fetchText(url) {
-            return fetch(url).then(res => {
+        function readResponseOrThrow(res) {
+            return res.text().then(text => {
                 if (!res.ok) {
-                    throw new Error(`HTTP error! status: ${res.status}`);
+                    const detail = text.trim();
+                    throw new Error(detail || `Request failed (HTTP ${res.status})`);
                 }
-                return res.text();
+                return text;
             });
+        }
+
+        function fetchText(url) {
+            return fetch(url).then(readResponseOrThrow);
         }
 
         function getUnselectedOptionsHtml(html) {
@@ -821,20 +826,16 @@
                     'HX-Request': 'true'  // so that your server can detect HTMX if needed
                 }
 
-            }).then(res => {
-                if (!res.ok) {
-                    // Turn HTTP error into a real JS error to trigger .catch
-                    throw new Error(`HTTP error! status: ${res.status}`);
-                }
-                return res.text(); // if OK, read body
-
-            }).then(html => {
+            }).then(readResponseOrThrow).then(() => {
                 // go back to remove add/edit problem screen
                 goBackAfterDelay(0);
 
             }).catch(err => {
                 console.error("Error during problem creation:", err);
-                alert("There was an error while saving the problem.");
+                const message = err && err.message
+                    ? err.message
+                    : "There was an error while saving the problem.";
+                alert(message);
                 toggleButton(saveBtn, false, 'Save');
             });
         };


### PR DESCRIPTION
## Summary
- 🔍 **Problem save failures were opaque in production** — users only saw a generic “There was an error while saving the problem.” alert, which made debugging hard.
- 🛠️ **API repository now includes db-service error bodies** — non-2xx responses from db-service are returned with status code and response text (e.g. `API error (status 422): {...}`).
- 💬 **Add/edit problem screen shows the real server message** — save failures read the response body and display it in the alert instead of a fixed fallback.

## Changes
- `internal/repositories/remote/api_repository.go` — read response body before checking status; include body in error when present
- `web/html/add_problem.html` — add `readResponseOrThrow()` helper; use it for save and related fetches; alert `err.message` on failure

## Test plan
- [x] Create a problem successfully — should still save and navigate back as before
- [x] Edit an existing problem successfully — same behavior
- [x] Trigger a save failure (e.g. invalid payload or db-service validation error) — alert should show the server error text, not only a generic message
- [x] Confirm browser console still logs the full error for debugging