### PR TITLE
5 - Lint: apply Go naming conventions (initialisms, receivers, consts)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,7 +70,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	constants.InitRuntimeConstant()
 	configLoader.LoadEnv(new(config.Env))
 
-	muxHandler.Handle("/web/", appComponentPtr.CssPathHandler)
+	muxHandler.Handle("/web/", appComponentPtr.CSSPathHandler)
 
 	muxHandler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -68,7 +68,7 @@ func TestSetup(t *testing.T) {
 		pattern string
 		handler http.Handler
 	}{
-		{"/web/", appComponentPtr.CssPathHandler},
+		{"/web/", appComponentPtr.CSSPathHandler},
 		{"/", http.HandlerFunc(handlers.GenericHandler)},
 		{"/tests", http.HandlerFunc(handlers.GenericHandler)},
 		{"/add-chapter", http.HandlerFunc(handlers.GenericHandler)},
@@ -94,7 +94,7 @@ func TestSetup(t *testing.T) {
 	setup(mockConfig, mockServeMux, appComponentPtr)
 
 	// verify if runtime constants are  initialized
-	assert.NotEmpty(t, constants.GetHtmlFolderPath(), "Runtime constants are not initilized")
+	assert.NotEmpty(t, constants.GetHTMLFolderPath(), "Runtime constants are not initilized")
 
 	// verify if environment variables are loaded from .env file
 	mockConfig.AssertCalled(t, "LoadEnv", mock.Anything)

--- a/di/app_component.go
+++ b/di/app_component.go
@@ -17,7 +17,7 @@ import (
 
 type AppComponent struct {
 	DB                 *sql.DB
-	CssPathHandler     http.Handler
+	CSSPathHandler     http.Handler
 	LoginHandler       *handlers.LoginHandler
 	AdminUsersHandler  *handlers.AdminUsersHandler
 	ChaptersHandler    *handlers.ChaptersHandler
@@ -88,7 +88,7 @@ func NewAppComponent() (*AppComponent, error) {
 
 	return &AppComponent{
 		DB:                 database,
-		CssPathHandler:     cssPathHandler,
+		CSSPathHandler:     cssPathHandler,
 		LoginHandler:       loginHandler,
 		AdminUsersHandler:  adminUsersHandler,
 		ChaptersHandler:    chaptersHandler,

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -41,6 +41,6 @@ func initialize() {
 	}
 }
 
-func GetHtmlFolderPath() string {
+func GetHTMLFolderPath() string {
 	return htmlFolder
 }

--- a/internal/dto/chapter_dto.go
+++ b/internal/dto/chapter_dto.go
@@ -8,6 +8,6 @@ type ChapterData struct {
 }
 
 type ResourcesData struct {
-	ChapterId string
-	TopicId   string
+	ChapterID string
+	TopicID   string
 }

--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -49,12 +49,12 @@ func (h *ChaptersHandler) LoadChapters(responseWriter http.ResponseWriter, _ *ht
 
 func (h *ChaptersHandler) GetChapters(responseWriter http.ResponseWriter, request *http.Request) {
 	urlVals := request.URL.Query()
-	curriculumId, gradeId, subjectId := getCurriculumGradeSubjectIds(urlVals)
-	if curriculumId == 0 || gradeId == 0 || subjectId == 0 {
+	curriculumID, gradeID, subjectID := getCurriculumGradeSubjectIDs(urlVals)
+	if curriculumID == 0 || gradeID == 0 || subjectID == 0 {
 		return
 	}
 
-	queryParams := fmt.Sprintf("?"+QUERY_PARAM_CURRICULUM_ID+"=%d&grade_id=%d&subject_id=%d", curriculumId, gradeId, subjectId)
+	queryParams := fmt.Sprintf("?"+QueryParamCurriculumID+"=%d&grade_id=%d&subject_id=%d", curriculumID, gradeID, subjectID)
 	chapters, err := h.chaptersService.GetList(chaptersEndPoint+queryParams, chaptersKey, false, true)
 
 	if err != nil {
@@ -66,7 +66,7 @@ func (h *ChaptersHandler) GetChapters(responseWriter http.ResponseWriter, reques
 	}).([]*models.Chapter)
 
 	for _, chapterPtr := range *chapters {
-		chapterPtr.CurriculumID = curriculumId
+		chapterPtr.CurriculumID = curriculumID
 	}
 
 	h.getTopics(responseWriter, *chapters)
@@ -145,8 +145,8 @@ func (h *ChaptersHandler) EditChapter(responseWriter http.ResponseWriter, reques
 }
 
 func (h *ChaptersHandler) UpdateChapter(responseWriter http.ResponseWriter, request *http.Request) {
-	chapterIdStr := request.FormValue("id")
-	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+	chapterIDStr := request.FormValue("id")
+	chapterID, err := utils.StringToIntType[int16](chapterIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Chapter ID", http.StatusBadRequest)
 		return
@@ -158,9 +158,9 @@ func (h *ChaptersHandler) UpdateChapter(responseWriter http.ResponseWriter, requ
 	dummyChapterPtr := &models.Chapter{}
 	chapterMap := dummyChapterPtr.BuildMap(chapterCode, chapterName)
 
-	_, err = h.chaptersService.UpdateObject(chapterIdStr, chaptersEndPoint, chapterMap, chaptersKey,
+	_, err = h.chaptersService.UpdateObject(chapterIDStr, chaptersEndPoint, chapterMap, chaptersKey,
 		func(chapter *models.Chapter) bool {
-			return (*chapter).ID == chapterId
+			return (*chapter).ID == chapterID
 		})
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error updating chapter: %v", err), http.StatusInternalServerError)
@@ -173,25 +173,25 @@ func (h *ChaptersHandler) UpdateChapter(responseWriter http.ResponseWriter, requ
 func (h *ChaptersHandler) AddChapter(responseWriter http.ResponseWriter, request *http.Request) {
 	chapterCode := request.FormValue("code")
 	chapterName := request.FormValue("name")
-	curriculumIdStr := request.FormValue(CURRICULUM_DROPDOWN_NAME)
-	curriculumId, err := utils.StringToIntType[int16](curriculumIdStr)
+	curriculumIDStr := request.FormValue(CurriculumDropdownName)
+	curriculumID, err := utils.StringToIntType[int16](curriculumIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Curriculum ID", http.StatusBadRequest)
 		return
 	}
-	gradeIdStr := request.FormValue(GRADE_DROPDOWN_NAME)
-	gradeId, err := utils.StringToIntType[int8](gradeIdStr)
+	gradeIDStr := request.FormValue(GradeDropdownName)
+	gradeID, err := utils.StringToIntType[int8](gradeIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Grade ID", http.StatusBadRequest)
 		return
 	}
-	subjectIdStr := request.FormValue(SUBJECT_DROPDOWN_NAME)
-	subjectId, err := utils.StringToIntType[int8](subjectIdStr)
+	subjectIDStr := request.FormValue(SubjectDropdownName)
+	subjectID, err := utils.StringToIntType[int8](subjectIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Subject ID", http.StatusBadRequest)
 		return
 	}
-	newChapterPtr := models.NewChapter(chapterCode, chapterName, curriculumId, gradeId, subjectId)
+	newChapterPtr := models.NewChapter(chapterCode, chapterName, curriculumID, gradeID, subjectID)
 
 	newChapterPtr, err = h.chaptersService.AddObject(newChapterPtr, chaptersKey, chaptersEndPoint)
 	if err != nil {
@@ -206,8 +206,8 @@ func (h *ChaptersHandler) AddChapter(responseWriter http.ResponseWriter, request
 }
 
 func (h *ChaptersHandler) ArchiveChapter(responseWriter http.ResponseWriter, request *http.Request) {
-	chapterIdStr := request.URL.Query().Get("id")
-	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+	chapterIDStr := request.URL.Query().Get("id")
+	chapterID, err := utils.StringToIntType[int16](chapterIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Chapter ID", http.StatusBadRequest)
 		return
@@ -217,9 +217,9 @@ func (h *ChaptersHandler) ArchiveChapter(responseWriter http.ResponseWriter, req
 		"cms_status_id": constants.StatusArchived,
 	}
 
-	err = h.chaptersService.ArchiveObject(chapterIdStr, chaptersEndPoint, chapterMap, chaptersKey,
+	err = h.chaptersService.ArchiveObject(chapterIDStr, chaptersEndPoint, chapterMap, chaptersKey,
 		func(chapter *models.Chapter) bool {
-			return (*chapter).ID != chapterId
+			return (*chapter).ID != chapterID
 		})
 
 	// If http error is thrown from here then target row won't be removed by htmx code
@@ -259,19 +259,19 @@ func sortChapters(chapterPtrs []*models.Chapter, sortColumn string, sortOrder st
 
 func (h *ChaptersHandler) getChapter(request *http.Request) (*models.Chapter, int, error) {
 	urlVals := request.URL.Query()
-	chapterIdStr := urlVals.Get("id")
+	chapterIDStr := urlVals.Get("id")
 
-	if chapterIdStr == "" {
-		chapterIdStr = urlVals.Get("chapter-dropdown")
+	if chapterIDStr == "" {
+		chapterIDStr = urlVals.Get("chapter-dropdown")
 	}
-	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+	chapterID, err := utils.StringToIntType[int16](chapterIDStr)
 	if err != nil {
 		return nil, http.StatusBadRequest, fmt.Errorf("invalid Chapter ID: %w", err)
 	}
 
-	selectedChapterPtr, err := h.chaptersService.GetObject(chapterIdStr,
+	selectedChapterPtr, err := h.chaptersService.GetObject(chapterIDStr,
 		func(chapter *models.Chapter) bool {
-			return (*chapter).ID == chapterId
+			return (*chapter).ID == chapterID
 		}, chaptersKey, chaptersEndPoint)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching chapter: %v", err)
@@ -287,16 +287,16 @@ func (h *ChaptersHandler) GetChapter(responseWriter http.ResponseWriter, request
 		return
 	}
 
-	curriculumId, gradeId, subjectId := getCurriculumGradeSubjectIds(request.URL.Query())
-	if curriculumId == 0 || gradeId == 0 || subjectId == 0 {
+	curriculumID, gradeID, subjectID := getCurriculumGradeSubjectIDs(request.URL.Query())
+	if curriculumID == 0 || gradeID == 0 || subjectID == 0 {
 		return
 	}
 
 	data := dto.ChapterData{
 		HomeData: dto.HomeData{
-			CurriculumID: curriculumId,
-			GradeID:      gradeId,
-			SubjectID:    subjectId,
+			CurriculumID: curriculumID,
+			GradeID:      gradeID,
+			SubjectID:    subjectID,
 		},
 		ChapterPtr: selectedChapterPtr,
 	}
@@ -306,17 +306,17 @@ func (h *ChaptersHandler) GetChapter(responseWriter http.ResponseWriter, request
 }
 
 func (h *ChaptersHandler) LoadTopics(responseWriter http.ResponseWriter, request *http.Request) {
-	chapterIdStr := request.URL.Query().Get("id")
+	chapterIDStr := request.URL.Query().Get("id")
 	data := dto.TopicsData{
-		ChapterID: chapterIdStr,
+		ChapterID: chapterIDStr,
 	}
 	views.ExecuteTemplate(topicsTemplate, responseWriter, data, nil)
 }
 
 func (h *ChaptersHandler) LoadResources(responseWriter http.ResponseWriter, request *http.Request) {
-	chapterIdStr := request.URL.Query().Get("chapterId")
+	chapterIDStr := request.URL.Query().Get("chapterId")
 	data := dto.ResourcesData{
-		ChapterId: chapterIdStr,
+		ChapterID: chapterIDStr,
 	}
 	views.ExecuteTemplate(resourcesTemplate, responseWriter, data, nil)
 }
@@ -354,9 +354,9 @@ func (h *ChaptersHandler) GetTopics(responseWriter http.ResponseWriter, request 
 	// Use a local copy so we never mutate the cached chapter pointer.
 	localChapter := *selectedChapterPtr
 	localChapter.Topics = nil
-	curriculumId, _, _ := getCurriculumGradeSubjectIds(urlVals)
-	if curriculumId != 0 {
-		localChapter.CurriculumID = curriculumId
+	curriculumID, _, _ := getCurriculumGradeSubjectIDs(urlVals)
+	if curriculumID != 0 {
+		localChapter.CurriculumID = curriculumID
 	}
 	h.getTopics(responseWriter, []*models.Chapter{&localChapter})
 

--- a/internal/handlers/concept_handler.go
+++ b/internal/handlers/concept_handler.go
@@ -33,14 +33,14 @@ func (h *ConceptsHandler) GetConcepts(responseWriter http.ResponseWriter, reques
 	queryParams := ""
 
 	urlVals := request.URL.Query()
-	if urlVals.Has(QUERY_PARAM_TOPIC_ID) {
-		topicIdStr := urlVals.Get(QUERY_PARAM_TOPIC_ID)
-		topicId, err := utils.StringToIntType[int16](topicIdStr)
+	if urlVals.Has(QueryParamTopicID) {
+		topicIDStr := urlVals.Get(QueryParamTopicID)
+		topicID, err := utils.StringToIntType[int16](topicIDStr)
 		if err != nil {
 			http.Error(responseWriter, fmt.Sprintf("Invalid Topic ID: %v", err), http.StatusBadRequest)
 			return
 		}
-		queryParams = fmt.Sprintf("?"+QUERY_PARAM_TOPIC_ID+"=%d", topicId)
+		queryParams = fmt.Sprintf("?"+QueryParamTopicID+"=%d", topicID)
 	}
 	concepts, err := h.service.GetList(conceptsEndPoint+queryParams, conceptsKey, false, true)
 	if err != nil {
@@ -55,18 +55,18 @@ func (h *ConceptsHandler) GetConcepts(responseWriter http.ResponseWriter, reques
 		// no exclusion, just reuse
 		filtered = concepts
 	} else {
-		excludeIds := make(map[int32]struct{})
+		excludeIDs := make(map[int32]struct{})
 		for _, idStr := range strings.Split(excludeStr, ",") {
 			if idStr == "" {
 				continue
 			}
 			if id, err := utils.StringToIntType[int32](idStr); err == nil {
-				excludeIds[id] = struct{}{}
+				excludeIDs[id] = struct{}{}
 			}
 		}
 		tmp := make([]*models.Concept, 0, len(*concepts))
 		for _, c := range *concepts {
-			if _, found := excludeIds[c.ID]; !found {
+			if _, found := excludeIDs[c.ID]; !found {
 				tmp = append(tmp, c)
 			}
 		}

--- a/internal/handlers/curriculum_handler.go
+++ b/internal/handlers/curriculum_handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/avantifellows/nex-gen-cms/internal/views"
 )
 
-const QUERY_PARAM_CURRICULUM_ID = "curriculum_id"
+const QueryParamCurriculumID = "curriculum_id"
 
 const getCurriculumsEndPoint = "curriculum"
 const curriculumsKey = "curriculums"

--- a/internal/handlers/generic_handler.go
+++ b/internal/handlers/generic_handler.go
@@ -13,9 +13,9 @@ import (
 	"github.com/avantifellows/nex-gen-cms/utils"
 )
 
-const CURRICULUM_DROPDOWN_NAME = "curriculum-dropdown"
-const GRADE_DROPDOWN_NAME = "grade-dropdown"
-const SUBJECT_DROPDOWN_NAME = "subject-dropdown"
+const CurriculumDropdownName = "curriculum-dropdown"
+const GradeDropdownName = "grade-dropdown"
+const SubjectDropdownName = "subject-dropdown"
 
 const baseTemplate = "home.html"
 
@@ -29,7 +29,7 @@ func GenericHandler(responseWriter http.ResponseWriter, request *http.Request) {
 	// All urls contain -, which are replaced by _ in file names, hence replace hyphens by underscores
 	filename := strings.ReplaceAll(path, "-", "_")
 	// Define the template file path
-	filePath := filepath.Join(constants.GetHtmlFolderPath(), filename+".html")
+	filePath := filepath.Join(constants.GetHTMLFolderPath(), filename+".html")
 
 	// Parse the template
 	tmpl, err := template.ParseFiles(filePath)
@@ -46,19 +46,19 @@ func GenericHandler(responseWriter http.ResponseWriter, request *http.Request) {
 	}
 }
 
-func getCurriculumGradeSubjectIds(urlValues url.Values) (int16, int8, int8) {
+func getCurriculumGradeSubjectIDs(urlValues url.Values) (int16, int8, int8) {
 	// these query parameters can be queried by element names only, not ids
-	curriculumId, err := utils.StringToIntType[int16](urlValues.Get(CURRICULUM_DROPDOWN_NAME))
+	curriculumID, err := utils.StringToIntType[int16](urlValues.Get(CurriculumDropdownName))
 	if err != nil {
 		fmt.Println("Selected Curriculum is invalid")
 	}
-	gradeId, err := utils.StringToIntType[int8](urlValues.Get(GRADE_DROPDOWN_NAME))
+	gradeID, err := utils.StringToIntType[int8](urlValues.Get(GradeDropdownName))
 	if err != nil {
 		fmt.Println("Selected Grade is invalid")
 	}
-	subjectId, err := utils.StringToIntType[int8](urlValues.Get(SUBJECT_DROPDOWN_NAME))
+	subjectID, err := utils.StringToIntType[int8](urlValues.Get(SubjectDropdownName))
 	if err != nil {
 		fmt.Println("Selected Subject is invalid")
 	}
-	return curriculumId, gradeId, subjectId
+	return curriculumID, gradeID, subjectID
 }

--- a/internal/handlers/handlerutils/subject_util.go
+++ b/internal/handlers/handlerutils/subject_util.go
@@ -13,16 +13,16 @@ const SubjectsEndPoint = "subject"
 const SubjectsKey = "subjects"
 
 func FetchSelectedSubject(
-	subIdStr string,
+	subIDStr string,
 	subjectsService *services.Service[models.Subject],
 ) (*models.Subject, int, error) {
-	subjectId, err := utils.StringToIntType[int8](subIdStr)
+	subjectID, err := utils.StringToIntType[int8](subIDStr)
 	if err != nil {
 		return nil, http.StatusBadRequest, fmt.Errorf("invalid subject ID: %w", err)
 	}
 
-	selectedSubPtr, err := subjectsService.GetObject(subIdStr, func(subject *models.Subject) bool {
-		return subject.ID == subjectId
+	selectedSubPtr, err := subjectsService.GetObject(subIDStr, func(subject *models.Subject) bool {
+		return subject.ID == subjectID
 	}, SubjectsKey, SubjectsEndPoint)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching subject: %w", err)

--- a/internal/handlers/handlerutils/topic_util.go
+++ b/internal/handlers/handlerutils/topic_util.go
@@ -12,15 +12,15 @@ import (
 const TopicsEndPoint = "topic"
 const TopicsKey = "topics"
 
-func GetTopicById(topicIdStr string, topicsService *services.Service[models.Topic]) (*models.Topic, int, error) {
-	topicId, err := utils.StringToIntType[int16](topicIdStr)
+func GetTopicByID(topicIDStr string, topicsService *services.Service[models.Topic]) (*models.Topic, int, error) {
+	topicID, err := utils.StringToIntType[int16](topicIDStr)
 	if err != nil {
 		return nil, http.StatusBadRequest, fmt.Errorf("invalid Topic ID: %w", err)
 	}
 
-	selectedTopicPtr, err := topicsService.GetObject(topicIdStr,
+	selectedTopicPtr, err := topicsService.GetObject(topicIDStr,
 		func(topic *models.Topic) bool {
-			return (*topic).ID == topicId
+			return (*topic).ID == topicID
 		}, TopicsKey, TopicsEndPoint)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching topic: %v", err)

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -84,15 +84,15 @@ func (h *ProblemsHandler) GetProblem(responseWriter http.ResponseWriter, request
 }
 
 func (h *ProblemsHandler) getProblem(urlValues url.Values) (*models.Problem, int, error) {
-	problemIdStr := urlValues.Get("id")
-	problemId := utils.StringToInt(problemIdStr)
-	endPointWithId := fmt.Sprintf(problemEndPoint, problemId, urlValues.Get(QUERY_PARAM_CURRICULUM_ID))
+	problemIDStr := urlValues.Get("id")
+	problemID := utils.StringToInt(problemIDStr)
+	endPointWithID := fmt.Sprintf(problemEndPoint, problemID, urlValues.Get(QueryParamCurriculumID))
 
 	// In problemEndPoint problem id is already included in path segment, hence passing blank as first argument
 	selectedProblemPtr, err := h.problemsService.GetObject("",
 		func(problem *models.Problem) bool {
-			return problem.ID == problemId
-		}, problemsKey, endPointWithId)
+			return problem.ID == problemID
+		}, problemsKey, endPointWithID)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching problem: %v", err)
 	}
@@ -111,8 +111,8 @@ func (h *ProblemsHandler) getProblem(urlValues url.Values) (*models.Problem, int
 	}
 
 	// Loop through skill ids and add corresponding skills
-	for _, skillId := range selectedProblemPtr.SkillIDs {
-		selectedProblemPtr.Skills = append(selectedProblemPtr.Skills, *skillPtrsMap[skillId])
+	for _, skillID := range selectedProblemPtr.SkillIDs {
+		selectedProblemPtr.Skills = append(selectedProblemPtr.Skills, *skillPtrsMap[skillID])
 	}
 	return selectedProblemPtr, http.StatusOK, nil
 }
@@ -121,14 +121,14 @@ func (h *ProblemsHandler) GetTopicProblems(responseWriter http.ResponseWriter, r
 	const includeParagraphSiblingsParam = "include_paragraph_siblings"
 
 	urlValues := request.URL.Query()
-	topicIdStr := urlValues.Get("topic-dropdown")
-	topicId, err := utils.StringToIntType[int16](topicIdStr)
+	topicIDStr := urlValues.Get("topic-dropdown")
+	topicID, err := utils.StringToIntType[int16](topicIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Topic ID", http.StatusBadRequest)
 		return
 	}
 
-	queryParams := fmt.Sprintf("?"+QUERY_PARAM_CURRICULUM_ID+"=%s&topic_id=%d&lang_code=en", urlValues.Get(CURRICULUM_DROPDOWN_NAME), topicId)
+	queryParams := fmt.Sprintf("?"+QueryParamCurriculumID+"=%s&topic_id=%d&lang_code=en", urlValues.Get(CurriculumDropdownName), topicID)
 	if urlValues.Has(includeParagraphSiblingsParam) {
 		queryParams += "&" + includeParagraphSiblingsParam + "=" + urlValues.Get(includeParagraphSiblingsParam)
 	}
@@ -138,7 +138,7 @@ func (h *ProblemsHandler) GetTopicProblems(responseWriter http.ResponseWriter, r
 		return
 	}
 
-	subjectPtr, statusCode, err := handlerutils.FetchSelectedSubject(urlValues.Get(SUBJECT_DROPDOWN_NAME),
+	subjectPtr, statusCode, err := handlerutils.FetchSelectedSubject(urlValues.Get(SubjectDropdownName),
 		h.subjectsService)
 	if err != nil {
 		http.Error(responseWriter, err.Error(), statusCode)
@@ -156,15 +156,15 @@ func (h *ProblemsHandler) GetTopicProblems(responseWriter http.ResponseWriter, r
 		problemPtr.Subject = *subjectPtr
 
 		// Loop through tag ids and add corresponding tag names
-		for _, tagId := range problemPtr.TagIDs {
-			problemPtr.TagNames = append(problemPtr.TagNames, tagsMap[tagId])
+		for _, tagID := range problemPtr.TagIDs {
+			problemPtr.TagNames = append(problemPtr.TagNames, tagsMap[tagID])
 		}
 	}
 
 	levels := urlValues["level"]
 	ptype := urlValues.Get("ptype-dropdown")
-	selectedIds := urlValues.Get("selected-ids")
-	filterProblems(problems, levels, ptype, selectedIds)
+	selectedIDs := urlValues.Get("selected-ids")
+	filterProblems(problems, levels, ptype, selectedIDs)
 
 	if urlValues.Has("ptype-dropdown") {
 		// for add/edit test screen
@@ -193,11 +193,11 @@ func (h *ProblemsHandler) getTagsMap() (map[int]string, error) {
 	return tagsMap, nil
 }
 
-func filterProblems(problems *[]*models.Problem, levels []string, ptype string, selectedIdsRaw string) {
+func filterProblems(problems *[]*models.Problem, levels []string, ptype string, selectedIDsRaw string) {
 	// Build map of already selected problem ids. map is used instead of slice for better performance
-	selectedIds := map[int]bool{}
-	for _, id := range strings.Split(selectedIdsRaw, ",") {
-		selectedIds[utils.StringToInt(id)] = true
+	selectedIDs := map[int]bool{}
+	for _, id := range strings.Split(selectedIDsRaw, ",") {
+		selectedIDs[utils.StringToInt(id)] = true
 	}
 
 	// Build a map of allowed difficulty levels for fast lookup
@@ -230,7 +230,7 @@ func filterProblems(problems *[]*models.Problem, levels []string, ptype string, 
 		}
 
 		// skip already selected ones
-		if selectedIds[p.ID] {
+		if selectedIDs[p.ID] {
 			continue
 		}
 
@@ -246,13 +246,13 @@ func (h *ProblemsHandler) LoadProblems(responseWriter http.ResponseWriter, _ *ht
 }
 
 func (h *ProblemsHandler) LoadTopicProblems(responseWriter http.ResponseWriter, request *http.Request) {
-	topicIdStr := request.URL.Query().Get(QUERY_PARAM_TOPIC_ID)
-	views.ExecuteTemplate(topicProblemsTemplate, responseWriter, topicIdStr, nil)
+	topicIDStr := request.URL.Query().Get(QueryParamTopicID)
+	views.ExecuteTemplate(topicProblemsTemplate, responseWriter, topicIDStr, nil)
 }
 
 func (h *ProblemsHandler) AddProblem(responseWriter http.ResponseWriter, request *http.Request) {
-	topicIdStr := request.URL.Query().Get(QUERY_PARAM_TOPIC_ID)
-	selectedTopicPtr, code, err := handlerutils.GetTopicById(topicIdStr, h.topicsService)
+	topicIDStr := request.URL.Query().Get(QueryParamTopicID)
+	selectedTopicPtr, code, err := handlerutils.GetTopicByID(topicIDStr, h.topicsService)
 	if err != nil {
 		http.Error(responseWriter, err.Error(), code)
 		return
@@ -265,7 +265,7 @@ func (h *ProblemsHandler) AddProblem(responseWriter http.ResponseWriter, request
 		"joinInt16":        utils.JoinInt16,
 		"add":              utils.Add,
 		"stringToInt":      utils.StringToInt,
-		"toJson":           utils.ToJson,
+		"toJson":           utils.ToJSON,
 		"getConceptName":   getConceptName,
 		"dict":             utils.Dict,
 		"emptyStringSlice": utils.EmptyStringSlice,
@@ -327,7 +327,7 @@ func (h *ProblemsHandler) EditProblem(responseWriter http.ResponseWriter, reques
 		"joinInt16":        utils.JoinInt16,
 		"add":              utils.Add,
 		"stringToInt":      utils.StringToInt,
-		"toJson":           utils.ToJson,
+		"toJson":           utils.ToJSON,
 		"getConceptName":   getConceptName,
 		"dict":             utils.Dict,
 		"emptyStringSlice": utils.EmptyStringSlice,
@@ -342,12 +342,12 @@ func (h *ProblemsHandler) UpdateProblem(responseWriter http.ResponseWriter, requ
 		return
 	}
 
-	problemIdStr := request.URL.Query().Get("id")
-	problemId := utils.StringToInt(problemIdStr)
+	problemIDStr := request.URL.Query().Get("id")
+	problemID := utils.StringToInt(problemIDStr)
 
-	_, err = h.problemsService.UpdateObject(problemIdStr, resourcesEndPoint, reqBodyBytes, problemsKey,
+	_, err = h.problemsService.UpdateObject(problemIDStr, resourcesEndPoint, reqBodyBytes, problemsKey,
 		func(problem *models.Problem) bool {
-			return (*problem).ID == problemId
+			return (*problem).ID == problemID
 		})
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error updating problem: %v", err), http.StatusInternalServerError)
@@ -356,16 +356,16 @@ func (h *ProblemsHandler) UpdateProblem(responseWriter http.ResponseWriter, requ
 }
 
 func (h *ProblemsHandler) ArchiveProblem(responseWriter http.ResponseWriter, request *http.Request) {
-	problemIdStr := request.URL.Query().Get("id")
-	problemId := utils.StringToInt(problemIdStr)
+	problemIDStr := request.URL.Query().Get("id")
+	problemID := utils.StringToInt(problemIDStr)
 	body := map[string]any{
 		"cms_status_id": constants.StatusArchived,
 		"lang_code":     "en",
 	}
 
-	err := h.problemsService.ArchiveObject(problemIdStr, resourcesEndPoint, body, problemsKey,
+	err := h.problemsService.ArchiveObject(problemIDStr, resourcesEndPoint, body, problemsKey,
 		func(problem *models.Problem) bool {
-			return problem.ID != problemId
+			return problem.ID != problemID
 		})
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error archiving problem: %v", err), http.StatusInternalServerError)
@@ -381,9 +381,9 @@ func (h *ProblemsHandler) GetSearchProblems(responseWriter http.ResponseWriter, 
 	offset := utils.StringToIntOrDefault(urlVals.Get("offset"), 0, 0) // min = 0
 	queryParams := "?lang_code=en&search=" + url.QueryEscape(search) + "&limit=" + strconv.Itoa(limit) + "&offset=" + strconv.Itoa(offset)
 
-	subjectId := utils.StringToInt(urlVals.Get("problems-subject-dropdown"))
-	if subjectId != 0 {
-		queryParams += "&subject_id=" + strconv.Itoa(subjectId)
+	subjectID := utils.StringToInt(urlVals.Get("problems-subject-dropdown"))
+	if subjectID != 0 {
+		queryParams += "&subject_id=" + strconv.Itoa(subjectID)
 	}
 
 	problems, err := h.problemsService.GetList(searchProblemsEndPoint+queryParams, "", false, true)
@@ -429,8 +429,8 @@ func (h *ProblemsHandler) GetSearchProblems(responseWriter http.ResponseWriter, 
 		problemPtr.Subject = *subjectPtr
 
 		// Loop through tag ids and add corresponding tag names
-		for _, tagId := range problemPtr.TagIDs {
-			problemPtr.TagNames = append(problemPtr.TagNames, tagsMap[tagId])
+		for _, tagID := range problemPtr.TagIDs {
+			problemPtr.TagNames = append(problemPtr.TagNames, tagsMap[tagID])
 		}
 	}
 
@@ -477,41 +477,41 @@ func (h *ProblemsHandler) MoveProblems(responseWriter http.ResponseWriter, reque
 		return
 	}
 
-	curriculumId, gradeId, subjectId := getCurriculumGradeSubjectIds(request.Form)
-	if curriculumId == 0 || gradeId == 0 || subjectId == 0 {
+	curriculumID, gradeID, subjectID := getCurriculumGradeSubjectIDs(request.Form)
+	if curriculumID == 0 || gradeID == 0 || subjectID == 0 {
 		http.Error(responseWriter, "Invalid curriculum, grade or subject ID", http.StatusBadRequest)
 		return
 	}
 
-	chapterIdStr := request.Form.Get("chapter-dropdown")
-	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+	chapterIDStr := request.Form.Get("chapter-dropdown")
+	chapterID, err := utils.StringToIntType[int16](chapterIDStr)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Invalid Chapter ID: %v", err), http.StatusBadRequest)
 		return
 	}
 
-	topicIdStr := request.Form.Get("topic_id")
-	topicId, err := utils.StringToIntType[int16](topicIdStr)
+	topicIDStr := request.Form.Get("topic_id")
+	topicID, err := utils.StringToIntType[int16](topicIDStr)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Invalid Topic ID: %v", err), http.StatusBadRequest)
 		return
 	}
-	topicIdPtr := &topicId
+	topicIDPtr := &topicID
 
-	problemIdsStr := request.Form.Get("problem_ids")
-	problemIds := utils.StringSliceToIntSlice(strings.Split(problemIdsStr, ","))
+	problemIDsStr := request.Form.Get("problem_ids")
+	problemIDs := utils.StringSliceToIntSlice(strings.Split(problemIDsStr, ","))
 
 	reqBody := dto.MoveResourcesRequest{
-		ResourceIDs: problemIds,
+		ResourceIDs: problemIDs,
 		CurriculumGrades: []models.CurriculumGrade{
 			{
-				CurriculumID: curriculumId,
-				GradeID:      gradeId,
+				CurriculumID: curriculumID,
+				GradeID:      gradeID,
 			},
 		},
-		SubjectID: subjectId,
-		ChapterID: chapterId,
-		TopicID:   topicIdPtr,
+		SubjectID: subjectID,
+		ChapterID: chapterID,
+		TopicID:   topicIDPtr,
 		LangCode:  "en",
 	}
 

--- a/internal/handlers/resource_handler.go
+++ b/internal/handlers/resource_handler.go
@@ -49,11 +49,11 @@ func NewResourcesHandler(service *services.Service[models.Resource]) *ResourcesH
 }
 
 func (h *ResourcesHandler) OpenAddResource(responseWriter http.ResponseWriter, request *http.Request) {
-	chapterId := request.URL.Query().Get("chapterId")
-	topicId := request.URL.Query().Get("topicId")
+	chapterID := request.URL.Query().Get("chapterId")
+	topicID := request.URL.Query().Get("topicId")
 	data := addResourceTemplateData{
-		ChapterID:   chapterId,
-		TopicID:     topicId,
+		ChapterID:   chapterID,
+		TopicID:     topicID,
 		TypeOptions: resourceTypeOptions,
 	}
 	views.ExecuteTemplate(addResourceTemplate, responseWriter, data, nil)
@@ -61,38 +61,38 @@ func (h *ResourcesHandler) OpenAddResource(responseWriter http.ResponseWriter, r
 
 func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, request *http.Request) {
 	urlVals := request.URL.Query()
-	curriculumIdStr := urlVals.Get(CURRICULUM_DROPDOWN_NAME)
-	gradeIdStr := urlVals.Get(GRADE_DROPDOWN_NAME)
-	chapterIdStr := urlVals.Get("chapter_id")
-	topicIdStr := urlVals.Get("topic_id")
+	curriculumIDStr := urlVals.Get(CurriculumDropdownName)
+	gradeIDStr := urlVals.Get(GradeDropdownName)
+	chapterIDStr := urlVals.Get("chapter_id")
+	topicIDStr := urlVals.Get("topic_id")
 
-	curriculumId, err := utils.StringToIntType[int16](curriculumIdStr)
+	curriculumID, err := utils.StringToIntType[int16](curriculumIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Curriculum ID", http.StatusBadRequest)
 		return
 	}
-	gradeId, err := utils.StringToIntType[int8](gradeIdStr)
+	gradeID, err := utils.StringToIntType[int8](gradeIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Grade ID", http.StatusBadRequest)
 		return
 	}
 
-	isTopicRequest := strings.TrimSpace(topicIdStr) != ""
+	isTopicRequest := strings.TrimSpace(topicIDStr) != ""
 	var queryParams string
 	if isTopicRequest {
-		topicId, err := utils.StringToIntType[int16](topicIdStr)
+		topicID, err := utils.StringToIntType[int16](topicIDStr)
 		if err != nil {
 			http.Error(responseWriter, "Invalid Topic ID", http.StatusBadRequest)
 			return
 		}
-		queryParams = fmt.Sprintf("?curriculum_id=%d&grade_id=%d&topic_id=%d", curriculumId, gradeId, topicId)
+		queryParams = fmt.Sprintf("?curriculum_id=%d&grade_id=%d&topic_id=%d", curriculumID, gradeID, topicID)
 	} else {
-		chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+		chapterID, err := utils.StringToIntType[int16](chapterIDStr)
 		if err != nil {
 			http.Error(responseWriter, "Invalid Chapter ID", http.StatusBadRequest)
 			return
 		}
-		queryParams = fmt.Sprintf("?curriculum_id=%d&grade_id=%d&chapter_id=%d", curriculumId, gradeId, chapterId)
+		queryParams = fmt.Sprintf("?curriculum_id=%d&grade_id=%d&chapter_id=%d", curriculumID, gradeID, chapterID)
 	}
 
 	resources, err := h.service.GetList(resourcesCurriculumEndPoint+queryParams, resourcesKey, false, true)
@@ -121,16 +121,16 @@ func (h *ResourcesHandler) GetResources(responseWriter http.ResponseWriter, requ
 }
 
 func (h *ResourcesHandler) EditResource(responseWriter http.ResponseWriter, request *http.Request) {
-	resourceIdStr := request.URL.Query().Get("id")
-	resourceId, err := utils.StringToIntType[int32](resourceIdStr)
+	resourceIDStr := request.URL.Query().Get("id")
+	resourceID, err := utils.StringToIntType[int32](resourceIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Resource ID", http.StatusBadRequest)
 		return
 	}
 
-	selectedResourcePtr, err := h.service.GetObject(resourceIdStr,
+	selectedResourcePtr, err := h.service.GetObject(resourceIDStr,
 		func(resource *models.Resource) bool {
-			return resource.ID == int(resourceId)
+			return resource.ID == int(resourceID)
 		}, resourcesKey, resourcesEndPoint)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching resource: %v", err), http.StatusInternalServerError)
@@ -147,8 +147,8 @@ func (h *ResourcesHandler) EditResource(responseWriter http.ResponseWriter, requ
 }
 
 func (h *ResourcesHandler) UpdateResource(responseWriter http.ResponseWriter, request *http.Request) {
-	resourceIdStr := request.FormValue("id")
-	resourceId, err := utils.StringToIntType[int32](resourceIdStr)
+	resourceIDStr := request.FormValue("id")
+	resourceID, err := utils.StringToIntType[int32](resourceIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Resource ID", http.StatusBadRequest)
 		return
@@ -163,9 +163,9 @@ func (h *ResourcesHandler) UpdateResource(responseWriter http.ResponseWriter, re
 	dummyResourcePtr := &models.Resource{}
 	resourceMap := dummyResourcePtr.BuildMap(resourceCode, resourceName, resourceType, resourceSubtype, srcLink)
 
-	_, err = h.service.UpdateObject(resourceIdStr, resourcesEndPoint, resourceMap, resourcesKey,
+	_, err = h.service.UpdateObject(resourceIDStr, resourcesEndPoint, resourceMap, resourcesKey,
 		func(resource *models.Resource) bool {
-			return resource.ID == int(resourceId)
+			return resource.ID == int(resourceID)
 		})
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error updating resource: %v", err), http.StatusInternalServerError)
@@ -176,16 +176,16 @@ func (h *ResourcesHandler) UpdateResource(responseWriter http.ResponseWriter, re
 }
 
 func (h *ResourcesHandler) DeleteResource(responseWriter http.ResponseWriter, request *http.Request) {
-	resourceIdStr := request.URL.Query().Get("id")
-	resourceId, err := utils.StringToIntType[int32](resourceIdStr)
+	resourceIDStr := request.URL.Query().Get("id")
+	resourceID, err := utils.StringToIntType[int32](resourceIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Resource ID", http.StatusBadRequest)
 		return
 	}
 
-	err = h.service.DeleteObject(resourceIdStr,
+	err = h.service.DeleteObject(resourceIDStr,
 		func(resource *models.Resource) bool {
-			return resource.ID != int(resourceId)
+			return resource.ID != int(resourceID)
 		}, resourcesKey, resourcesEndPoint)
 
 	// If http error is thrown from here then target row won't be removed by htmx code
@@ -201,40 +201,40 @@ func (h *ResourcesHandler) AddResource(responseWriter http.ResponseWriter, reque
 	resourceSubtype := request.FormValue("subtype")
 	srcLink := request.FormValue("src_link")
 
-	chapterIdStr := request.FormValue("chapter_id")
-	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+	chapterIDStr := request.FormValue("chapter_id")
+	chapterID, err := utils.StringToIntType[int16](chapterIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Chapter ID", http.StatusBadRequest)
 		return
 	}
 
-	topicIdStr := request.FormValue("topic_id")
-	var topicId int16
-	if strings.TrimSpace(topicIdStr) != "" {
-		topicId, err = utils.StringToIntType[int16](topicIdStr)
+	topicIDStr := request.FormValue("topic_id")
+	var topicID int16
+	if strings.TrimSpace(topicIDStr) != "" {
+		topicID, err = utils.StringToIntType[int16](topicIDStr)
 		if err != nil {
 			http.Error(responseWriter, "Invalid Topic ID", http.StatusBadRequest)
 			return
 		}
 	}
 
-	curriculumIdStr := request.FormValue(CURRICULUM_DROPDOWN_NAME)
-	curriculumId, err := utils.StringToIntType[int16](curriculumIdStr)
+	curriculumIDStr := request.FormValue(CurriculumDropdownName)
+	curriculumID, err := utils.StringToIntType[int16](curriculumIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Curriculum ID", http.StatusBadRequest)
 		return
 	}
 
-	gradeIdStr := request.FormValue(GRADE_DROPDOWN_NAME)
-	gradeId, err := utils.StringToIntType[int8](gradeIdStr)
+	gradeIDStr := request.FormValue(GradeDropdownName)
+	gradeID, err := utils.StringToIntType[int8](gradeIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Grade ID", http.StatusBadRequest)
 		return
 	}
 
-	newResourcePtr := models.NewResource(resourceCode, resourceName, resourceType, resourceSubtype, srcLink, chapterId, curriculumId, gradeId)
-	if topicId != 0 {
-		newResourcePtr.TopicID = topicId
+	newResourcePtr := models.NewResource(resourceCode, resourceName, resourceType, resourceSubtype, srcLink, chapterID, curriculumID, gradeID)
+	if topicID != 0 {
+		newResourcePtr.TopicID = topicID
 	}
 	newResourcePtr, err = h.service.AddObject(newResourcePtr, resourcesKey, resourcesEndPoint)
 	if err != nil {
@@ -264,7 +264,7 @@ func (h *ResourcesHandler) MoveResource(responseWriter http.ResponseWriter, requ
 		return
 	}
 
-	curriculumID, gradeID, subjectID := getCurriculumGradeSubjectIds(request.Form)
+	curriculumID, gradeID, subjectID := getCurriculumGradeSubjectIDs(request.Form)
 	if curriculumID == 0 || gradeID == 0 || subjectID == 0 {
 		http.Error(responseWriter, "Invalid curriculum, grade or subject ID", http.StatusBadRequest)
 		return

--- a/internal/handlers/skill_handler.go
+++ b/internal/handlers/skill_handler.go
@@ -28,11 +28,11 @@ func NewSkillsHandler(service *services.Service[models.Skill]) *SkillsHandler {
 }
 
 func (h *SkillsHandler) GetSkills(responseWriter http.ResponseWriter, request *http.Request) {
-	selectedSkillIds := request.URL.Query().Get("selected_skill_ids")
+	selectedSkillIDs := request.URL.Query().Get("selected_skill_ids")
 	selectedIDs := make(map[int]bool)
 
-	if selectedSkillIds != "" {
-		ids := strings.Split(selectedSkillIds, ",")
+	if selectedSkillIDs != "" {
+		ids := strings.Split(selectedSkillIDs, ",")
 		for _, idStr := range ids {
 			id, err := strconv.Atoi(idStr)
 			if err == nil {
@@ -50,10 +50,10 @@ func (h *SkillsHandler) GetSkills(responseWriter http.ResponseWriter, request *h
 	// Wrap both skills & selected skill ids in a struct
 	data := struct {
 		Skills           *[]*models.Skill
-		SelectedSkillIds map[int]bool
+		SelectedSkillIDs map[int]bool
 	}{
 		Skills:           skills,
-		SelectedSkillIds: selectedIDs,
+		SelectedSkillIDs: selectedIDs,
 	}
 
 	views.ExecuteTemplate(skillsTemplate, responseWriter, data, nil)

--- a/internal/handlers/subject_handler.go
+++ b/internal/handlers/subject_handler.go
@@ -46,7 +46,7 @@ func getParentSubjectName(s models.Subject, lang string) string {
 	return s.GetNameByLang(lang)
 }
 
-func getParentSubjectId(s models.Subject) int8 {
+func getParentSubjectID(s models.Subject) int8 {
 	if s.ParentID != 0 {
 		return s.ParentID
 	}

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -30,7 +30,7 @@ import (
 	"github.com/avantifellows/nex-gen-cms/utils"
 )
 
-const TESTTYPE_DROPDOWN_NAME = "testtype-dropdown"
+const TestTypeDropdownName = "testtype-dropdown"
 
 const testsTemplate = "tests.html"
 const testsFilterViewTemplate = "tests_filter_view.html"
@@ -60,7 +60,7 @@ const questionPaperWithAnswersTemplate = "question_paper_with_answers.html"
 const answerSolutionSheetTemplate = "answer_sheet.html"
 const pdfSharedTemplate = "test_pdf_shared.html"
 
-const testProblemsEndPoint = "resource/test/%d/problems?lang_code=en&" + QUERY_PARAM_CURRICULUM_ID + "=%s"
+const testProblemsEndPoint = "resource/test/%d/problems?lang_code=en&" + QueryParamCurriculumID + "=%s"
 const testRulesEndPoint = "test-rule"
 
 const testsKey = "tests"
@@ -116,12 +116,12 @@ func (h *TestsHandler) LoadTests(responseWriter http.ResponseWriter, request *ht
 func (h *TestsHandler) GetTests(responseWriter http.ResponseWriter, request *http.Request) {
 	urlVals := request.URL.Query()
 
-	curriculumId, gradeId, _ := getCurriculumGradeSubjectIds(urlVals)
-	if curriculumId == 0 || gradeId == 0 {
+	curriculumID, gradeID, _ := getCurriculumGradeSubjectIDs(urlVals)
+	if curriculumID == 0 || gradeID == 0 {
 		return
 	}
-	testtype := urlVals.Get(TESTTYPE_DROPDOWN_NAME)
-	queryParams := fmt.Sprintf("?"+QUERY_PARAM_CURRICULUM_ID+"=%d&grade_id=%d&type=test&subtype=%s", curriculumId, gradeId, testtype)
+	testtype := urlVals.Get(TestTypeDropdownName)
+	queryParams := fmt.Sprintf("?"+QueryParamCurriculumID+"=%d&grade_id=%d&type=test&subtype=%s", curriculumID, gradeID, testtype)
 
 	tests, err := h.testsService.GetList(resourcesCurriculumEndPoint+queryParams, testsKey, false, true)
 	if err != nil {
@@ -328,10 +328,10 @@ func (h *TestsHandler) GetSubjectwiseTestProblems(responseWriter http.ResponseWr
 	}
 
 	selectedIDs := map[int]bool{}
-	selectedIdsParam := request.URL.Query().Get("selected-ids")
-	if selectedIdsParam != "" {
+	selectedIDsParam := request.URL.Query().Get("selected-ids")
+	if selectedIDsParam != "" {
 		// Build a set of already-selected problem IDs
-		for _, idStr := range strings.Split(selectedIdsParam, ",") {
+		for _, idStr := range strings.Split(selectedIDsParam, ",") {
 			selectedIDs[utils.StringToInt(idStr)] = true
 		}
 	}
@@ -351,22 +351,22 @@ func (h *TestsHandler) GetSubjectwiseTestProblems(responseWriter http.ResponseWr
 
 func (h *TestsHandler) getTest(responseWriter http.ResponseWriter, request *http.Request) (*models.Test, int, error) {
 	urlVals := request.URL.Query()
-	testIdStr := urlVals.Get("id")
-	testId := utils.StringToInt(testIdStr)
+	testIDStr := urlVals.Get("id")
+	testID := utils.StringToInt(testIDStr)
 
-	selectedTestPtr, err := h.testsService.GetObject(testIdStr,
+	selectedTestPtr, err := h.testsService.GetObject(testIDStr,
 		func(test *models.Test) bool {
-			return (*test).ID == testId
+			return (*test).ID == testID
 		}, testsKey, resourcesEndPoint)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching test: %v", err)
 	}
 
-	curriculumId, err := utils.StringToIntType[int16](urlVals.Get(QUERY_PARAM_CURRICULUM_ID))
+	curriculumID, err := utils.StringToIntType[int16](urlVals.Get(QueryParamCurriculumID))
 	if err == nil {
-		gradeId, err := utils.StringToIntType[int8](urlVals.Get("grade_id"))
+		gradeID, err := utils.StringToIntType[int8](urlVals.Get("grade_id"))
 		if err == nil {
-			selectedTestPtr.SetCurriculumGrade(curriculumId, gradeId)
+			selectedTestPtr.SetCurriculumGrade(curriculumID, gradeID)
 		}
 	}
 
@@ -382,11 +382,11 @@ func (h *TestsHandler) fillSubjectNames(responseWriter http.ResponseWriter, test
 		http.Error(responseWriter, fmt.Sprintf("Error fetching subjects: %v", err), http.StatusInternalServerError)
 	} else {
 		// Create a map to quickly lookup subject names by their ID
-		subjectIdToNameMap := make(map[int8]string)
+		subjectIDToNameMap := make(map[int8]string)
 
 		// fill the map with the address of each subject
 		for _, subjectPtr := range *subjectPtrs {
-			subjectIdToNameMap[subjectPtr.ID] = subjectPtr.GetNameByLang("en")
+			subjectIDToNameMap[subjectPtr.ID] = subjectPtr.GetNameByLang("en")
 		}
 
 		// loop through subjects of test and update subject name
@@ -395,7 +395,7 @@ func (h *TestsHandler) fillSubjectNames(responseWriter http.ResponseWriter, test
 			updating name directly on testSubject will change it in copy of actual subjects instead of
 			original subjects under testPtr, hence we are assigning it to testPtr.TypeParams.Subjects[i].Name
 			*/
-			testPtr.TypeParams.Subjects[i].Name = subjectIdToNameMap[testSubject.SubjectID]
+			testPtr.TypeParams.Subjects[i].Name = subjectIDToNameMap[testSubject.SubjectID]
 		}
 	}
 }
@@ -407,14 +407,14 @@ func (h *TestsHandler) GetTestProblems(responseWriter http.ResponseWriter, reque
 	}
 
 	urlVals := request.URL.Query()
-	subjectId, err := utils.StringToIntType[int8](urlVals.Get("subject_id"))
+	subjectID, err := utils.StringToIntType[int8](urlVals.Get("subject_id"))
 	if err != nil {
 		fmt.Println("invalid subject id")
 		return
 	}
 
 	*problems = funk.Filter(*problems, func(p *models.Problem) bool {
-		return p.SubjectID == subjectId
+		return p.SubjectID == subjectID
 	}).([]*models.Problem)
 
 	// Passing custom function add to use in template for serial number by adding 1 to index
@@ -425,11 +425,11 @@ func (h *TestsHandler) GetTestProblems(responseWriter http.ResponseWriter, reque
 
 func (h *TestsHandler) getTestProblems(responseWriter http.ResponseWriter, request *http.Request) *[]*models.Problem {
 	urlVals := request.URL.Query()
-	testIdStr := urlVals.Get("id")
-	testId := utils.StringToInt(testIdStr)
+	testIDStr := urlVals.Get("id")
+	testID := utils.StringToInt(testIDStr)
 
-	endPointWithId := fmt.Sprintf(testProblemsEndPoint, testId, urlVals.Get(QUERY_PARAM_CURRICULUM_ID))
-	problems, err := h.problemsService.GetList(endPointWithId, problemsKey, false, true)
+	endPointWithID := fmt.Sprintf(testProblemsEndPoint, testID, urlVals.Get(QueryParamCurriculumID))
+	problems, err := h.problemsService.GetList(endPointWithID, problemsKey, false, true)
 
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching problems: %v", err), http.StatusInternalServerError)
@@ -446,15 +446,15 @@ func (h *TestsHandler) fillProblemSubjects(responseWriter http.ResponseWriter, p
 		http.Error(responseWriter, fmt.Sprintf("Error fetching subjects: %v", err), http.StatusInternalServerError)
 	} else {
 		// Create a map to quickly lookup subjects by their ID
-		subjectIdToSubMap := make(map[int8]models.Subject)
+		subjectIDToSubMap := make(map[int8]models.Subject)
 
 		// fill the map with each subject
 		for _, subjectPtr := range *subjectPtrs {
-			subjectIdToSubMap[subjectPtr.ID] = *subjectPtr
+			subjectIDToSubMap[subjectPtr.ID] = *subjectPtr
 		}
 		// loop through problems and update subject inside it
 		for _, problem := range *problems {
-			problem.Subject = subjectIdToSubMap[problem.SubjectID]
+			problem.Subject = subjectIDToSubMap[problem.SubjectID]
 		}
 	}
 }
@@ -477,8 +477,8 @@ func (h *TestsHandler) AddTest(responseWriter http.ResponseWriter, request *http
 		"getSectionName":           views.GetSectionName,
 		"sectionSubtypeForProblem": views.SectionSubtypeForProblem,
 		"examIdFromTest":           views.ExamIDFromTest,
-		"toJson":                   utils.ToJson,
-		"getParentId":              getParentSubjectId,
+		"toJson":                   utils.ToJSON,
+		"getParentId":              getParentSubjectID,
 		"currentYear":              utils.GetCurrentYearLast2Digits,
 	}, baseTemplate, addTestTemplate, problemTypeOptionsTemplate, testTypeOptionsTemplate, testChipEditorTemplate,
 		addTestDestSubjectRowTemplate, addTestDestSubtypeRowTemplate, addTestDestProblemRowTemplate, chipBoxCellTemplate,
@@ -496,35 +496,35 @@ func (h *TestsHandler) buildTestData(request *http.Request) (dto.TestData, error
 
 	var curriculumGrades []models.CurriculumGrade
 	for i := range curriculums {
-		curriculumId, err := utils.StringToIntType[int16](curriculums[i])
+		curriculumID, err := utils.StringToIntType[int16](curriculums[i])
 		if err != nil {
 			return dto.TestData{}, fmt.Errorf("invalid curriculum id at index %d", i)
 		}
 
-		gradeId, err := utils.StringToIntType[int8](grades[i])
+		gradeID, err := utils.StringToIntType[int8](grades[i])
 		if err != nil {
 			return dto.TestData{}, fmt.Errorf("invalid grade id at index %d", i)
 		}
 
 		curriculumGrades = append(curriculumGrades, models.CurriculumGrade{
-			CurriculumID: curriculumId,
-			GradeID:      gradeId,
+			CurriculumID: curriculumID,
+			GradeID:      gradeID,
 		})
 	}
 
-	examId, err := utils.StringToIntType[int8](request.FormValue("modal-examType"))
+	examID, err := utils.StringToIntType[int8](request.FormValue("modal-examType"))
 	if err != nil {
 		return dto.TestData{}, fmt.Errorf("invalid exam id")
 	}
 
-	testRule, err := h.getTestRule(testType, examId)
+	testRule, err := h.getTestRule(testType, examID)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
 
 	data := dto.TestData{
 		TestPtr: &models.Test{
-			ExamIDs:          []int8{examId},
+			ExamIDs:          []int8{examID},
 			Subtype:          testType,
 			CurriculumGrades: curriculumGrades,
 		},
@@ -550,16 +550,16 @@ func (h *TestsHandler) resolveJeeAdvancedExamID() int16 {
 }
 
 func (h *TestsHandler) AddQuestionToTest(responseWriter http.ResponseWriter, request *http.Request) {
-	problemIdStr := request.FormValue("id")
-	problemId := utils.StringToInt(problemIdStr)
+	problemIDStr := request.FormValue("id")
+	problemID := utils.StringToInt(problemIDStr)
 
-	endPointWithId := fmt.Sprintf(problemEndPoint, problemId, request.FormValue("curriculum-id"))
+	endPointWithID := fmt.Sprintf(problemEndPoint, problemID, request.FormValue("curriculum-id"))
 
 	// In problemEndPoint problem id is already included in path segment, hence passing blank as first argument
 	problemPtr, err := h.problemsService.GetObject("",
 		func(problem *models.Problem) bool {
-			return problem.ID == problemId
-		}, problemsKey, endPointWithId)
+			return problem.ID == problemID
+		}, problemsKey, endPointWithID)
 	if err != nil {
 		http.Error(responseWriter, err.Error(), http.StatusInternalServerError)
 	}
@@ -573,12 +573,12 @@ func (h *TestsHandler) AddQuestionToTest(responseWriter http.ResponseWriter, req
 	// set subject as its name is required to be displayed under right hand side table for add/edit test screen
 	problemPtr.Subject = *subjectPtr
 
-	insertAfterId := request.FormValue("insert-after-id")
+	insertAfterID := request.FormValue("insert-after-id")
 	subjectExists := request.FormValue("subject-exists") == "true"
 	subtypeExists := request.FormValue("subtype-exists") == "true"
 	readOnlyMarks := request.FormValue("read-only-marks") == "true"
 	canSaveSingleSubject := request.FormValue("can-save-single-subject") == "true" // for edit test scenario
-	testId := request.FormValue("test-id")
+	testID := request.FormValue("test-id")
 	examID, _ := utils.StringToIntType[int8](request.FormValue("exam-id"))
 	sectionSubtype := views.SectionSubtypeForProblem(problemPtr.Subtype, examID, h.resolveJeeAdvancedExamID())
 
@@ -594,7 +594,7 @@ func (h *TestsHandler) AddQuestionToTest(responseWriter http.ResponseWriter, req
 			"SectionSubtype":       sectionSubtype,
 			"ReadOnlyMarks":        readOnlyMarks,
 			"CanSaveSingleSubject": canSaveSingleSubject,
-			"TestId":               testId,
+			"TestId":               testID,
 		}
 
 	case subjectExists && !subtypeExists:
@@ -603,7 +603,7 @@ func (h *TestsHandler) AddQuestionToTest(responseWriter http.ResponseWriter, req
 		data = map[string]any{
 			"Problem":        problemPtr,
 			"SectionSubtype": sectionSubtype,
-			"InsertAfterId":  insertAfterId,
+			"InsertAfterId":  insertAfterID,
 			"ReadOnlyMarks":  readOnlyMarks,
 		}
 
@@ -613,14 +613,14 @@ func (h *TestsHandler) AddQuestionToTest(responseWriter http.ResponseWriter, req
 		data = map[string]any{
 			"Problem":        problemPtr,
 			"SectionSubtype": sectionSubtype,
-			"InsertAfterId":  insertAfterId,
+			"InsertAfterId":  insertAfterID,
 			"ReadOnlyMarks":  readOnlyMarks,
 		}
 	}
 
 	views.ExecuteTemplates(responseWriter, data, template.FuncMap{
 		"getParentName":  getParentSubjectName,
-		"getParentId":    getParentSubjectId,
+		"getParentId":    getParentSubjectID,
 		"joinInt16":      utils.JoinInt16,
 		"dict":           utils.Dict,
 		"getSectionName": views.GetSectionName,
@@ -689,8 +689,8 @@ func (h *TestsHandler) EditTest(responseWriter http.ResponseWriter, request *htt
 		"getSectionName":           views.GetSectionName,
 		"sectionSubtypeForProblem": views.SectionSubtypeForProblem,
 		"examIdFromTest":           views.ExamIDFromTest,
-		"toJson":                   utils.ToJson,
-		"getParentId":              getParentSubjectId,
+		"toJson":                   utils.ToJSON,
+		"getParentId":              getParentSubjectID,
 		"currentYear":              utils.GetCurrentYearLast2Digits,
 	}, baseTemplate, addTestTemplate, problemTypeOptionsTemplate, testTypeOptionsTemplate, testChipEditorTemplate,
 		addTestDestSubjectRowTemplate, addTestDestSubtypeRowTemplate, addTestDestProblemRowTemplate, chipBoxCellTemplate,
@@ -708,12 +708,12 @@ func (h *TestsHandler) UpdateTest(responseWriter http.ResponseWriter, request *h
 		return
 	}
 
-	testIdStr := request.URL.Query().Get("id")
-	testId := utils.StringToInt(testIdStr)
+	testIDStr := request.URL.Query().Get("id")
+	testID := utils.StringToInt(testIDStr)
 
-	_, err = h.testsService.UpdateObject(testIdStr, resourcesEndPoint, testObj, testsKey,
+	_, err = h.testsService.UpdateObject(testIDStr, resourcesEndPoint, testObj, testsKey,
 		func(test *models.Test) bool {
-			return (*test).ID == testId
+			return (*test).ID == testID
 		})
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error updating test: %v", err), http.StatusInternalServerError)
@@ -769,15 +769,15 @@ func (h *TestsHandler) UpdateTestSubject(responseWriter http.ResponseWriter, req
 }
 
 func (h *TestsHandler) ArchiveTest(responseWriter http.ResponseWriter, request *http.Request) {
-	testIdStr := request.URL.Query().Get("id")
-	testId := utils.StringToInt(testIdStr)
+	testIDStr := request.URL.Query().Get("id")
+	testID := utils.StringToInt(testIDStr)
 	body := map[string]any{
 		"cms_status_id": constants.StatusArchived,
 	}
 
-	err := h.testsService.ArchiveObject(testIdStr, resourcesEndPoint, body, testsKey,
+	err := h.testsService.ArchiveObject(testIDStr, resourcesEndPoint, body, testsKey,
 		func(test *models.Test) bool {
-			return test.ID != testId
+			return test.ID != testID
 		})
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error archiving test: %v", err), http.StatusInternalServerError)
@@ -797,11 +797,11 @@ func (h *TestsHandler) AddTestModal(responseWriter http.ResponseWriter, request 
 	if len(query) > 0 {
 		// copy test scenario
 		subtype := query.Get("subtype")
-		examIdStr := query.Get("exam_id")
+		examIDStr := query.Get("exam_id")
 		curriculumGradesStr := query.Get("curriculum_grades")
 
 		// Decode exam_id
-		examId, _ := utils.StringToIntType[int8](examIdStr)
+		examID, _ := utils.StringToIntType[int8](examIDStr)
 
 		// Decode curriculum_grades JSON string
 		var curriculumGrades []models.CurriculumGrade
@@ -812,7 +812,7 @@ func (h *TestsHandler) AddTestModal(responseWriter http.ResponseWriter, request 
 		data = dto.AddTestDialogData{
 			Subtype:          subtype,
 			CurriculumGrades: curriculumGrades,
-			ExamID:           examId,
+			ExamID:           examID,
 		}
 
 	} else {
@@ -831,19 +831,19 @@ func (h *TestsHandler) AddCurriculumGradeDropdowns(responseWriter http.ResponseW
 	views.ExecuteTemplates(responseWriter, nil, nil, addCurriculumGradeSelectsTemplate, curriculumGradeSelectsTemplate)
 }
 
-func (h *TestsHandler) getTestRule(testType string, examId int8) (*models.TestRule, error) {
+func (h *TestsHandler) getTestRule(testType string, examID int8) (*models.TestRule, error) {
 	testRules, err := h.testRulesService.GetList(testRulesEndPoint, testRulesKey, false, false)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching test rules: %v", err)
 	}
 
 	for _, rule := range *testRules {
-		if rule.ExamID == examId && rule.TestType == testType {
+		if rule.ExamID == examID && rule.TestType == testType {
 			return rule, nil
 		}
 	}
 
-	return nil, fmt.Errorf("no matching test rule found for examID=%d and testType=%s", examId, testType)
+	return nil, fmt.Errorf("no matching test rule found for examID=%d and testType=%s", examID, testType)
 }
 
 func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *http.Request) {
@@ -900,8 +900,8 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 	}
 
 	// Load template
-	tmplPath := filepath.Join(constants.GetHtmlFolderPath(), pdfTemplate)
-	sharedTmplPath := filepath.Join(constants.GetHtmlFolderPath(), pdfSharedTemplate)
+	tmplPath := filepath.Join(constants.GetHTMLFolderPath(), pdfTemplate)
+	sharedTmplPath := filepath.Join(constants.GetHTMLFolderPath(), pdfSharedTemplate)
 	tmpl, err := template.New(pdfTemplate).Funcs(template.FuncMap{
 		"getName":        getTestName,
 		"add":            utils.Add,
@@ -1112,8 +1112,8 @@ func (h *TestsHandler) CopyTest(responseWriter http.ResponseWriter, request *htt
 		"getSectionName":           views.GetSectionName,
 		"sectionSubtypeForProblem": views.SectionSubtypeForProblem,
 		"examIdFromTest":           views.ExamIDFromTest,
-		"toJson":                   utils.ToJson,
-		"getParentId":              getParentSubjectId,
+		"toJson":                   utils.ToJSON,
+		"getParentId":              getParentSubjectID,
 		"currentYear":              utils.GetCurrentYearLast2Digits,
 	}, baseTemplate, addTestTemplate, problemTypeOptionsTemplate, testTypeOptionsTemplate, testChipEditorTemplate,
 		addTestDestSubjectRowTemplate, addTestDestSubtypeRowTemplate, addTestDestProblemRowTemplate, chipBoxCellTemplate,

--- a/internal/handlers/topic_handler.go
+++ b/internal/handlers/topic_handler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/avantifellows/nex-gen-cms/utils"
 )
 
-const QUERY_PARAM_TOPIC_ID = "topic_id"
+const QueryParamTopicID = "topic_id"
 
 const topicsTemplate = "topics.html"
 const topicRowTemplate = "topic_row.html"
@@ -36,36 +36,36 @@ func NewTopicsHandler(service *services.Service[models.Topic]) *TopicsHandler {
 }
 
 func (h *TopicsHandler) LoadResources(responseWriter http.ResponseWriter, request *http.Request) {
-	topicIdStr := request.URL.Query().Get("topicId")
-	chapterIdStr := request.URL.Query().Get("chapterId")
+	topicIDStr := request.URL.Query().Get("topicId")
+	chapterIDStr := request.URL.Query().Get("chapterId")
 	data := dto.ResourcesData{
-		ChapterId: chapterIdStr,
-		TopicId:   topicIdStr,
+		ChapterID: chapterIDStr,
+		TopicID:   topicIDStr,
 	}
 	views.ExecuteTemplate(resourcesTemplate, responseWriter, data, nil)
 }
 
 func (h *TopicsHandler) OpenAddTopic(responseWriter http.ResponseWriter, request *http.Request) {
-	chapterId := request.URL.Query().Get("chapterId")
-	views.ExecuteTemplate(addTopicTemplate, responseWriter, chapterId, nil)
+	chapterID := request.URL.Query().Get("chapterId")
+	views.ExecuteTemplate(addTopicTemplate, responseWriter, chapterID, nil)
 }
 
 func (h *TopicsHandler) AddTopic(responseWriter http.ResponseWriter, request *http.Request) {
 	topicCode := request.FormValue("code")
 	topicName := request.FormValue("name")
-	chapterIdStr := request.FormValue("chapter_id")
-	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+	chapterIDStr := request.FormValue("chapter_id")
+	chapterID, err := utils.StringToIntType[int16](chapterIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Chapter ID", http.StatusBadRequest)
 		return
 	}
-	curriculumIdStr := request.FormValue(CURRICULUM_DROPDOWN_NAME)
-	curriculumId, err := utils.StringToIntType[int16](curriculumIdStr)
+	curriculumIDStr := request.FormValue(CurriculumDropdownName)
+	curriculumID, err := utils.StringToIntType[int16](curriculumIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Curriculum ID", http.StatusBadRequest)
 		return
 	}
-	newTopicPtr := models.NewTopic(topicCode, topicName, chapterId, curriculumId)
+	newTopicPtr := models.NewTopic(topicCode, topicName, chapterID, curriculumID)
 
 	newTopicPtr, err = h.service.AddObject(newTopicPtr, handlerutils.TopicsKey, handlerutils.TopicsEndPoint)
 	if err != nil {
@@ -89,8 +89,8 @@ func getTopicName(t models.Topic, lang string) string {
 }
 
 func (h *TopicsHandler) ArchiveTopic(responseWriter http.ResponseWriter, request *http.Request) {
-	topicIdStr := request.URL.Query().Get("id")
-	topicId, err := utils.StringToIntType[int16](topicIdStr)
+	topicIDStr := request.URL.Query().Get("id")
+	topicID, err := utils.StringToIntType[int16](topicIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Topic ID", http.StatusBadRequest)
 		return
@@ -100,9 +100,9 @@ func (h *TopicsHandler) ArchiveTopic(responseWriter http.ResponseWriter, request
 		"cms_status_id": constants.StatusArchived,
 	}
 
-	err = h.service.ArchiveObject(topicIdStr, handlerutils.TopicsEndPoint, topicMap, handlerutils.TopicsKey,
+	err = h.service.ArchiveObject(topicIDStr, handlerutils.TopicsEndPoint, topicMap, handlerutils.TopicsKey,
 		func(topic *models.Topic) bool {
-			return (*topic).ID != topicId
+			return (*topic).ID != topicID
 		})
 
 	// If http error is thrown from here then target row won't be removed by htmx code
@@ -112,7 +112,7 @@ func (h *TopicsHandler) ArchiveTopic(responseWriter http.ResponseWriter, request
 }
 
 func (h *TopicsHandler) EditTopic(responseWriter http.ResponseWriter, request *http.Request) {
-	selectedTopicPtr, code, err := handlerutils.GetTopicById(request.URL.Query().Get("id"), h.service)
+	selectedTopicPtr, code, err := handlerutils.GetTopicByID(request.URL.Query().Get("id"), h.service)
 	if err != nil {
 		http.Error(responseWriter, err.Error(), code)
 		return
@@ -124,8 +124,8 @@ func (h *TopicsHandler) EditTopic(responseWriter http.ResponseWriter, request *h
 }
 
 func (h *TopicsHandler) UpdateTopic(responseWriter http.ResponseWriter, request *http.Request) {
-	topicIdStr := request.FormValue("id")
-	topicId, err := utils.StringToIntType[int16](topicIdStr)
+	topicIDStr := request.FormValue("id")
+	topicID, err := utils.StringToIntType[int16](topicIDStr)
 	if err != nil {
 		http.Error(responseWriter, "Invalid Topic ID", http.StatusBadRequest)
 		return
@@ -137,9 +137,9 @@ func (h *TopicsHandler) UpdateTopic(responseWriter http.ResponseWriter, request 
 	dummyTopicPtr := &models.Topic{}
 	topicMap := dummyTopicPtr.BuildMap(topicCode, topicName)
 
-	_, err = h.service.UpdateObject(topicIdStr, handlerutils.TopicsEndPoint, topicMap, handlerutils.TopicsKey,
+	_, err = h.service.UpdateObject(topicIDStr, handlerutils.TopicsEndPoint, topicMap, handlerutils.TopicsKey,
 		func(topic *models.Topic) bool {
-			return topic.ID == topicId
+			return topic.ID == topicID
 		})
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error updating topic: %v", err), http.StatusInternalServerError)
@@ -176,18 +176,18 @@ func sortTopics(topics []*models.Topic, sortColumn string, sortOrder string) {
 }
 
 func (h *TopicsHandler) GetTopic(responseWriter http.ResponseWriter, request *http.Request) {
-	selectedTopicPtr, code, err := handlerutils.GetTopicById(request.URL.Query().Get("id"), h.service)
+	selectedTopicPtr, code, err := handlerutils.GetTopicByID(request.URL.Query().Get("id"), h.service)
 	if err != nil {
 		http.Error(responseWriter, err.Error(), code)
 		return
 	}
 
-	curriculumId, gradeId, subjectId := getCurriculumGradeSubjectIds(request.URL.Query())
+	curriculumID, gradeID, subjectID := getCurriculumGradeSubjectIDs(request.URL.Query())
 	data := dto.TopicData{
 		HomeData: dto.HomeData{
-			CurriculumID: curriculumId,
-			GradeID:      gradeId,
-			SubjectID:    subjectId,
+			CurriculumID: curriculumID,
+			GradeID:      gradeID,
+			SubjectID:    subjectID,
 		},
 		TopicPtr: selectedTopicPtr,
 	}

--- a/internal/models/chapter.go
+++ b/internal/models/chapter.go
@@ -20,13 +20,13 @@ type ChapterLang struct {
 	LangCode    string `json:"lang_code"`
 }
 
-func NewChapter(code string, name string, curriculum_id int16, grade_id int8, subject_id int8) *Chapter {
+func NewChapter(code string, name string, curriculumID int16, gradeID int8, subjectID int8) *Chapter {
 	return &Chapter{
 		Code:         code,
 		Name:         []ChapterLang{{ChapterName: name, LangCode: "en"}},
-		CurriculumID: curriculum_id,
-		GradeID:      grade_id,
-		SubjectID:    subject_id,
+		CurriculumID: curriculumID,
+		GradeID:      gradeID,
+		SubjectID:    subjectID,
 	}
 }
 
@@ -34,15 +34,15 @@ func (chapter Chapter) TopicCount() int8 {
 	return int8(len(chapter.Topics))
 }
 
-func (chapterPtr *Chapter) BuildMap(code string, name string) map[string]any {
+func (chapter *Chapter) BuildMap(code string, name string) map[string]any {
 	return map[string]any{
 		"code": code,
 		"name": []ChapterLang{{ChapterName: name, LangCode: "en"}},
 	}
 }
 
-func (ch *Chapter) GetNameByLang(langCode string) string {
-	for _, chapterLang := range ch.Name {
+func (chapter *Chapter) GetNameByLang(langCode string) string {
+	for _, chapterLang := range chapter.Name {
 		if chapterLang.LangCode == langCode {
 			return chapterLang.ChapterName
 		}

--- a/internal/models/problem.go
+++ b/internal/models/problem.go
@@ -27,7 +27,7 @@ type Problem struct {
 }
 
 type ProbTypeParams struct {
-	TestIds []int `json:"test_ids"`
+	TestIDs []int `json:"test_ids"`
 }
 
 type ProbMetaData struct {

--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -66,8 +66,8 @@ func (resourcePtr *Resource) BuildMap(code string, name string, resourceType str
 	return resourceMap
 }
 
-func (r *Resource) GetNameByLang(langCode string) string {
-	for _, resourceLang := range r.Name {
+func (resourcePtr *Resource) GetNameByLang(langCode string) string {
+	for _, resourceLang := range resourcePtr.Name {
 		if resourceLang.LangCode == langCode {
 			return resourceLang.Resource
 		}

--- a/internal/models/test.go
+++ b/internal/models/test.go
@@ -98,8 +98,8 @@ func (t Test) ProblemCount() int {
 	return total
 }
 
-func (test *Test) GetNameByLang(langCode string) string {
-	for _, testLang := range test.Name {
+func (t *Test) GetNameByLang(langCode string) string {
+	for _, testLang := range t.Name {
 		if testLang.LangCode == langCode {
 			return testLang.Resource
 		}
@@ -107,27 +107,27 @@ func (test *Test) GetNameByLang(langCode string) string {
 	return ""
 }
 
-func (test *Test) SetCurriculumGrade(curriculumID int16, gradeID int8) {
+func (t *Test) SetCurriculumGrade(curriculumID int16, gradeID int8) {
 	newPair := CurriculumGrade{
 		CurriculumID: curriculumID,
 		GradeID:      gradeID,
 	}
 
 	// If nil or empty, initialize with the new pair
-	if len(test.CurriculumGrades) == 0 {
-		test.CurriculumGrades = []CurriculumGrade{newPair}
+	if len(t.CurriculumGrades) == 0 {
+		t.CurriculumGrades = []CurriculumGrade{newPair}
 		return
 	}
 
 	// Check if the pair already exists
-	for _, cg := range test.CurriculumGrades {
+	for _, cg := range t.CurriculumGrades {
 		if cg.CurriculumID == curriculumID && cg.GradeID == gradeID {
 			return // Already exists, do nothing
 		}
 	}
 
 	// Append if not found
-	test.CurriculumGrades = append(test.CurriculumGrades, newPair)
+	t.CurriculumGrades = append(t.CurriculumGrades, newPair)
 }
 
 func (t *Test) DisplaySubtype() string {

--- a/internal/models/topic.go
+++ b/internal/models/topic.go
@@ -21,12 +21,12 @@ type TopicLang struct {
 	TopicName string `json:"topic"`
 }
 
-func NewTopic(code string, name string, chapter_id int16, curriculum_id int16) *Topic {
+func NewTopic(code string, name string, chapterID int16, curriculumID int16) *Topic {
 	return &Topic{
 		Code:         code,
 		Name:         []TopicLang{{LangCode: "en", TopicName: name}},
-		ChapterID:    chapter_id,
-		CurriculumID: curriculum_id,
+		ChapterID:    chapterID,
+		CurriculumID: curriculumID,
 	}
 }
 
@@ -51,7 +51,7 @@ func (t *Topic) HasCurriculumID(curriculumID int16) bool {
 	return false
 }
 
-func (topicPtr *Topic) BuildMap(code string, name string) map[string]any {
+func (t *Topic) BuildMap(code string, name string) map[string]any {
 	return map[string]any{
 		"code": code,
 		"name": []TopicLang{{TopicName: name, LangCode: "en"}},

--- a/internal/repositories/remote/api_repository.go
+++ b/internal/repositories/remote/api_repository.go
@@ -42,9 +42,9 @@ func (r *APIRepository) CallAPI(urlEndPoint string, method string, body any) ([]
 	}
 
 	// Build a request url
-	apiUrl := config.GetEnv("DB_SERVICE_ENDPOINT", "") + urlEndPoint
+	apiURL := config.GetEnv("DB_SERVICE_ENDPOINT", "") + urlEndPoint
 
-	req, err := http.NewRequest(method, apiUrl, reqBody)
+	req, err := http.NewRequest(method, apiURL, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %v", err)
 	}

--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -58,7 +58,7 @@ func (s *Service[T]) GetList(urlEndPoint string, cacheKey string, onlyCache bool
 	return &list, nil
 }
 
-func (s *Service[T]) GetObject(objIdStr string, objFindingPredicate func(*T) bool, cacheKey string,
+func (s *Service[T]) GetObject(objIDStr string, objFindingPredicate func(*T) bool, cacheKey string,
 	urlEndPoint string) (*T, error) {
 
 	// check in the cache for list
@@ -71,10 +71,10 @@ func (s *Service[T]) GetObject(objIdStr string, objFindingPredicate func(*T) boo
 	}
 
 	var fullURL string
-	if objIdStr == "" {
+	if objIDStr == "" {
 		fullURL = urlEndPoint
 	} else {
-		fullURL = urlEndPoint + "/" + objIdStr
+		fullURL = urlEndPoint + "/" + objIDStr
 	}
 
 	// call api to fetch single object
@@ -91,10 +91,10 @@ func (s *Service[T]) GetObject(objIdStr string, objFindingPredicate func(*T) boo
 	return objPtr, nil
 }
 
-func (s *Service[T]) UpdateObject(objIdStr string, urlEndPoint string, body any, cacheKey string,
+func (s *Service[T]) UpdateObject(objIDStr string, urlEndPoint string, body any, cacheKey string,
 	objFindingPredicate func(*T) bool) (*T, error) {
 
-	respBytes, err := s.apiRepository.CallAPI(urlEndPoint+"/"+objIdStr, http.MethodPatch, body)
+	respBytes, err := s.apiRepository.CallAPI(urlEndPoint+"/"+objIDStr, http.MethodPatch, body)
 	if err != nil {
 		return nil, err
 	}
@@ -142,9 +142,9 @@ func (s *Service[T]) InvalidateCache(cacheKey string) {
 	s.cacheRepository.Delete(cacheKey)
 }
 
-func (s *Service[T]) DeleteObject(objIdStr string, objKeepingPredicate func(*T) bool, cacheKey string,
+func (s *Service[T]) DeleteObject(objIDStr string, objKeepingPredicate func(*T) bool, cacheKey string,
 	urlEndPoint string) error {
-	_, err := s.apiRepository.CallAPI(urlEndPoint+"/"+objIdStr, http.MethodDelete, nil)
+	_, err := s.apiRepository.CallAPI(urlEndPoint+"/"+objIDStr, http.MethodDelete, nil)
 	if err != nil {
 		return err
 	}
@@ -157,9 +157,9 @@ func (s *Service[T]) DeleteObject(objIdStr string, objKeepingPredicate func(*T) 
 	return nil
 }
 
-func (s *Service[T]) ArchiveObject(objIdStr string, urlEndPoint string, body any, cacheKey string,
+func (s *Service[T]) ArchiveObject(objIDStr string, urlEndPoint string, body any, cacheKey string,
 	objKeepingPredicate func(*T) bool) error {
-	_, err := s.apiRepository.CallAPI(urlEndPoint+"/"+objIdStr, http.MethodPatch, body)
+	_, err := s.apiRepository.CallAPI(urlEndPoint+"/"+objIDStr, http.MethodPatch, body)
 	if err != nil {
 		return err
 	}

--- a/internal/views/render.go
+++ b/internal/views/render.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExecuteTemplate(filename string, responseWriter http.ResponseWriter, data any, funcMap template.FuncMap) {
-	tmplPath := filepath.Join(constants.GetHtmlFolderPath(), filename)
+	tmplPath := filepath.Join(constants.GetHTMLFolderPath(), filename)
 	var tmpl *template.Template
 	if funcMap != nil {
 		tmpl = template.Must(template.New(filename).Funcs(funcMap).ParseFiles(tmplPath))
@@ -29,7 +29,7 @@ func ExecuteTemplates(responseWriter http.ResponseWriter, data any, funcMap temp
 		return
 	}
 
-	htmlFolderPath := constants.GetHtmlFolderPath()
+	htmlFolderPath := constants.GetHTMLFolderPath()
 	var fullPaths []string
 	for _, file := range templateFiles {
 		fullPaths = append(fullPaths, filepath.Join(htmlFolderPath, file))

--- a/utils/conversion_util.go
+++ b/utils/conversion_util.go
@@ -120,7 +120,7 @@ func Dict(values ...any) map[string]any {
 	return dict
 }
 
-func ToJson(v any) template.JS {
+func ToJSON(v any) template.JS {
 	b, err := json.Marshal(v)
 	if err != nil {
 		log.Printf("Error marshaling to JSON: %v", err)

--- a/web/html/resources.html
+++ b/web/html/resources.html
@@ -21,10 +21,10 @@
              eg - Click edit on any resource -> Back. It should invoke /api/resources only once
              -->
             <tbody id="resourceTableBody" class="text-ink-muted text-sm"
-                {{ if .TopicId }}
-                    hx-get="/api/resources?topic_id={{.TopicId}}"
+                {{ if .TopicID }}
+                    hx-get="/api/resources?topic_id={{.TopicID}}"
                 {{ else }}
-                    hx-get="/api/resources?chapter_id={{.ChapterId}}"
+                    hx-get="/api/resources?chapter_id={{.ChapterID}}"
                 {{ end }}
                 hx-trigger="load delay:150ms, change from:(#curriculum-dropdown, #grade-dropdown), refreshResources"
                 hx-include="#curriculum-dropdown, #grade-dropdown">
@@ -36,7 +36,7 @@
     <!-- Form to add new resource -->
     <div class="mt-4">
         <h4 id="addResourceLink" class="add-new-link"
-            onclick="toggleResourceForm(event, '{{.ChapterId}}', '{{.TopicId}}')">
+            onclick="toggleResourceForm(event, '{{.ChapterID}}', '{{.TopicID}}')">
             <a href="#">+ Add New Resource</a>
         </h4>
     </div>

--- a/web/html/skills.html
+++ b/web/html/skills.html
@@ -1,3 +1,3 @@
 {{ range .Skills }}
-    <option value="{{.ID}}" {{ if index $.SelectedSkillIds .ID }}selected{{ end }}>{{.Name}}</option>
+    <option value="{{.ID}}" {{ if index $.SelectedSkillIDs .ID }}selected{{ end }}>{{.Name}}</option>
 {{ end }}


### PR DESCRIPTION
**Stacked PR 5 of 7** — review on top of `lint/4-minor-style`.

Fixes all 145 var-naming/receiver-naming issues: initialisms uppercased (Id→ID, Url→URL, Json→JSON, Html→HTML, Css→CSS), ALL_CAPS consts → CamelCase, underscore params → camelCase, and consistent receiver names per type. Wire format is preserved (`ProbTypeParams.TestIds` keeps its `json:"test_ids"` tag); the template-only struct fields are renamed in lockstep with `resources.html`/`skills.html`, and the camelCase `topicId`/`chapterId` query-param **keys** are left unchanged.

This is part of a stacked series that brings the repo to **zero `golangci-lint` issues** (the committed config audits revive/staticcheck/dupl/gocognit/etc.). Each PR is one category so review stays small; merge in order 1→7.

### Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race ./...` ✓
- `golangci-lint run ./...` ✓ (this category clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
### 📚 Stack (merge in order)
1. #138 — 1 - Lint: format imports and fix spelling
2. #139 — 2 - Lint: remove redundant code and simplify
3. #140 — 3 - Lint: check previously ignored errors
4. #141 — 4 - Lint: minor style fixes
5. **#142** ◀ this PR — 5 - Lint: apply Go naming conventions
6. #143 — 6 - Lint: dedupe exam/grade handlers
7. #144 — 7 - Lint: reduce cognitive complexity
