### PR TITLE
1 - Lint: format imports and fix spelling

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -5,13 +5,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/avantifellows/nex-gen-cms/config"
 	"github.com/avantifellows/nex-gen-cms/di"
 	"github.com/avantifellows/nex-gen-cms/internal/constants"
 	"github.com/avantifellows/nex-gen-cms/internal/handlers"
 	"github.com/avantifellows/nex-gen-cms/internal/middleware"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 type MockConfig struct {

--- a/di/app_component.go
+++ b/di/app_component.go
@@ -9,9 +9,9 @@ import (
 	"github.com/avantifellows/nex-gen-cms/internal/auth"
 	"github.com/avantifellows/nex-gen-cms/internal/handlers"
 	"github.com/avantifellows/nex-gen-cms/internal/models"
+	pgrepo "github.com/avantifellows/nex-gen-cms/internal/repositories/db"
 	local_repo "github.com/avantifellows/nex-gen-cms/internal/repositories/local"
 	remote_repo "github.com/avantifellows/nex-gen-cms/internal/repositories/remote"
-	pgrepo "github.com/avantifellows/nex-gen-cms/internal/repositories/db"
 	"github.com/avantifellows/nex-gen-cms/internal/services"
 )
 

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/avantifellows/nex-gen-cms/config"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
+
+	"github.com/avantifellows/nex-gen-cms/config"
 )
 
 const (

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/avantifellows/nex-gen-cms/config"
 	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/avantifellows/nex-gen-cms/config"
 )
 
 const (

--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/thoas/go-funk"
+
 	"github.com/avantifellows/nex-gen-cms/internal/constants"
 	"github.com/avantifellows/nex-gen-cms/internal/dto"
 	"github.com/avantifellows/nex-gen-cms/internal/handlers/handlerutils"
@@ -14,7 +16,6 @@ import (
 	"github.com/avantifellows/nex-gen-cms/internal/services"
 	"github.com/avantifellows/nex-gen-cms/internal/views"
 	"github.com/avantifellows/nex-gen-cms/utils"
-	"github.com/thoas/go-funk"
 )
 
 const chaptersEndPoint = "chapter"

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -16,6 +16,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+	"github.com/thoas/go-funk"
+
 	"github.com/avantifellows/nex-gen-cms/internal/constants"
 	"github.com/avantifellows/nex-gen-cms/internal/dto"
 	"github.com/avantifellows/nex-gen-cms/internal/handlers/handlerutils"
@@ -23,10 +28,6 @@ import (
 	"github.com/avantifellows/nex-gen-cms/internal/services"
 	"github.com/avantifellows/nex-gen-cms/internal/views"
 	"github.com/avantifellows/nex-gen-cms/utils"
-	"github.com/chromedp/cdproto/page"
-	"github.com/chromedp/cdproto/runtime"
-	"github.com/chromedp/chromedp"
-	"github.com/thoas/go-funk"
 )
 
 const TESTTYPE_DROPDOWN_NAME = "testtype-dropdown"

--- a/internal/repositories/db/db.go
+++ b/internal/repositories/db/db.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/avantifellows/nex-gen-cms/config"
 	_ "github.com/lib/pq"
+
+	"github.com/avantifellows/nex-gen-cms/config"
 )
 
 // Open returns a configured sql.DB. Caller is responsible for closing it on shutdown.

--- a/internal/repositories/remote/api_repository.go
+++ b/internal/repositories/remote/api_repository.go
@@ -34,7 +34,7 @@ func (r *APIRepository) CallAPI(urlEndPoint string, method string, body any) ([]
 			var err error
 			jsonBodyBytes, err = json.Marshal(body)
 			if err != nil {
-				return nil, fmt.Errorf("error marshalling request body: %v", err)
+				return nil, fmt.Errorf("error marshaling request body: %v", err)
 			}
 		}
 

--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/thoas/go-funk"
+
 	local_repo "github.com/avantifellows/nex-gen-cms/internal/repositories/local"
 	remote_repo "github.com/avantifellows/nex-gen-cms/internal/repositories/remote"
-	"github.com/thoas/go-funk"
 )
 
 type Service[T any] struct {

--- a/utils/conversion_util.go
+++ b/utils/conversion_util.go
@@ -123,7 +123,7 @@ func Dict(values ...any) map[string]any {
 func ToJson(v any) template.JS {
 	b, err := json.Marshal(v)
 	if err != nil {
-		log.Printf("Error marshalling to JSON: %v", err)
+		log.Printf("Error marshaling to JSON: %v", err)
 		return template.JS("[]") // fallback to empty JSON array
 	}
 	return template.JS(b)


### PR DESCRIPTION
## Why this series of PRs?

We added a **lint step** to this Go project's CI — `golangci-lint`, a tool that reads the code and flags problems, dead/redundant code, missed error checks, and style issues before they ever reach `main`. It's the Go equivalent of the checks our JS/TS repos already run.

When we turned it on and ran it across the whole codebase, it reported a pile of pre-existing issues. Rather than fix them all in one giant, hard-to-review PR, we're cleaning them up **one category at a time**, as a chain of small **stacked PRs** (each builds on the previous). So:

- Every PR fixes **one kind of issue** → the diff is small and easy to read.
- They're numbered `1 - Lint:`, `2 - Lint:`, … and **must be merged in order** (1 first, then 2, …).
- None of these change how the app behaves — they're cleanups the linter asked for. Each PR is verified with `go build`, `go vet`, `go test -race`, and the linter itself.

**One thing we're deliberately skipping for now:** the **naming-convention** fixes (Go wants initialisms uppercased, e.g. `Id` → `ID`, `Url` → `URL`). The linter flagged ~145 of those. They're pure style, the codebase is already consistent the way it is, and fixing them touches a huge number of files — so we're **intentionally leaving them out** of this round to keep the noise down. We can revisit later if we want.

Going forward, the lint step runs on every PR (only flagging **newly changed** code), so we don't pile up debt like this again.

---

**Stacked PR 1 of 6** — review on top of `main`.

Runs `golangci-lint fmt` (goimports grouping with local-prefix ordering) across the codebase and fixes two misspellings ("marshalling" → "marshaling"). No logic changes.

Part of a stacked series that cleans up `golangci-lint` findings by category, one PR each, so review stays small; merge in order 1→6. (The naming-convention PR was dropped as low priority for now.)

### Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race ./...` ✓
- `golangci-lint run ./...` ✓ (this category clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### 📚 Stack (merge in order)
1. **#138** ◀ this PR — 1 - Lint: format imports and fix spelling
2. #139 — 2 - Lint: remove redundant code and simplify
3. #140 — 3 - Lint: check previously ignored errors
4. #141 — 4 - Lint: minor style fixes
5. #143 — 5 - Lint: dedupe exam/grade handlers
6. #144 — 6 - Lint: reduce cognitive complexity
