### PR TITLE
6 - Lint: reduce cognitive complexity of sortTests and DownloadPdf

### DIFF
--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -240,57 +240,72 @@ func (h *TestsHandler) GetSearchTests(responseWriter http.ResponseWriter, reques
 func sortTests(testPtrs []*models.Test, sortColumn string, sortOrder string, curriculumMap map[int16]string,
 	gradeMap map[int8]int8) {
 	slices.SortStableFunc(testPtrs, func(t1, t2 *models.Test) int {
-		var sortResult int
-		switch sortColumn {
-		case "1":
-			sortResult = strings.Compare(t1.Code, t2.Code)
-		case "2":
-			sortResult = strings.Compare(t1.Name[0].Resource, t2.Name[0].Resource)
-		case "3":
-			if curriculumMap != nil {
-				// Search case: sort by curriculum name
-				var c1, c2 string
-				if len(t1.CurriculumGrades) > 0 {
-					c1 = curriculumMap[t1.CurriculumGrades[0].CurriculumID]
-				}
-				if len(t2.CurriculumGrades) > 0 {
-					c2 = curriculumMap[t2.CurriculumGrades[0].CurriculumID]
-				}
-				sortResult = strings.Compare(c1, c2)
-			} else {
-				// Normal case: sort by problem count
-				sortResult = t1.ProblemCount() - t2.ProblemCount()
-			}
-		case "4":
-			if gradeMap != nil {
-				// Search case: sort by grade number
-				var g1, g2 int8
-				if len(t1.CurriculumGrades) > 0 {
-					g1 = gradeMap[t1.CurriculumGrades[0].GradeID]
-				}
-				if len(t2.CurriculumGrades) > 0 {
-					g2 = gradeMap[t2.CurriculumGrades[0].GradeID]
-				}
-				sortResult = int(g1 - g2)
-			} else {
-				// Normal case: sort by marks
-				sortResult = int(t1.TypeParams.Marks - t2.TypeParams.Marks)
-			}
-		case "5":
-			if curriculumMap != nil {
-				sortResult = strings.Compare(t1.DisplaySubtype(), t2.DisplaySubtype())
-			} else {
-				sortResult = utils.StringToInt(t1.TypeParams.Duration) - utils.StringToInt(t2.TypeParams.Duration)
-			}
-		default:
-			sortResult = 0
-		}
-
+		sortResult := compareTestsByColumn(t1, t2, sortColumn, curriculumMap, gradeMap)
 		if constants.SortOrder(sortOrder) == constants.SortOrderDesc {
-			sortResult = -sortResult
+			return -sortResult
 		}
 		return sortResult
 	})
+}
+
+// compareTestsByColumn returns the ascending ordering of t1 vs t2 for the given
+// sort column. A non-nil curriculumMap/gradeMap signals the search view, which
+// sorts some columns differently from the normal list view.
+func compareTestsByColumn(t1, t2 *models.Test, sortColumn string, curriculumMap map[int16]string,
+	gradeMap map[int8]int8) int {
+	switch sortColumn {
+	case "1":
+		return strings.Compare(t1.Code, t2.Code)
+	case "2":
+		return strings.Compare(t1.Name[0].Resource, t2.Name[0].Resource)
+	case "3":
+		return compareByCurriculumOrProblemCount(t1, t2, curriculumMap)
+	case "4":
+		return compareByGradeOrMarks(t1, t2, gradeMap)
+	case "5":
+		return compareBySubtypeOrDuration(t1, t2, curriculumMap)
+	default:
+		return 0
+	}
+}
+
+func compareByCurriculumOrProblemCount(t1, t2 *models.Test, curriculumMap map[int16]string) int {
+	if curriculumMap == nil {
+		// Normal case: sort by problem count
+		return t1.ProblemCount() - t2.ProblemCount()
+	}
+	// Search case: sort by curriculum name
+	var c1, c2 string
+	if len(t1.CurriculumGrades) > 0 {
+		c1 = curriculumMap[t1.CurriculumGrades[0].CurriculumID]
+	}
+	if len(t2.CurriculumGrades) > 0 {
+		c2 = curriculumMap[t2.CurriculumGrades[0].CurriculumID]
+	}
+	return strings.Compare(c1, c2)
+}
+
+func compareByGradeOrMarks(t1, t2 *models.Test, gradeMap map[int8]int8) int {
+	if gradeMap == nil {
+		// Normal case: sort by marks
+		return int(t1.TypeParams.Marks - t2.TypeParams.Marks)
+	}
+	// Search case: sort by grade number
+	var g1, g2 int8
+	if len(t1.CurriculumGrades) > 0 {
+		g1 = gradeMap[t1.CurriculumGrades[0].GradeID]
+	}
+	if len(t2.CurriculumGrades) > 0 {
+		g2 = gradeMap[t2.CurriculumGrades[0].GradeID]
+	}
+	return int(g1 - g2)
+}
+
+func compareBySubtypeOrDuration(t1, t2 *models.Test, curriculumMap map[int16]string) int {
+	if curriculumMap != nil {
+		return strings.Compare(t1.DisplaySubtype(), t2.DisplaySubtype())
+	}
+	return utils.StringToInt(t1.TypeParams.Duration) - utils.StringToInt(t2.TypeParams.Duration)
 }
 
 func (h *TestsHandler) GetTest(responseWriter http.ResponseWriter, request *http.Request) {
@@ -861,38 +876,7 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 
 	pdfType := request.URL.Query().Get("type") // "questions", "questions_with_answers", or "answers"
 
-	var pdfTemplate, headerTxt, pdfSuffix string
-	var testRule *models.TestRule
-	switch pdfType {
-	case "questions":
-		pdfTemplate = questionPaperTemplate
-		headerTxt = selectedTestPtr.DisplaySubtype()
-		pdfSuffix = "Question Paper"
-
-		if len(selectedTestPtr.ExamIDs) > 0 {
-			testRule, err = h.getTestRule(selectedTestPtr.Subtype, selectedTestPtr.ExamIDs[0])
-			if err != nil {
-				fmt.Println(err.Error())
-			}
-		}
-
-	case "questions_with_answers":
-		pdfTemplate = questionPaperWithAnswersTemplate
-		headerTxt = selectedTestPtr.DisplaySubtype() + " - Questions & Answers"
-		pdfSuffix = "Question Paper with Answers"
-
-		if len(selectedTestPtr.ExamIDs) > 0 {
-			testRule, err = h.getTestRule(selectedTestPtr.Subtype, selectedTestPtr.ExamIDs[0])
-			if err != nil {
-				fmt.Println(err.Error())
-			}
-		}
-
-	case "answers":
-		pdfTemplate = answerSolutionSheetTemplate
-		headerTxt = selectedTestPtr.DisplaySubtype() + " - Answer Sheet"
-		pdfSuffix = "Answer Sheet"
-	}
+	pdfTemplate, headerTxt, pdfSuffix, testRule := h.resolvePdfParams(selectedTestPtr, pdfType)
 
 	if pdfTemplate == "" {
 		http.Error(responseWriter, `Invalid type: use "questions", "questions_with_answers", or "answers"`, http.StatusBadRequest)
@@ -984,10 +968,63 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 	defer cancel()
 
 	var pdfData []byte
+	tasks := buildPdfTasks(htmlContent, headerHTML, pdfType, &pdfData)
 
-	// Load HTML via CDP SetDocumentContent instead of a data: URL. Chrome aborts navigation
-	// (net::ERR_ABORTED) when the encoded data URL exceeds ~2MB;
-	tasks := chromedp.Tasks{
+	if err := chromedp.Run(ctx, tasks); err != nil {
+		http.Error(responseWriter, "PDF generation failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Send as response
+	responseWriter.Header().Set("Content-Type", "application/pdf")
+	responseWriter.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s - %s.pdf"`,
+		selectedTestPtr.GetNameByLang("en"), pdfSuffix))
+	_, _ = responseWriter.Write(pdfData)
+}
+
+// resolvePdfParams maps a pdfType ("questions", "questions_with_answers",
+// "answers") to its template, header text and filename suffix, plus the test
+// rule used by question papers. An unknown pdfType yields an empty pdfTemplate,
+// which the caller treats as a bad request.
+func (h *TestsHandler) resolvePdfParams(test *models.Test, pdfType string) (pdfTemplate, headerTxt,
+	pdfSuffix string, testRule *models.TestRule) {
+	switch pdfType {
+	case "questions":
+		pdfTemplate = questionPaperTemplate
+		headerTxt = test.DisplaySubtype()
+		pdfSuffix = "Question Paper"
+		testRule = h.ruleForTest(test)
+	case "questions_with_answers":
+		pdfTemplate = questionPaperWithAnswersTemplate
+		headerTxt = test.DisplaySubtype() + " - Questions & Answers"
+		pdfSuffix = "Question Paper with Answers"
+		testRule = h.ruleForTest(test)
+	case "answers":
+		pdfTemplate = answerSolutionSheetTemplate
+		headerTxt = test.DisplaySubtype() + " - Answer Sheet"
+		pdfSuffix = "Answer Sheet"
+	}
+	return
+}
+
+// ruleForTest fetches the test rule for the test's first exam, returning nil
+// (and logging) when there is no exam or the lookup fails.
+func (h *TestsHandler) ruleForTest(test *models.Test) *models.TestRule {
+	if len(test.ExamIDs) == 0 {
+		return nil
+	}
+	testRule, err := h.getTestRule(test.Subtype, test.ExamIDs[0])
+	if err != nil {
+		fmt.Println(err.Error())
+		return nil
+	}
+	return testRule
+}
+
+// buildPdfTasks builds the chromedp pipeline that loads htmlContent, waits for
+// MathJax typesetting and fonts to settle, then renders an A4 PDF into *pdfData.
+func buildPdfTasks(htmlContent, headerHTML, pdfType string, pdfData *[]byte) chromedp.Tasks {
+	return chromedp.Tasks{
 		chromedp.Navigate("about:blank"),
 		// Set page content
 		chromedp.ActionFunc(func(ctx context.Context) error {
@@ -1028,7 +1065,7 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 		// Generate PDF using CDP low-level API
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			var err error
-			pdfData, _, err = page.PrintToPDF().
+			*pdfData, _, err = page.PrintToPDF().
 				WithPrintBackground(true).
 				WithPaperWidth(8.27).   // A4 width in inches
 				WithPaperHeight(11.69). // A4 height in inches
@@ -1054,17 +1091,6 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 			return err
 		}),
 	}
-
-	if err := chromedp.Run(ctx, tasks); err != nil {
-		http.Error(responseWriter, "PDF generation failed: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// Send as response
-	responseWriter.Header().Set("Content-Type", "application/pdf")
-	responseWriter.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s - %s.pdf"`,
-		selectedTestPtr.GetNameByLang("en"), pdfSuffix))
-	_, _ = responseWriter.Write(pdfData)
 }
 
 func evalAwaitPromise(p *runtime.EvaluateParams) *runtime.EvaluateParams {


### PR DESCRIPTION
**Stacked PR 6 of 6** — review on top of `lint/6-dedupe-handlers`.

Both `sortTests` and `DownloadPdf` exceeded the `gocognit` threshold. `sortTests`: the per-column comparison moves into `compareTestsByColumn` + three small helpers. `DownloadPdf`: the `pdfType` switch moves into `resolvePdfParams` (sharing a `ruleForTest` helper) and the chromedp pipeline into `buildPdfTasks`. Behaviour unchanged.

Part of a stacked series that cleans up `golangci-lint` findings by category, one PR each, so review stays small; merge in order 1→6. (The naming-convention PR was dropped as low priority for now.)

### Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race ./...` ✓
- `golangci-lint run ./...` ✓ (this category clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### 📚 Stack (merge in order)
1. #138 — 1 - Lint: format imports and fix spelling
2. #139 — 2 - Lint: remove redundant code and simplify
3. #140 — 3 - Lint: check previously ignored errors
4. #141 — 4 - Lint: minor style fixes
5. #143 — 5 - Lint: dedupe exam/grade handlers
6. **#144** ◀ this PR — 6 - Lint: reduce cognitive complexity
