### PR TITLE
🐛 Fix: Restore editable LaTeX when editing problems with legacy MathJax HTML

### DIFF
--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -623,13 +623,17 @@
                 ...Array.from({ length: 4 }, () => ({ html: '', preview: '' }))
             {{ end }}
         ];
-        
+
         // Initial rendering of options & answers for mcq & matrix match only
-        const subtype = document.getElementById('problem-type-dropdown').value;
-        if (subtype === 'mcq_single_answer' || subtype === 'matrix_match' || subtype === 'mcq_multiple_answer') {
-            renderTabs();
-            setActiveTab(0);
+        function bootMcqTabsIfNeeded() {
+            const subtype = document.getElementById('problem-type-dropdown').value;
+            if (subtype === 'mcq_single_answer' || subtype === 'matrix_match' || subtype === 'mcq_multiple_answer') {
+                renderTabs();
+                setActiveTab(0);
+            }
         }
+
+        bootMcqTabsIfNeeded();
 
         function getLabel(index) {
             return labelPool[index];
@@ -761,10 +765,21 @@
 
         function loadActiveContent() {
             const content = tabContent[activeIndex] || { html: '', preview: '' };
-            editor.innerHTML = content.html;
-            preview.innerHTML = content.preview;
-            // This is required for edit problem where by default MathJax is applied to only first option
-            applyMathJaxIfNeeded();
+            const applyContent = () => {
+                editor.innerHTML = content.html;
+                if (typeof normalizeRenderedMath === 'function') {
+                    normalizeRenderedMath(editor);
+                }
+                // This is required for edit problem where by default MathJax is applied to only first option
+                if (typeof renderMath === 'function') {
+                    renderMath(editor);
+                } else {
+                    preview.innerHTML = content.preview;
+                    applyMathJaxIfNeeded();
+                }
+            };
+
+            applyContent();
         }
 
         function applyMathJaxIfNeeded() {
@@ -1167,19 +1182,22 @@
         }
 
         function scheduleEditorBoot() {
-            if (bootRichTextEditors()) return;
-
-            const editorScript = document.querySelector('script[src*="editor.js"]');
-            if (editorScript) {
-                const run = () => { bootRichTextEditors(); };
-                if (window.initializeRichTextEditors) {
-                    run();
+            const boot = () => {
+                if (bootRichTextEditors()) return;
+                const editorScript = document.querySelector('script[src*="editor.js"]');
+                if (editorScript) {
+                    const run = () => { bootRichTextEditors(); };
+                    if (window.initializeRichTextEditors) {
+                        run();
+                    } else {
+                        editorScript.addEventListener('load', run, { once: true });
+                    }
                 } else {
-                    editorScript.addEventListener('load', run, { once: true });
+                    requestAnimationFrame(scheduleEditorBoot);
                 }
-            } else {
-                requestAnimationFrame(scheduleEditorBoot);
-            }
+            };
+
+            boot();
         }
         scheduleEditorBoot();
     })();

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -236,6 +236,5 @@
 
 <div id="math-keyboard" class="ML__keyboard mt-4"></div>
 
-<script src="/web/static/js/editor-math.js"></script>
 <script src="/web/static/js/editor-image.js"></script>
 {{ end }}

--- a/web/html/home.html
+++ b/web/html/home.html
@@ -14,8 +14,28 @@
     <!-- For Font Awesome library -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
     <script src="https://unpkg.com/mathlive"></script>
+    <script>
+        window.MathJax = {
+            options: {
+                renderActions: {
+                    addSourceTex: [
+                        151,
+                        (doc) => {
+                            for (const math of doc.math) {
+                                doc.adaptor.setAttribute(math.typesetRoot, 'data-tex', math.math);
+                            }
+                        },
+                        (math, doc) => {
+                            doc.adaptor.setAttribute(math.typesetRoot, 'data-tex', math.math);
+                        },
+                    ],
+                },
+            },
+        };
+    </script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
     </script>
+    <script src="/web/static/js/editor-math.js"></script>
     <script src="/web/static/js/constants.js"></script>
     <script src="/web/static/js/resource-form.js"></script>
     <script src="/web/static/js/infinite-scroll.js"></script>

--- a/web/static/js/editor-math.js
+++ b/web/static/js/editor-math.js
@@ -1,3 +1,197 @@
+function whenMathEditorReady(callback) {
+    if (window.customElements?.get('math-field')) {
+        callback();
+        return;
+    }
+    if (window.customElements?.whenDefined) {
+        customElements.whenDefined('math-field').then(callback).catch(() => callback());
+        return;
+    }
+    callback();
+}
+window.whenMathEditorReady = whenMathEditorReady;
+window.whenMathNormalizerReady = whenMathEditorReady;
+
+function mathmlTextContent(node) {
+    return (node.textContent || '')
+        .replace(/\u00A0/g, ' ')
+        .replace(/&nbsp;/gi, ' ');
+}
+
+function isMathmlElement(node, name) {
+    return node?.nodeType === Node.ELEMENT_NODE && node.localName?.toLowerCase() === name;
+}
+
+function mathmlChildren(node) {
+    return [...node.childNodes].filter((child) => child.nodeType === Node.ELEMENT_NODE);
+}
+
+function serializeMathmlRow(nodes) {
+    const parts = [];
+    let run = '';
+
+    const flushRun = () => {
+        if (!run) return;
+        parts.push(run);
+        run = '';
+    };
+
+    for (const child of nodes) {
+        if (isMathmlElement(child, 'mi') || isMathmlElement(child, 'mn')) {
+            run += mathmlTextContent(child);
+            continue;
+        }
+        flushRun();
+        parts.push(serializeMathmlNode(child));
+    }
+    flushRun();
+    return parts.join('');
+}
+
+function serializeMathmlNode(node) {
+    if (!node || node.nodeType !== Node.ELEMENT_NODE) return '';
+
+    const tag = node.localName.toLowerCase();
+    const children = mathmlChildren(node);
+
+    switch (tag) {
+        case 'math':
+            return serializeMathmlRow(children);
+        case 'mrow':
+            return serializeMathmlRow(children);
+        case 'mn':
+        case 'mi':
+            return mathmlTextContent(node);
+        case 'mtext': {
+            const text = mathmlTextContent(node);
+            if (!text) return '';
+            if (/^\s+$/.test(text)) return text;
+            return `\\text{${text}}`;
+        }
+        case 'mo':
+            return mathmlTextContent(node);
+        case 'msub': {
+            const base = serializeMathmlNode(children[0]);
+            const sub = serializeMathmlNode(children[1]);
+            return `${base}_{${sub}}`;
+        }
+        case 'msup': {
+            const base = serializeMathmlNode(children[0]);
+            const sup = serializeMathmlNode(children[1]);
+            return `${base}^{${sup}}`;
+        }
+        case 'mfrac': {
+            const num = serializeMathmlNode(children[0]);
+            const den = serializeMathmlNode(children[1]);
+            return `\\frac{${num}}{${den}}`;
+        }
+        case 'mstyle': {
+            // MathJax uses a leading mspace to indent continuation lines under a bullet.
+            const mspace = children.find((child) => isMathmlElement(child, 'mspace'));
+            if (mspace && children.length === 1) {
+                return serializeMathmlNode(mspace);
+            }
+            return serializeMathmlRow(children);
+        }
+        case 'mspace': {
+            const width = node.getAttribute('width') || '1em';
+            return `\\hspace{${width}}`;
+        }
+        default:
+            return serializeMathmlRow(children);
+    }
+}
+
+function mathJaxAssistiveMathToLatex(mathEl) {
+    if (!mathEl) return '';
+    return serializeMathmlNode(mathEl).replace(/\s{2,}/g, ' ').trim();
+}
+
+function createMathField() {
+    const mathfield = document.createElement('math-field');
+    mathfield.setAttribute(
+        'style',
+        'display:inline-block; min-width:9em; border: 1px solid rgba(38, 20, 16, 0.15);'
+    );
+    mathfield.setAttribute('virtual-keyboard-target', '#math-keyboard');
+    return mathfield;
+}
+
+function latexSpanFromText(latex) {
+    const span = document.createElement('span');
+    span.textContent = `\\(${latex}\\)`;
+    return span;
+}
+
+function getLatexFromMathJaxContainer(container) {
+    const dataTex = container.getAttribute('data-tex');
+    if (dataTex) return dataTex;
+
+    const assistiveMath = container.querySelector('mjx-assistive-mml math');
+    if (assistiveMath) {
+        const latex = mathJaxAssistiveMathToLatex(assistiveMath);
+        if (latex) return latex;
+    }
+
+    if (window.MathJax?.startup?.document?.math) {
+        for (const math of MathJax.startup.document.math) {
+            if (container === math.typesetRoot && math.math) {
+                return math.math;
+            }
+        }
+    }
+
+    return null;
+}
+
+function wrapLatexDelimiters(latex, container, assistive) {
+    const isDisplay = assistive?.getAttribute('display') === 'block' ||
+        container.getAttribute('display') === 'true';
+    return isDisplay ? `\\[${latex}\\]` : `\\(${latex}\\)`;
+}
+
+function serializeMathFields(root) {
+    // Toolbar insertMath leaves temporary math-field nodes until Enter is pressed.
+    root.querySelectorAll('math-field').forEach((mathfield) => {
+        const latex = mathfield.getValue('latex')?.trim() || '';
+        mathfield.replaceWith(latex ? latexSpanFromText(latex) : document.createTextNode(''));
+    });
+}
+window.serializeMathFields = serializeMathFields;
+
+// Replace MathJax-rendered nodes with editable \( \) LaTeX text.
+function normalizeRenderedMath(root) {
+    if (!root) return false;
+
+    const containers = [...root.querySelectorAll('mjx-container')];
+    if (!containers.length) return false;
+
+    let converted = 0;
+    containers.forEach((container) => {
+        const latex = getLatexFromMathJaxContainer(container);
+        if (!latex) return;
+
+        const assistive = container.querySelector('mjx-assistive-mml');
+        const span = document.createElement('span');
+        span.textContent = wrapLatexDelimiters(latex, container, assistive);
+        container.replaceWith(span);
+        converted += 1;
+    });
+
+    return converted > 0;
+}
+window.normalizeRenderedMath = normalizeRenderedMath;
+
+function normalizeEditorHtmlString(html) {
+    if (!html || !html.includes('mjx-container')) return html;
+
+    const temp = document.createElement('div');
+    temp.innerHTML = html;
+    normalizeRenderedMath(temp);
+    return temp.innerHTML;
+}
+window.normalizeEditorHtmlString = normalizeEditorHtmlString;
+
 // Insert \( \) delimiters at the cursor so LaTeX can be typed directly.
 function insertInlineMathDelimiters(editor) {
     const selection = window.getSelection();
@@ -33,10 +227,7 @@ function insertInlineMathDelimiters(editor) {
 
 // Insert an editable inline math field at the cursor
 function insertMath(editor) {
-    const mathfield = document.createElement('math-field');
-
-    mathfield.setAttribute('style', 'display:inline-block; min-width:9em; border: 1px solid rgba(38, 20, 16, 0.15);');
-    mathfield.setAttribute('virtual-keyboard-target', '#math-keyboard');
+    const mathfield = createMathField();
 
     // Insert at caret position
     const range = window.getSelection().getRangeAt(0);
@@ -44,33 +235,34 @@ function insertMath(editor) {
     mathfield.focus();
 
     mathfield.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            const latex = mathfield.getValue('latex')?.trim() || '';
-            const span = document.createElement('span');
-            span.textContent = `\\(${latex}\\)`;
+        if (e.key !== 'Enter') return;
+        e.preventDefault();
 
-            // Replace the mathfield with the LaTeX span directly in #editor
-            mathfield.replaceWith(span);
+        const latex = mathfield.getValue('latex')?.trim() || '';
+        const replacement = latex ? latexSpanFromText(latex) : document.createTextNode('');
 
-            // Place caret after the span
-            const range = document.createRange();
-            const selection = window.getSelection();
-            range.setStartAfter(span);
-            range.setEndAfter(span);
-            selection.removeAllRanges();
-            selection.addRange(range);
+        // Replace the mathfield with the LaTeX span directly in #editor
+        mathfield.replaceWith(replacement);
 
-            // Update preview
-            renderMath(editor);
-        }
+        // Place caret after the span
+        const selection = window.getSelection();
+        const after = document.createRange();
+        after.setStartAfter(replacement);
+        after.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(after);
+
+        // Update preview
+        renderMath(editor);
     });
 }
 
 function renderMath(editor) {
     const container = editor.closest('.container');
     const output = container.querySelector('.output');
-    output.innerHTML = editor.innerHTML;
+    const clone = editor.cloneNode(true);
+    serializeMathFields(clone);
+    output.innerHTML = clone.innerHTML;
     if (window.MathJax?.typesetPromise) {
         MathJax.typesetPromise([output]).catch(console.error);
     }

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -1,5 +1,12 @@
 function getEditorHtml(editor) {
-    let html = editor.innerHTML;
+    const clone = editor.cloneNode(true);
+    if (typeof serializeMathFields === 'function') {
+        serializeMathFields(clone);
+    }
+    if (typeof normalizeRenderedMath === 'function') {
+        normalizeRenderedMath(clone);
+    }
+    let html = clone.innerHTML;
     if (typeof stripImageCaretMarkers === 'function') {
         html = stripImageCaretMarkers(html);
     }
@@ -17,15 +24,26 @@ window.initializeRichTextEditors = function (root = document) {
 
     const editor = editorWrapper.querySelector(".editor");
 
-    // for edit problem screen update preview on opening page itself, because content must already be there in editor
-    const latex = editor.innerHTML.trim();
-    if (latex && typeof renderMath === 'function') {
-        try {
-            renderMath(editor);
-        } catch (err) {
-            console.error('Editor preview render failed', err);
+    const initPreview = () => {
+        // for edit problem screen update preview on opening page itself, because content must already be there in editor
+        const latex = editor.innerHTML.trim();
+        if (latex && typeof renderMath === 'function') {
+            try {
+                renderMath(editor);
+            } catch (err) {
+                console.error('Editor preview render failed', err);
+            }
         }
-    }
+    };
+
+    const initEditorContent = () => {
+        if (typeof normalizeRenderedMath === 'function') {
+            normalizeRenderedMath(editor);
+        }
+        initPreview();
+    };
+
+    initEditorContent();
 
     // listener to display preview
     editor.addEventListener('input', () => {


### PR DESCRIPTION
## Summary

🔧 Fixes the edit problem screen where some fields stored **rendered MathJax markup** (`mjx-container`) instead of editable `\( \)` LaTeX — equations appeared correctly but could not be edited.

✨ **What this PR does:**
- 🔄 Converts legacy `mjx-container` nodes back to editable `\( \)` LaTeX text on load and save
- 🧠 Uses a custom MathML walker on MathJax **assistive MathML** (`mjx-assistive-mml math`) for reliable round-trip recovery
- 📐 Preserves spacing, `\text{}`, fractions, subscripts/superscripts, and bullet continuation indents (`\hspace{1em}`)
- 💾 Normalizes math on editor init, MCQ option tab switch, and via `getEditorHtml` before save
- 📦 Loads `editor-math.js` once from the base layout (`home.html`) instead of per-editor duplication
- 🏷️ Optionally stamps `data-tex` on MathJax preview renders for safer future round-trips

## Problem

📝 On `/problems/edit-problem`, legacy DB content sometimes contained MathJax-rendered HTML in `text`, `options`, etc., while `solutions` often still had raw LaTeX. Editors showed non-editable rendered math instead of `\(...\)` syntax.

## Solution

🛠️ `normalizeRenderedMath()` walks rendered nodes and replaces them with LaTeX text spans. Recovery priority:
1. `data-tex` on the container (if present)
2. Assistive MathML → `mathJaxAssistiveMathToLatex`
3. MathJax session `math.typesetRoot` match

🎯 `math-field` remains for **toolbar insert** only (Enter commits to LaTeX span); legacy content is normalized to plain LaTeX, not MathLive widgets.

## Files changed

| File | Change |
|------|--------|
| `web/static/js/editor-math.js` | MathML walker, normalization, serialize on save |
| `web/static/js/editor.js` | Normalize on init; clone + normalize in `getEditorHtml` |
| `web/html/add_problem.html` | Normalize + re-render on MCQ tab load |
| `web/html/home.html` | Shared `editor-math.js` + optional `data-tex` renderAction |
| `web/html/editor.html` | Remove duplicate `editor-math.js` script tag |

## Test plan

- [x] Open an **existing problem** with MathJax HTML in question text → equations show as editable `\( \)` LaTeX
- [x] Switch **MCQ option tabs** on edit → each option normalizes and preview re-renders correctly
- [x] Edit an equation, save, reopen → LaTeX persists (not re-stored as `mjx-container`)
- [x] Verify **new math insert** via toolbar still works (math-field → Enter → LaTeX span)
- [x] Check bullet lists with indented continuation lines under equations
- [x] Confirm **solutions** and fields that already had LaTeX are unchanged

## Notes

⚠️ MathML → LaTeX recovery is intentionally structural (tag-based), not symbol-by-symbol patching. Edge-case MathML may still need new tag handlers rather than one-off symbol maps.

🚀 No backend or schema changes — client-side normalization only.