### PR TITLE
✨ Surface db-service errors when saving tests and block user from creating new test with existing test's code

### DIFF
--- a/internal/handlers/handlerutils/api_error_util.go
+++ b/internal/handlers/handlerutils/api_error_util.go
@@ -1,0 +1,45 @@
+package handlerutils
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	remote_repo "github.com/avantifellows/nex-gen-cms/internal/repositories/remote"
+)
+
+// WriteRemoteAPIError writes a client-safe error response for db-service failures.
+func WriteRemoteAPIError(w http.ResponseWriter, fallbackMessage string, err error) {
+	var apiErr *remote_repo.APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode >= 400 && apiErr.StatusCode < 500 {
+		msg := remoteErrorMessage(apiErr.Body, fallbackMessage)
+		http.Error(w, msg, apiErr.StatusCode)
+		return
+	}
+
+	http.Error(w, fmt.Sprintf("%s: %v", fallbackMessage, err), http.StatusInternalServerError)
+}
+
+func remoteErrorMessage(body string, fallback string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return fallback
+	}
+
+	var parsed struct {
+		Errors struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		return body
+	}
+
+	if msg := strings.TrimSpace(parsed.Errors.Message); msg != "" {
+		return msg
+	}
+
+	return body
+}

--- a/internal/handlers/handlerutils/api_error_util_test.go
+++ b/internal/handlers/handlerutils/api_error_util_test.go
@@ -1,0 +1,70 @@
+package handlerutils
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	remote_repo "github.com/avantifellows/nex-gen-cms/internal/repositories/remote"
+)
+
+func TestWriteRemoteAPIErrorPassesThroughClientError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	err := &remote_repo.APIError{
+		StatusCode: http.StatusUnprocessableEntity,
+		Body:       "This test code has already been used.",
+	}
+
+	WriteRemoteAPIError(rec, "Error adding test", err)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnprocessableEntity)
+	}
+	if body := rec.Body.String(); body != "This test code has already been used.\n" {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestWriteRemoteAPIErrorExtractsErrorsMessage(t *testing.T) {
+	rec := httptest.NewRecorder()
+	err := &remote_repo.APIError{
+		StatusCode: http.StatusUnprocessableEntity,
+		Body: `{
+			"errors": {
+				"message": "This test code has already been used.",
+				"detail": "Unprocessable Entity"
+			}
+		}`,
+	}
+
+	WriteRemoteAPIError(rec, "Error adding test", err)
+
+	if body := rec.Body.String(); body != "This test code has already been used.\n" {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestWriteRemoteAPIErrorUsesInternalServerErrorForUpstreamFailures(t *testing.T) {
+	rec := httptest.NewRecorder()
+	err := &remote_repo.APIError{
+		StatusCode: http.StatusBadGateway,
+		Body:       "upstream unavailable",
+	}
+
+	WriteRemoteAPIError(rec, "Error adding test", err)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestWriteRemoteAPIErrorUsesInternalServerErrorForNonAPIErrors(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	WriteRemoteAPIError(rec, "Error adding test", errors.New("network timeout"))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -638,7 +638,7 @@ func (h *TestsHandler) CreateTest(responseWriter http.ResponseWriter, request *h
 
 	_, err = h.testsService.AddObject(testObj, testsKey, resourcesEndPoint)
 	if err != nil {
-		http.Error(responseWriter, fmt.Sprintf("Error adding test: %v", err), http.StatusInternalServerError)
+		handlerutils.WriteRemoteAPIError(responseWriter, "Error adding test", err)
 		return
 	}
 }
@@ -714,7 +714,7 @@ func (h *TestsHandler) UpdateTest(responseWriter http.ResponseWriter, request *h
 			return (*test).ID == testId
 		})
 	if err != nil {
-		http.Error(responseWriter, fmt.Sprintf("Error updating test: %v", err), http.StatusInternalServerError)
+		handlerutils.WriteRemoteAPIError(responseWriter, "Error updating test", err)
 		return
 	}
 }

--- a/internal/repositories/remote/api_error.go
+++ b/internal/repositories/remote/api_error.go
@@ -9,8 +9,5 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	if e.Body != "" {
-		return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Body)
-	}
 	return fmt.Sprintf("received non-success status code: %d", e.StatusCode)
 }

--- a/internal/repositories/remote/api_error.go
+++ b/internal/repositories/remote/api_error.go
@@ -1,0 +1,16 @@
+package remote_repo
+
+import "fmt"
+
+// APIError represents a non-success response from db-service.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	if e.Body != "" {
+		return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Body)
+	}
+	return fmt.Sprintf("received non-success status code: %d", e.StatusCode)
+}

