### PR TITLE
5 - Lint: dedupe near-identical exam/grade list handlers

### DIFF
--- a/internal/handlers/exam_handler.go
+++ b/internal/handlers/exam_handler.go
@@ -1,12 +1,10 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/avantifellows/nex-gen-cms/internal/models"
 	"github.com/avantifellows/nex-gen-cms/internal/services"
-	"github.com/avantifellows/nex-gen-cms/internal/views"
 )
 
 const examsEndPoint = "exam"
@@ -24,11 +22,5 @@ func NewExamsHandler(service *services.Service[models.Exam]) *ExamsHandler {
 }
 
 func (h *ExamsHandler) GetExams(responseWriter http.ResponseWriter, _ *http.Request) {
-	exams, err := h.service.GetList(examsEndPoint, examsKey, false, false)
-	if err != nil {
-		http.Error(responseWriter, fmt.Sprintf("Error fetching exams: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	views.ExecuteTemplate(examsTemplate, responseWriter, exams, nil)
+	renderEntityList(responseWriter, h.service, examsEndPoint, examsKey, examsTemplate, "exams")
 }

--- a/internal/handlers/generic_handler.go
+++ b/internal/handlers/generic_handler.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/avantifellows/nex-gen-cms/internal/constants"
+	"github.com/avantifellows/nex-gen-cms/internal/services"
+	"github.com/avantifellows/nex-gen-cms/internal/views"
 	"github.com/avantifellows/nex-gen-cms/utils"
 )
 
@@ -44,6 +46,19 @@ func GenericHandler(responseWriter http.ResponseWriter, request *http.Request) {
 		http.Error(responseWriter, "Error rendering template", http.StatusInternalServerError)
 		log.Printf("Error executing template: %s", err)
 	}
+}
+
+// renderEntityList fetches a cached list from the given endpoint and renders it
+// with the given template. On failure it writes a 500 referencing label (e.g.
+// "grades", "exams"). It backs the otherwise-identical simple list handlers.
+func renderEntityList[T any](responseWriter http.ResponseWriter, service *services.Service[T],
+	endpoint, cacheKey, tmpl, label string) {
+	items, err := service.GetList(endpoint, cacheKey, false, false)
+	if err != nil {
+		http.Error(responseWriter, fmt.Sprintf("Error fetching %s: %v", label, err), http.StatusInternalServerError)
+		return
+	}
+	views.ExecuteTemplate(tmpl, responseWriter, items, nil)
 }
 
 func getCurriculumGradeSubjectIds(urlValues url.Values) (int16, int8, int8) {

--- a/internal/handlers/grade_handler.go
+++ b/internal/handlers/grade_handler.go
@@ -1,12 +1,10 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/avantifellows/nex-gen-cms/internal/models"
 	"github.com/avantifellows/nex-gen-cms/internal/services"
-	"github.com/avantifellows/nex-gen-cms/internal/views"
 )
 
 const getGradesEndPoint = "grade"
@@ -24,12 +22,5 @@ func NewGradesHandler(service *services.Service[models.Grade]) *GradesHandler {
 }
 
 func (h *GradesHandler) GetGrades(responseWriter http.ResponseWriter, _ *http.Request) {
-	grades, err := h.service.GetList(getGradesEndPoint, gradesKey, false, false)
-	if err != nil {
-		http.Error(responseWriter, fmt.Sprintf("Error fetching grades: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	// Load grades.html
-	views.ExecuteTemplate(gradesTemplate, responseWriter, grades, nil)
+	renderEntityList(responseWriter, h.service, getGradesEndPoint, gradesKey, gradesTemplate, "grades")
 }


### PR DESCRIPTION
**Stacked PR 5 of 6** — review on top of `lint/4-minor-style`.

`GetExams` and `GetGrades` were token-for-token duplicates. Extracts the shared fetch-list-and-render body into a generic `renderEntityList[T]` helper; each handler becomes a one-liner. Behaviour unchanged. Resolves the two `dupl` findings.

Part of a stacked series that cleans up `golangci-lint` findings by category, one PR each, so review stays small; merge in order 1→6. (The naming-convention PR was dropped as low priority for now.)

### Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race ./...` ✓
- `golangci-lint run ./...` ✓ (this category clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### 📚 Stack (merge in order)
1. #138 — 1 - Lint: format imports and fix spelling
2. #139 — 2 - Lint: remove redundant code and simplify
3. #140 — 3 - Lint: check previously ignored errors
4. #141 — 4 - Lint: minor style fixes
5. **#143** ◀ this PR — 5 - Lint: dedupe exam/grade handlers
6. #144 — 6 - Lint: reduce cognitive complexity
