### PR TITLE
🐛 Fix intermittent panic when saving problems (cache miss in UpdateObject)

### DIFF
--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -107,8 +107,10 @@ func (s *Service[T]) UpdateObject(objIdStr string, urlEndPoint string, body any,
 	// Update in cache
 	list, _ := s.GetList(urlEndPoint, cacheKey, true, false)
 	if list != nil {
-		selectedObjPtr := funk.Find(*list, objFindingPredicate).(*T)
-		*selectedObjPtr = *objPtr
+		if found := funk.Find(*list, objFindingPredicate); found != nil {
+			selectedObjPtr := found.(*T)
+			*selectedObjPtr = *objPtr
+		}
 	}
 
 	return objPtr, nil


### PR DESCRIPTION
## Summary

- 🛠️ Guard `UpdateObject` cache sync when `funk.Find` returns no match, instead of type-asserting `nil`
- 💥 Fixes production panic: `interface conversion: interface {} is nil, not *models.Problem` during problem save
- ✅ API update already succeeded before cache sync; on cache miss we now skip the in-memory update and leave existing cache entries untouched

## Root cause

After a successful PATCH, `UpdateObject` tried to update the matching item in the in-memory `"problems"` cache. When the cached list existed but did not include the problem being saved (e.g. cache populated from a different view or multiple people/browser instances), `funk.Find` returned `nil` and the `.(*T)` assertion panicked.

View/edit still worked because `GetObject` falls back to the API on a cache miss; only save hit this path.

## Test plan

- [x] Open a test, view a problem, edit, and save — should succeed without panic
- [x] Browse topic problems, then edit/save a problem not in that cached list (using multiple tabs with different test opened) — should succeed
- [x] Confirm problem updates persist after save (reload problem view)