### PR TITLE
3 - Lint: check previously ignored errors

### DIFF
--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -445,7 +445,10 @@ func (h *ProblemsHandler) GetSearchProblems(responseWriter http.ResponseWriter, 
 }
 
 func (h *ProblemsHandler) LoadTestAssociations(responseWriter http.ResponseWriter, request *http.Request) {
-	request.ParseForm()
+	if err := request.ParseForm(); err != nil {
+		http.Error(responseWriter, fmt.Sprintf("Error parsing form: %v", err), http.StatusBadRequest)
+		return
+	}
 	problemIDsStr := request.Form["select-problem"]
 	problemIDs := utils.StringSliceToIntSlice(problemIDsStr)
 

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -1128,7 +1128,9 @@ func (h *TestsHandler) ValidateTest(responseWriter http.ResponseWriter, request 
 	}
 
 	responseWriter.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(responseWriter).Encode(data)
+	if err := json.NewEncoder(responseWriter).Encode(data); err != nil {
+		http.Error(responseWriter, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func getProblemChapterName(p models.Problem, lang string) string {

--- a/internal/views/render.go
+++ b/internal/views/render.go
@@ -17,7 +17,10 @@ func ExecuteTemplate(filename string, responseWriter http.ResponseWriter, data a
 	} else {
 		tmpl = template.Must(template.ParseFiles(tmplPath))
 	}
-	tmpl.Execute(responseWriter, data)
+	if err := tmpl.Execute(responseWriter, data); err != nil {
+		log.Println("Template Execution Error:", err)
+		http.Error(responseWriter, "Internal Server Error", http.StatusInternalServerError)
+	}
 }
 
 func ExecuteTemplates(responseWriter http.ResponseWriter, data any, funcMap template.FuncMap, templateFiles ...string) {


### PR DESCRIPTION
**Stacked PR 3 of 6** — review on top of `lint/2-redundant-code`.

Handles three previously-unchecked errors: template execution in `render.go`, `request.ParseForm()` in the problem handler, and a JSON encode in the test handler — each now returns an appropriate HTTP error instead of silently ignoring the failure.

Part of a stacked series that cleans up `golangci-lint` findings by category, one PR each, so review stays small; merge in order 1→6. (The naming-convention PR was dropped as low priority for now.)

### Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race ./...` ✓
- `golangci-lint run ./...` ✓ (this category clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### 📚 Stack (merge in order)
1. #138 — 1 - Lint: format imports and fix spelling
2. #139 — 2 - Lint: remove redundant code and simplify
3. **#140** ◀ this PR — 3 - Lint: check previously ignored errors
4. #141 — 4 - Lint: minor style fixes
5. #143 — 5 - Lint: dedupe exam/grade handlers
6. #144 — 6 - Lint: reduce cognitive complexity
