### PR TITLE
2 - Lint: remove redundant code and simplify

### DIFF
--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -325,11 +325,12 @@ func (h *ChaptersHandler) GetTopics(responseWriter http.ResponseWriter, request 
 	urlVals := request.URL.Query()
 	view := urlVals.Get("view")
 	var filename string
-	if view == "list" {
+	switch view {
+	case "list":
 		filename = topicRowTemplate
-	} else if view == "dropdown-optional" {
+	case "dropdown-optional":
 		filename = topicDropdownOptionalTemplate
-	} else {
+	default:
 		filename = topicDropdownTemplate
 	}
 

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -476,7 +476,7 @@ func (h *ProblemsHandler) MoveProblems(responseWriter http.ResponseWriter, reque
 
 	curriculumId, gradeId, subjectId := getCurriculumGradeSubjectIds(request.Form)
 	if curriculumId == 0 || gradeId == 0 || subjectId == 0 {
-		http.Error(responseWriter, fmt.Sprint("Invalid curriculum, grade or subject ID"), http.StatusBadRequest)
+		http.Error(responseWriter, "Invalid curriculum, grade or subject ID", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -259,7 +259,7 @@ func sortTests(testPtrs []*models.Test, sortColumn string, sortOrder string, cur
 				sortResult = strings.Compare(c1, c2)
 			} else {
 				// Normal case: sort by problem count
-				sortResult = int(t1.ProblemCount() - t2.ProblemCount())
+				sortResult = t1.ProblemCount() - t2.ProblemCount()
 			}
 		case "4":
 			if gradeMap != nil {
@@ -280,7 +280,7 @@ func sortTests(testPtrs []*models.Test, sortColumn string, sortOrder string, cur
 			if curriculumMap != nil {
 				sortResult = strings.Compare(t1.DisplaySubtype(), t2.DisplaySubtype())
 			} else {
-				sortResult = int(utils.StringToInt(t1.TypeParams.Duration) - utils.StringToInt(t2.TypeParams.Duration))
+				sortResult = utils.StringToInt(t1.TypeParams.Duration) - utils.StringToInt(t2.TypeParams.Duration)
 			}
 		default:
 			sortResult = 0
@@ -863,7 +863,8 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 
 	var pdfTemplate, headerTxt, pdfSuffix string
 	var testRule *models.TestRule
-	if pdfType == "questions" {
+	switch pdfType {
+	case "questions":
 		pdfTemplate = questionPaperTemplate
 		headerTxt = selectedTestPtr.DisplaySubtype()
 		pdfSuffix = "Question Paper"
@@ -875,7 +876,7 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 			}
 		}
 
-	} else if pdfType == "questions_with_answers" {
+	case "questions_with_answers":
 		pdfTemplate = questionPaperWithAnswersTemplate
 		headerTxt = selectedTestPtr.DisplaySubtype() + " - Questions & Answers"
 		pdfSuffix = "Question Paper with Answers"
@@ -887,7 +888,7 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 			}
 		}
 
-	} else if pdfType == "answers" {
+	case "answers":
 		pdfTemplate = answerSolutionSheetTemplate
 		headerTxt = selectedTestPtr.DisplaySubtype() + " - Answer Sheet"
 		pdfSuffix = "Answer Sheet"

--- a/internal/models/test.go
+++ b/internal/models/test.go
@@ -114,7 +114,7 @@ func (test *Test) SetCurriculumGrade(curriculumID int16, gradeID int8) {
 	}
 
 	// If nil or empty, initialize with the new pair
-	if test.CurriculumGrades == nil || len(test.CurriculumGrades) == 0 {
+	if len(test.CurriculumGrades) == 0 {
 		test.CurriculumGrades = []CurriculumGrade{newPair}
 		return
 	}
@@ -154,7 +154,7 @@ func (t *Test) DisplaySubtype() string {
 }
 
 func (t *Test) RecalculateTotalMarksFromSubjects() {
-	var total int16 = 0
+	var total int16
 
 	for _, subject := range t.TypeParams.Subjects {
 		total += int16(subject.Marks)

--- a/utils/conversion_util.go
+++ b/utils/conversion_util.go
@@ -85,7 +85,7 @@ func ExtractNumericSuffix(s string) int {
 }
 
 func JoinInt16(intArr []int16, separator string) string {
-	var stringArr []string
+	stringArr := make([]string, 0, len(intArr))
 	for _, integer := range intArr {
 		stringArr = append(stringArr, strconv.Itoa(int(integer)))
 	}


### PR DESCRIPTION
**Stacked PR 2 of 6** — review on top of `lint/1-formatting-spelling`.

Preallocates a slice, drops a redundant `var x = 0` initializer and a redundant nil+len check, removes unnecessary `fmt.Sprint`/`int()` conversions, and converts two if/else-if chains to tagged `switch` statements (staticcheck QF1003).

Part of a stacked series that cleans up `golangci-lint` findings by category, one PR each, so review stays small; merge in order 1→6. (The naming-convention PR was dropped as low priority for now.)

### Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race ./...` ✓
- `golangci-lint run ./...` ✓ (this category clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### 📚 Stack (merge in order)
1. #138 — 1 - Lint: format imports and fix spelling
2. **#139** ◀ this PR — 2 - Lint: remove redundant code and simplify
3. #140 — 3 - Lint: check previously ignored errors
4. #141 — 4 - Lint: minor style fixes
5. #143 — 5 - Lint: dedupe exam/grade handlers
6. #144 — 6 - Lint: reduce cognitive complexity
