### PR TITLE
4 - Lint: minor style fixes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,7 +79,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 		}
 		http.NotFound(w, r)
 	})
-	muxHandler.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
+	muxHandler.HandleFunc("/favicon.ico", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -43,7 +43,7 @@ func NewChaptersHandler(chaptersService *services.Service[models.Chapter],
 	}
 }
 
-func (h *ChaptersHandler) LoadChapters(responseWriter http.ResponseWriter, request *http.Request) {
+func (h *ChaptersHandler) LoadChapters(responseWriter http.ResponseWriter, _ *http.Request) {
 	views.ExecuteTemplates(responseWriter, nil, nil, baseTemplate, chaptersTemplate)
 }
 

--- a/internal/handlers/curriculum_handler.go
+++ b/internal/handlers/curriculum_handler.go
@@ -25,7 +25,7 @@ func NewCurriculumsHandler(service *services.Service[models.Curriculum]) *Curric
 	}
 }
 
-func (h *CurriculumsHandler) GetCurriculums(responseWriter http.ResponseWriter, request *http.Request) {
+func (h *CurriculumsHandler) GetCurriculums(responseWriter http.ResponseWriter, _ *http.Request) {
 	curriculums, err := h.service.GetList(getCurriculumsEndPoint, curriculumsKey, false, false)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching curriculums: %v", err), http.StatusInternalServerError)

--- a/internal/handlers/exam_handler.go
+++ b/internal/handlers/exam_handler.go
@@ -23,7 +23,7 @@ func NewExamsHandler(service *services.Service[models.Exam]) *ExamsHandler {
 	}
 }
 
-func (h *ExamsHandler) GetExams(responseWriter http.ResponseWriter, request *http.Request) {
+func (h *ExamsHandler) GetExams(responseWriter http.ResponseWriter, _ *http.Request) {
 	exams, err := h.service.GetList(examsEndPoint, examsKey, false, false)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching exams: %v", err), http.StatusInternalServerError)

--- a/internal/handlers/grade_handler.go
+++ b/internal/handlers/grade_handler.go
@@ -23,7 +23,7 @@ func NewGradesHandler(service *services.Service[models.Grade]) *GradesHandler {
 	}
 }
 
-func (h *GradesHandler) GetGrades(responseWriter http.ResponseWriter, request *http.Request) {
+func (h *GradesHandler) GetGrades(responseWriter http.ResponseWriter, _ *http.Request) {
 	grades, err := h.service.GetList(getGradesEndPoint, gradesKey, false, false)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching grades: %v", err), http.StatusInternalServerError)

--- a/internal/handlers/login_handler.go
+++ b/internal/handlers/login_handler.go
@@ -124,7 +124,7 @@ func (h *LoginHandler) DevLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 // Logout clears the session and redirects to /login.
-func (h *LoginHandler) Logout(w http.ResponseWriter, r *http.Request) {
+func (h *LoginHandler) Logout(w http.ResponseWriter, _ *http.Request) {
 	auth.ClearSession(w)
 	w.Header().Set("HX-Redirect", "/login")
 	w.WriteHeader(http.StatusOK)

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -100,21 +100,21 @@ func (h *ProblemsHandler) getProblem(urlValues url.Values) (*models.Problem, int
 	skills, err := h.skillsService.GetList(skillsEndPoint, skillsKey, false, false)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching skills: %v", err)
-	} else {
-		// Create a map to quickly lookup skills by their ID
-		skillPtrsMap := make(map[int16]*models.Skill)
-
-		// Fill the map with the address of each skill
-		for _, skillPtr := range *skills {
-			skillPtrsMap[skillPtr.ID] = skillPtr
-		}
-
-		// Loop through skill ids and add corresponding skills
-		for _, skillId := range selectedProblemPtr.SkillIDs {
-			selectedProblemPtr.Skills = append(selectedProblemPtr.Skills, *skillPtrsMap[skillId])
-		}
-		return selectedProblemPtr, http.StatusOK, nil
 	}
+
+	// Create a map to quickly lookup skills by their ID
+	skillPtrsMap := make(map[int16]*models.Skill)
+
+	// Fill the map with the address of each skill
+	for _, skillPtr := range *skills {
+		skillPtrsMap[skillPtr.ID] = skillPtr
+	}
+
+	// Loop through skill ids and add corresponding skills
+	for _, skillId := range selectedProblemPtr.SkillIDs {
+		selectedProblemPtr.Skills = append(selectedProblemPtr.Skills, *skillPtrsMap[skillId])
+	}
+	return selectedProblemPtr, http.StatusOK, nil
 }
 
 func (h *ProblemsHandler) GetTopicProblems(responseWriter http.ResponseWriter, request *http.Request) {
@@ -241,7 +241,7 @@ func filterProblems(problems *[]*models.Problem, levels []string, ptype string, 
 	*problems = ps[:n]
 }
 
-func (h *ProblemsHandler) LoadProblems(responseWriter http.ResponseWriter, request *http.Request) {
+func (h *ProblemsHandler) LoadProblems(responseWriter http.ResponseWriter, _ *http.Request) {
 	views.ExecuteTemplates(responseWriter, nil, nil, baseTemplate, problemsTemplate)
 }
 
@@ -273,7 +273,7 @@ func (h *ProblemsHandler) AddProblem(responseWriter http.ResponseWriter, request
 		editorTemplate, problemAnswerNumericalTemplate, inputTagsTemplate)
 }
 
-func (h *ProblemsHandler) AddConceptModal(responseWriter http.ResponseWriter, request *http.Request) {
+func (h *ProblemsHandler) AddConceptModal(responseWriter http.ResponseWriter, _ *http.Request) {
 	views.ExecuteTemplates(responseWriter, nil, nil, addConceptModalTemplate, curriculumGradeSelectsTemplate)
 }
 

--- a/internal/handlers/subject_handler.go
+++ b/internal/handlers/subject_handler.go
@@ -23,7 +23,7 @@ func NewSubjectsHandler(service *services.Service[models.Subject]) *SubjectsHand
 	}
 }
 
-func (h *SubjectsHandler) GetSubjects(responseWriter http.ResponseWriter, request *http.Request) {
+func (h *SubjectsHandler) GetSubjects(responseWriter http.ResponseWriter, _ *http.Request) {
 	subjects, err := h.service.GetList(handlerutils.SubjectsEndPoint, handlerutils.SubjectsKey, false, false)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching subjects: %v", err), http.StatusInternalServerError)
@@ -42,15 +42,13 @@ func getSubjectName(s models.Subject, lang string) string {
 func getParentSubjectName(s models.Subject, lang string) string {
 	if s.ParentID != 0 {
 		return s.GetParentNameByLang(lang)
-	} else {
-		return s.GetNameByLang(lang)
 	}
+	return s.GetNameByLang(lang)
 }
 
 func getParentSubjectId(s models.Subject) int8 {
 	if s.ParentID != 0 {
 		return s.ParentID
-	} else {
-		return s.ID
 	}
+	return s.ID
 }

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -827,7 +827,7 @@ func (h *TestsHandler) AddTestModal(responseWriter http.ResponseWriter, request 
 	}, addTestModalTemplate, testTypeOptionsTemplate, curriculumGradeSelectsTemplate)
 }
 
-func (h *TestsHandler) AddCurriculumGradeDropdowns(responseWriter http.ResponseWriter, request *http.Request) {
+func (h *TestsHandler) AddCurriculumGradeDropdowns(responseWriter http.ResponseWriter, _ *http.Request) {
 	views.ExecuteTemplates(responseWriter, nil, nil, addCurriculumGradeSelectsTemplate, curriculumGradeSelectsTemplate)
 }
 

--- a/internal/repositories/db/db.go
+++ b/internal/repositories/db/db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	// pq registers the "postgres" driver with database/sql via its init().
 	_ "github.com/lib/pq"
 
 	"github.com/avantifellows/nex-gen-cms/config"

--- a/utils/conversion_util.go
+++ b/utils/conversion_util.go
@@ -21,12 +21,12 @@ func StringToInt(s string) int {
 }
 
 // StringToIntOrDefault converts string to int with validation and fallback
-func StringToIntOrDefault(val string, defaultVal int, min int) int {
+func StringToIntOrDefault(val string, defaultVal int, minVal int) int {
 	if val == "" {
 		return defaultVal
 	}
 
-	if v, err := strconv.Atoi(val); err == nil && v >= min {
+	if v, err := strconv.Atoi(val); err == nil && v >= minVal {
 		return v
 	}
 


### PR DESCRIPTION
**Stacked PR 4 of 6** — review on top of `lint/3-error-handling`.

Fifteen small revive fixes: rename ten genuinely-unused handler params to `_`, drop three `else`-after-`return` blocks (indent-error-flow), document a blank `_ "github.com/lib/pq"` import, and rename a `min` parameter that shadowed the builtin.

Part of a stacked series that cleans up `golangci-lint` findings by category, one PR each, so review stays small; merge in order 1→6. (The naming-convention PR was dropped as low priority for now.)

### Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race ./...` ✓
- `golangci-lint run ./...` ✓ (this category clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### 📚 Stack (merge in order)
1. #138 — 1 - Lint: format imports and fix spelling
2. #139 — 2 - Lint: remove redundant code and simplify
3. #140 — 3 - Lint: check previously ignored errors
4. **#141** ◀ this PR — 4 - Lint: minor style fixes
5. #143 — 5 - Lint: dedupe exam/grade handlers
6. #144 — 6 - Lint: reduce cognitive complexity
