### PR TITLE
🔄 Refresh problem detail after edit & fix editor marker redeclaration

### DIFF
--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -830,6 +830,14 @@
                 return res.text(); // if OK, read body
 
             }).then(html => {
+                if (isEditPage && sessionStorage.getItem(REFRESH_PROBLEM_ON_BACK_KEY)) {
+                    const curriculumId = document.getElementById("curriculum-dropdown").value;
+                    sessionStorage.setItem(
+                        REFRESH_PROBLEM_URL_KEY,
+                        `/problem?id=${problemId}&curriculum_id=${curriculumId}`
+                    );
+                    sessionStorage.removeItem(REFRESH_PROBLEM_ON_BACK_KEY);
+                }
                 // go back to remove add/edit problem screen
                 goBackAfterDelay(0);
 

--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -1,5 +1,5 @@
 {{ define "content" }}
-<div>
+<div id="problem-div">
     <div class="flex items-center mb-4">
         <button class="btn-ghost btn-sm" onclick="window.history.back()">
             <i class="fa-solid fa-chevron-left"></i> Back
@@ -8,6 +8,7 @@
         <div class="flex space-x-4 ml-auto pr-4">
             <button class="action-button"
                 hx-get="/problems/edit-problem?id={{.ProblemPtr.ID}}&curriculum_id={{.ProblemPtr.CurriculumID}}&topic_id={{.ProblemPtr.TopicID}}"
+                hx-on::before-request="sessionStorage.setItem(REFRESH_PROBLEM_ON_BACK_KEY, '1')"
                 hx-target="body" hx-push-url="true" title="Edit problem">
                 <i class="fa-solid fa-pen"></i>
             </button>
@@ -96,6 +97,16 @@
     </div>
 </div>
 <script>
+    document.querySelector(PROBLEM_DIV_SELECTOR).addEventListener(BACK_TO_PROBLEM_EVT, () => {
+        sessionStorage.removeItem(REFRESH_PROBLEM_ON_BACK_KEY);
+        const refreshUrl = sessionStorage.getItem(REFRESH_PROBLEM_URL_KEY);
+        if (!refreshUrl) {
+            return;
+        }
+        sessionStorage.removeItem(REFRESH_PROBLEM_URL_KEY);
+        htmx.ajax('GET', refreshUrl, { target: 'body', swap: 'innerHTML' });
+    });
+
     htmx.defineExtension('goBackAfter', {
             onEvent: function (name, evt) {
                 if (name === 'htmx:afterRequest') {

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -216,8 +216,8 @@ function ensureImageBlock(img, editor) {
 }
 
 /** Zero-width space lets the caret sit after a floated image; stripped before save. */
-const IMAGE_CARET_MARKER = '\u200B';
-const IMAGE_CARET_MARKER_ENTITY = `&#${IMAGE_CARET_MARKER.charCodeAt(0)};`;
+var IMAGE_CARET_MARKER = '\u200B';
+var IMAGE_CARET_MARKER_ENTITY = `&#${IMAGE_CARET_MARKER.charCodeAt(0)};`;
 
 function ensureTextAfterImage(img) {
     const next = img.nextSibling;

--- a/web/static/js/nav-tracker.js
+++ b/web/static/js/nav-tracker.js
@@ -1,8 +1,12 @@
 var BACK_TO_ADD_TEST_EVT = "back-to-add-test";
 var BACK_TO_TOPIC_EVT = "back-to-topic";
+var BACK_TO_PROBLEM_EVT = "back-to-problem";
+var REFRESH_PROBLEM_ON_BACK_KEY = "refreshProblemOnBack";
+var REFRESH_PROBLEM_URL_KEY = "refreshProblemUrl";
 
 var ADD_TEST_DIV_SELECTOR = "#add-test-right-div";
 var TOPIC_DIV_SELECTOR = "#topic-div";
+var PROBLEM_DIV_SELECTOR = "#problem-div";
 
 var PUSHED_SCREEN_ADD_TEST = "add-test";
 var PUSHED_SCREEN_TOPIC = "topic";
@@ -23,6 +27,11 @@ if (!window._htmxHistoryRestoreAttached) {
         const topicDiv = document.querySelector(TOPIC_DIV_SELECTOR);
         if (topicDiv) {
             topicDiv.dispatchEvent(new CustomEvent(BACK_TO_TOPIC_EVT));
+            return;
+        }
+        const problemDiv = document.querySelector(PROBLEM_DIV_SELECTOR);
+        if (problemDiv) {
+            problemDiv.dispatchEvent(new CustomEvent(BACK_TO_PROBLEM_EVT));
             return;
         }
     });


### PR DESCRIPTION
## Summary

- 🔄 **Refresh problem detail after edit** — Saving an edited problem reloads the problem detail view when navigating back, so title, content, and metadata stay in sync without a manual refresh.
- 🎯 **Conditional refetch on history restore** — On `htmx:historyRestore`, the problem page is refetched only when a refresh URL was stored in sessionStorage after a successful save.
- 🧹 **Clear pending flag on restore** — The pending refresh flag is always cleared when returning to the problem page, even when no refetch runs.
- ⏭️ **No refresh on cancel or unchanged back** — Navigating back from edit without saving does not set a refresh URL, so the problem page is left as-is.
- 🐛 **Fix editor marker redeclaration** — Switches `IMAGE_CARET_MARKER` constants to `var` in `editor-image.js` to avoid duplicate declaration errors when the script loads more than once.

## How it works

1. ✏️ User taps **Edit** on a problem → `REFRESH_PROBLEM_ON_BACK_KEY` (pending flag) is set in sessionStorage.
2. 💾 User **saves** on the edit screen → refresh URL is stored in `REFRESH_PROBLEM_URL_KEY` and the pending flag is cleared.
3. 🔙 User **cancels** or goes **back unchanged** → no refresh URL is stored.
4. ↩️ On `htmx:historyRestore` / back → pending flag is always cleared; problem detail is refetched via HTMX **only** if a refresh URL exists.

## Changed files

| File | Change |
|------|--------|
| `web/html/problem.html` | `#problem-div`, edit-button pending flag, conditional refresh listener |
| `web/html/add_problem.html` | Store refresh URL after successful edit save only |
| `web/static/js/nav-tracker.js` | Problem back-event + sessionStorage keys |
| `web/static/js/editor-image.js` | `const` → `var` for caret markers |

## Test plan

- [x] Open a problem detail page, edit, save → confirm updated content appears after back
- [x] Open edit, then cancel without saving → confirm problem page is **not** refetched
- [x] Open edit, make no changes, go back → confirm problem page is **not** refetched
- [x] After a successful save + back, confirm sessionStorage flags are cleared
- [x] Open edit problem screen multiple times and confirm no `IMAGE_CARET_MARKER` redeclaration errors
- [ ] Smoke-test add-problem (create) flow is unchanged