--- a/internal/repositories/remote/api_repository.go
+++ b/internal/repositories/remote/api_repository.go
@@ -61,15 +61,18 @@ func (r *APIRepository) CallAPI(urlEndPoint string, method string, body any) ([]
 	}
 	defer resp.Body.Close()
 
-	// Check for non-2xx status codes
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("received non-success status code: %d", resp.StatusCode)
-	}
-
 	// Read the response body
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response: %v", err)
+	}
+
+	// Check for non-2xx status codes
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &APIError{
+			StatusCode: resp.StatusCode,
+			Body:       string(bodyBytes),
+		}
 	}
 
 	return bodyBytes, nil

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -894,6 +894,16 @@
         document.getElementById("total-marks").textContent = totalMarks;
     }
 
+    function readResponseOrThrow(res) {
+        return res.text().then(text => {
+            if (!res.ok) {
+                const detail = text.trim();
+                throw new Error(detail || `Request failed (HTTP ${res.status})`);
+            }
+            return text;
+        });
+    }
+
     function createTest(event, testId, subtype, curriculumGrades, examId) {
         event?.preventDefault();  // Cancel the request
 
@@ -922,14 +932,7 @@
                     'HX-Request': 'true'  // so that your server can detect HTMX if needed
                 }
 
-            }).then(res => {
-                  if (!res.ok) {
-                      // Turn HTTP error into a real JS error to trigger .catch
-                      throw new Error(`HTTP error! status: ${res.status}`);
-                  }
-                  return res.text(); // if OK, read body
-
-              }).then(html => {
+            }).then(readResponseOrThrow).then(() => {
                   // go back to remove add/edit test screen
                   goBackAfterDelay(0);
                   if (mode === "new") {
@@ -939,12 +942,19 @@
 
               }).catch(err => {
                   console.error(mode === "edit" ? "Error during test updation:" : "Error during test creation:", err);
+                  const message = err && err.message
+                      ? err.message
+                      : "There was an error while saving the test.";
+                  alert(message);
+
                   // Re-enable the Continue button on error (copy flow disables it before calling createTest)
-                  const submitBtn = document.querySelector('#add-test-right-div button[type="submit"]');
                   if (mode === "copy") {
-                      submitBtn.disabled = false;
-                      submitBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-                      submitBtn.textContent = "Continue";
+                    const continueBtn = document.getElementById('continue-btn');
+                    if (continueBtn) {
+                        continueBtn.disabled = false;
+                        continueBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+                        continueBtn.textContent = 'Continue';
+                    }
                   }
               });
         }


### PR DESCRIPTION
## 📋 Summary

- 🔁 Pass db-service **4xx** errors through to the add-test UI instead of returning a generic **500**
- 📝 Extract user-facing messages from db-service JSON (errors.message)
- 🚨 Show an alert on test save failure in add_test.html — including **duplicate test code on new test creation**, and any other db-service client error during create or update
- 🔘 Re-enable the copy-flow **Continue** button after a failed save

## 🔧 What changed

### Backend
- `APIError` type in remote repository with status code + response body
- `WriteRemoteAPIError()` helper in `handlerutils` to forward client errors
- `CreateTest()` and `UpdateTest()` now surface db-service validation errors

### Frontend
- `readResponseOrThrow()` reads error response body on failed save
- `alert()` displays the API message to the user

## ✅ Test plan

- [x] Create a new test with a test code that already exists
  - [x] Confirm alert shows: *This test code has already been used.*
  - [x] Confirm user stays on the add-test screen (no navigation away)
- [x] Create a new test with a unique test code — confirm test saves successfully
- [ ] Copy flow: trigger save error and confirm **Continue** button is re-enabled
- [ ] Run go test ./internal/handlers/handlerutils/...