### PR TITLE
Cms bugs issue 23 - Add inline image alignment

### DIFF
--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -35,7 +35,7 @@ Then read this file fully before doing anything else in this session.
 - Content CRUD for chapters, topics, concepts, resources, tests, problems, skills, tags, exams via the
   db-service API + `go-cache` (generic `Service[T]`).
 - Problem editor math templates include a piecewise/cases insert via the existing MathLive editor.
-- Problem editor images can be kept inline with surrounding labels/text or set to float-none move mode
+- Problem editor images can be kept inline with surrounding labels/text or set to old-CMS-style float none
   via the image toolbar; editor surfaces are resizable, keep the preview size in sync, and stay within
   the page card; add/edit problem pages use full width.
 - Server-rendered HTML + HTMX UI; Tailwind v4 styling (built from `input.css`; generated CSS not committed).

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -35,6 +35,9 @@ Then read this file fully before doing anything else in this session.
 - Content CRUD for chapters, topics, concepts, resources, tests, problems, skills, tags, exams via the
   db-service API + `go-cache` (generic `Service[T]`).
 - Problem editor math templates include a piecewise/cases insert via the existing MathLive editor.
+- Problem editor images can be kept inline with surrounding labels/text via the image toolbar; editor
+  surfaces are resizable, keep the preview size in sync, and stay within the page card; add/edit
+  problem pages use full width.
 - Server-rendered HTML + HTMX UI; Tailwind v4 styling (built from `input.css`; generated CSS not committed).
 - Question paper / answer sheet / combined PDF generation via headless Chrome (chromedp + MathJax).
 - Admin user management (`/admin/users`), move/copy of resources & problems.

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -35,9 +35,9 @@ Then read this file fully before doing anything else in this session.
 - Content CRUD for chapters, topics, concepts, resources, tests, problems, skills, tags, exams via the
   db-service API + `go-cache` (generic `Service[T]`).
 - Problem editor math templates include a piecewise/cases insert via the existing MathLive editor.
-- Problem editor images can be kept inline with surrounding labels/text via the image toolbar; editor
-  surfaces are resizable, keep the preview size in sync, and stay within the page card; add/edit
-  problem pages use full width.
+- Problem editor images can be kept inline with surrounding labels/text or set to float-none move mode
+  via the image toolbar; editor surfaces are resizable, keep the preview size in sync, and stay within
+  the page card; add/edit problem pages use full width.
 - Server-rendered HTML + HTMX UI; Tailwind v4 styling (built from `input.css`; generated CSS not committed).
 - Question paper / answer sheet / combined PDF generation via headless Chrome (chromedp + MathJax).
 - Admin user management (`/admin/users`), move/copy of resources & problems.

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -35,9 +35,9 @@ Then read this file fully before doing anything else in this session.
 - Content CRUD for chapters, topics, concepts, resources, tests, problems, skills, tags, exams via the
   db-service API + `go-cache` (generic `Service[T]`).
 - Problem editor math templates include a piecewise/cases insert via the existing MathLive editor.
-- Problem editor images can be kept inline with surrounding labels/text or set to old-CMS-style float none
-  via the image toolbar; editor surfaces are resizable, keep the preview size in sync, and stay within
-  the page card; add/edit problem pages use full width.
+- Problem editor images can be kept inline with surrounding labels/text via the image toolbar; editor
+  surfaces are resizable, keep the preview size in sync, and stay within the page card; add/edit
+  problem pages use full width.
 - Server-rendered HTML + HTMX UI; Tailwind v4 styling (built from `input.css`; generated CSS not committed).
 - Question paper / answer sheet / combined PDF generation via headless Chrome (chromedp + MathJax).
 - Admin user management (`/admin/users`), move/copy of resources & problems.

--- a/input.css
+++ b/input.css
@@ -194,6 +194,7 @@
 
   /* Image — show pointer to hint it's clickable */
   .editor img { cursor: pointer; }
+  .editor img.editor-img-free { cursor: move; }
   .editor img.img-selected { outline: 2px solid var(--color-accent); outline-offset: 1px; }
 
   /* Floated image: text beside, then full width below image (clearfix on paragraph) */

--- a/input.css
+++ b/input.css
@@ -184,6 +184,13 @@
   .editor {
     font-family: var(--font-sans);
   }
+  .editor,
+  .codeView {
+    resize: both;
+    overflow: auto;
+    min-width: 16rem;
+    min-height: 13rem;
+  }
 
   /* Image — show pointer to hint it's clickable */
   .editor img { cursor: pointer; }

--- a/input.css
+++ b/input.css
@@ -185,10 +185,6 @@
     font-family: var(--font-sans);
   }
   .editor,
-  .output {
-    position: relative;
-  }
-  .editor,
   .codeView {
     resize: both;
     overflow: auto;
@@ -198,7 +194,6 @@
 
   /* Image — show pointer to hint it's clickable */
   .editor img { cursor: pointer; }
-  .editor img.editor-img-free { cursor: move; }
 
   /* Floated image: text beside, then full width below image (clearfix on paragraph) */
   .editor p.editor-img-float,

--- a/input.css
+++ b/input.css
@@ -185,6 +185,10 @@
     font-family: var(--font-sans);
   }
   .editor,
+  .output {
+    position: relative;
+  }
+  .editor,
   .codeView {
     resize: both;
     overflow: auto;

--- a/input.css
+++ b/input.css
@@ -195,7 +195,6 @@
   /* Image — show pointer to hint it's clickable */
   .editor img { cursor: pointer; }
   .editor img.editor-img-free { cursor: move; }
-  .editor img.img-selected { outline: 2px solid var(--color-accent); outline-offset: 1px; }
 
   /* Floated image: text beside, then full width below image (clearfix on paragraph) */
   .editor p.editor-img-float,

--- a/tests/editor-image-front.spec.ts
+++ b/tests/editor-image-front.spec.ts
@@ -46,6 +46,47 @@ test('image toolbar can keep a diagram inline with its label', async ({ page }) 
     .not.toContain('img-selected');
 });
 
+test('image toolbar can make a diagram free movable inside the editor', async ({ page }) => {
+  await page.setViewportSize({ width: 1400, height: 900 });
+  await page.request.post('http://localhost:8080/dev-login');
+  await page.goto('http://localhost:8080/topic/add-problem?topic_id=3');
+
+  const editor = page.locator('#questionDiv .editor');
+  await editor.evaluate((el) => {
+    el.innerHTML = `
+      <p>
+        (A)
+        <img alt="movable-diagram" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4AWP8z8Dwn4EIwESJ5lEDAN9OCJm5N4+jAAAAAElFTkSuQmCC" style="width: 80px; max-width: 80px; height: auto;">
+      </p>`;
+  });
+
+  const image = page.locator('#questionDiv .editor img[alt="movable-diagram"]');
+  await image.click();
+  await page.locator('#questionDiv').getByTitle('Float None / Move').click();
+
+  const before = await image.boundingBox();
+  if (!before) throw new Error('Image bounding box missing before drag');
+
+  await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(before.x + before.width / 2 + 120, before.y + before.height / 2 + 24, { steps: 6 });
+  await page.mouse.up();
+
+  const after = await image.boundingBox();
+  if (!after) throw new Error('Image bounding box missing after drag');
+
+  expect(after.x - before.x).toBeGreaterThan(80);
+  expect(after.y - before.y).toBeGreaterThan(10);
+  await expect(image).toHaveCSS('position', 'relative');
+  await expect(image).toHaveCSS('float', 'none');
+
+  const savedHtml = await editor.evaluate((el: any) => window.getEditorHtml(el));
+  expect(savedHtml).toContain('position: relative');
+  expect(savedHtml).toContain('left:');
+  expect(savedHtml).not.toContain('draggable');
+  expect(savedHtml).not.toContain('img-selected');
+});
+
 test('resizing the editor keeps the preview matched', async ({ page }) => {
   await page.setViewportSize({ width: 1600, height: 900 });
   await page.request.post('http://localhost:8080/dev-login');

--- a/tests/editor-image-front.spec.ts
+++ b/tests/editor-image-front.spec.ts
@@ -46,7 +46,7 @@ test('image toolbar can keep a diagram inline with its label', async ({ page }) 
     .not.toContain('img-selected');
 });
 
-test('image toolbar can make a diagram free movable inside the editor', async ({ page }) => {
+test('image toolbar applies old CMS float-none behavior', async ({ page }) => {
   await page.setViewportSize({ width: 1400, height: 900 });
   await page.request.post('http://localhost:8080/dev-login');
   await page.goto('http://localhost:8080/topic/add-problem?topic_id=3');
@@ -68,26 +68,10 @@ test('image toolbar can make a diagram free movable inside the editor', async ({
 
   const image = page.locator('#questionDiv .editor img[alt="movable-diagram"]');
   await image.click();
-  await page.locator('#questionDiv').getByTitle('Float None / Move').click();
+  await page.locator('#questionDiv').getByTitle('Float None').click();
 
-  const before = await image.boundingBox();
-  if (!before) throw new Error('Image bounding box missing before drag');
-
-  const editorBox = await editor.boundingBox();
-  if (!editorBox) throw new Error('Editor bounding box missing');
-
-  await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2);
-  await page.mouse.down();
-  await page.mouse.move(editorBox.x + 8, before.y + before.height / 2 + 24, { steps: 6 });
-  await page.mouse.up();
-
-  const after = await image.boundingBox();
-  if (!after) throw new Error('Image bounding box missing after drag');
-
-  expect(after.x).toBeLessThan(editorBox.x + 16);
-  expect(after.y - before.y).toBeGreaterThan(10);
-  await expect(image).toHaveCSS('position', 'absolute');
   await expect(image).toHaveCSS('float', 'none');
+  await expect(image).not.toHaveClass(/editor-img-free/);
   await expect(image).toHaveCSS('outline-style', 'none');
 
   const overlay = page.locator('#questionDiv .img-resize-overlay');
@@ -102,8 +86,9 @@ test('image toolbar can make a diagram free movable inside the editor', async ({
   }).toBe(true);
 
   const savedHtml = await editor.evaluate((el: any) => window.getEditorHtml(el));
-  expect(savedHtml).toContain('position: absolute');
-  expect(savedHtml).toContain('left:');
+  expect(savedHtml).toContain('float: none');
+  expect(savedHtml).not.toContain('position: absolute');
+  expect(savedHtml).not.toContain('editor-img-free');
   expect(savedHtml).not.toContain('draggable');
   expect(savedHtml).not.toContain('img-selected');
 });

--- a/tests/editor-image-front.spec.ts
+++ b/tests/editor-image-front.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('image toolbar can keep a diagram inline with its label', async ({ page }) => {
+  await page.request.post('http://localhost:8080/dev-login');
+  await page.goto('http://localhost:8080/topic/add-problem?topic_id=3');
+
+  const editor = page.locator('#questionDiv .editor');
+  await editor.evaluate((el) => {
+    el.innerHTML = `
+      <table class="w-full border border-black border-collapse my-2">
+        <tbody>
+          <tr>
+            <td class="border border-black w-16 h-8 text-center">
+              <div style="text-align: left;">
+                (A)
+                <p class="editor-img-float editor-img-left">
+                  <img alt="diagram" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4AWP8z8Dwn4EIwESJ5lEDAN9OCJm5N4+jAAAAAElFTkSuQmCC" style="display: block; float: left; margin: 0px 0.75em 0.5em 0px; width: 40px; max-width: 40px; height: auto;">
+                </p>
+              </div>
+            </td>
+            <td class="border border-black w-16 h-8 text-center">i) 2R</td>
+          </tr>
+        </tbody>
+      </table>`;
+  });
+
+  const image = page.locator('#questionDiv .editor img[alt="diagram"]');
+  await image.click();
+  await page.locator('#questionDiv').getByTitle('Inline With Text').click();
+
+  await expect(image).toHaveCSS('display', 'inline-block');
+  await expect(image).toHaveCSS('float', 'none');
+
+  await expect(editor.locator('p.editor-img-float')).toHaveCount(0);
+
+  await expect
+    .poll(() => editor.evaluate((el: any) => window.getEditorHtml(el)))
+    .toContain('(A)');
+  await expect
+    .poll(() => editor.evaluate((el: any) => window.getEditorHtml(el)))
+    .toContain('display: inline-block');
+  await expect
+    .poll(() => editor.evaluate((el: any) => window.getEditorHtml(el)))
+    .not.toContain('img-selected');
+});
+
+test('resizing the editor keeps the preview matched', async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.request.post('http://localhost:8080/dev-login');
+  await page.goto('http://localhost:8080/topic/add-problem?topic_id=3');
+
+  const editor = page.locator('#questionDiv .editor');
+  const preview = page.locator('#questionDiv .output');
+  const wrapper = page.locator('#questionDiv .editor-wrapper');
+
+  await expect(editor).toHaveCSS('resize', 'both');
+
+  await editor.evaluate((el: HTMLElement) => {
+    el.style.width = '640px';
+    el.style.height = '360px';
+  });
+
+  await expect.poll(async () => {
+    const [editorBox, previewBox, wrapperBox] = await Promise.all([
+      editor.boundingBox(),
+      preview.boundingBox(),
+      wrapper.boundingBox(),
+    ]);
+    return {
+      editorWidth: Math.round(editorBox?.width ?? 0),
+      editorHeight: Math.round(editorBox?.height ?? 0),
+      previewWidth: Math.round(previewBox?.width ?? 0),
+      previewHeight: Math.round(previewBox?.height ?? 0),
+      wrapperWidth: Math.round(wrapperBox?.width ?? 0),
+    };
+  }).toEqual({
+    editorWidth: 640,
+    editorHeight: 360,
+    previewWidth: 640,
+    previewHeight: 360,
+    wrapperWidth: 640,
+  });
+});
+
+test('resizing the editor cannot push the preview outside the problem card', async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.request.post('http://localhost:8080/dev-login');
+  await page.goto('http://localhost:8080/topic/add-problem?topic_id=3');
+
+  const editor = page.locator('#questionDiv .editor');
+  const preview = page.locator('#questionDiv .output');
+  const form = page.locator('#content > form');
+
+  await editor.evaluate((el: HTMLElement) => {
+    el.style.width = '1200px';
+    el.style.height = '360px';
+  });
+  await page.waitForTimeout(300);
+
+  await expect.poll(async () => {
+    const [editorBox, previewBox, formBox] = await Promise.all([
+      editor.boundingBox(),
+      preview.boundingBox(),
+      form.boundingBox(),
+    ]);
+    const previewRight = (previewBox?.x ?? 0) + (previewBox?.width ?? 0);
+    const formRight = (formBox?.x ?? 0) + (formBox?.width ?? 0);
+    const overflow = Math.round(previewRight - formRight);
+    const widthDelta = Math.abs(Math.round((previewBox?.width ?? 0) - (editorBox?.width ?? 0)));
+    return overflow <= 0 && widthDelta <= 1;
+  }).toBe(true);
+});
+
+test('problem editor page uses the available horizontal space', async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.request.post('http://localhost:8080/dev-login');
+  await page.goto('http://localhost:8080/topic/add-problem?topic_id=3');
+
+  const content = page.locator('#content');
+  const form = page.locator('#content > form');
+
+  await expect.poll(async () => {
+    const [contentBox, formBox] = await Promise.all([
+      content.boundingBox(),
+      form.boundingBox(),
+    ]);
+    return Math.round((contentBox?.width ?? 0) - (formBox?.width ?? 0));
+  }).toBeLessThanOrEqual(4);
+});

--- a/tests/editor-image-front.spec.ts
+++ b/tests/editor-image-front.spec.ts
@@ -54,10 +54,16 @@ test('image toolbar can make a diagram free movable inside the editor', async ({
   const editor = page.locator('#questionDiv .editor');
   await editor.evaluate((el) => {
     el.innerHTML = `
-      <p>
-        (A)
-        <img alt="movable-diagram" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4AWP8z8Dwn4EIwESJ5lEDAN9OCJm5N4+jAAAAAElFTkSuQmCC" style="width: 80px; max-width: 80px; height: auto;">
-      </p>`;
+      <table style="width: 100%; border-collapse: collapse;">
+        <tbody>
+          <tr>
+            <td style="border: 1px solid black; height: 120px;">
+              <span id="option-label">(A)</span>
+              <img alt="movable-diagram" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4AWP8z8Dwn4EIwESJ5lEDAN9OCJm5N4+jAAAAAElFTkSuQmCC" style="width: 80px; max-width: 80px; height: auto;">
+            </td>
+          </tr>
+        </tbody>
+      </table>`;
   });
 
   const image = page.locator('#questionDiv .editor img[alt="movable-diagram"]');
@@ -67,17 +73,20 @@ test('image toolbar can make a diagram free movable inside the editor', async ({
   const before = await image.boundingBox();
   if (!before) throw new Error('Image bounding box missing before drag');
 
+  const editorBox = await editor.boundingBox();
+  if (!editorBox) throw new Error('Editor bounding box missing');
+
   await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2);
   await page.mouse.down();
-  await page.mouse.move(before.x + before.width / 2 + 120, before.y + before.height / 2 + 24, { steps: 6 });
+  await page.mouse.move(editorBox.x + 8, before.y + before.height / 2 + 24, { steps: 6 });
   await page.mouse.up();
 
   const after = await image.boundingBox();
   if (!after) throw new Error('Image bounding box missing after drag');
 
-  expect(after.x - before.x).toBeGreaterThan(80);
+  expect(after.x).toBeLessThan(editorBox.x + 16);
   expect(after.y - before.y).toBeGreaterThan(10);
-  await expect(image).toHaveCSS('position', 'relative');
+  await expect(image).toHaveCSS('position', 'absolute');
   await expect(image).toHaveCSS('float', 'none');
   await expect(image).toHaveCSS('outline-style', 'none');
 
@@ -93,7 +102,7 @@ test('image toolbar can make a diagram free movable inside the editor', async ({
   }).toBe(true);
 
   const savedHtml = await editor.evaluate((el: any) => window.getEditorHtml(el));
-  expect(savedHtml).toContain('position: relative');
+  expect(savedHtml).toContain('position: absolute');
   expect(savedHtml).toContain('left:');
   expect(savedHtml).not.toContain('draggable');
   expect(savedHtml).not.toContain('img-selected');

--- a/tests/editor-image-front.spec.ts
+++ b/tests/editor-image-front.spec.ts
@@ -32,6 +32,7 @@ test('image toolbar can keep a diagram inline with its label', async ({ page }) 
 
   await expect(image).toHaveCSS('display', 'inline-block');
   await expect(image).toHaveCSS('float', 'none');
+  await expect(image).toHaveCSS('outline-style', 'none');
 
   await expect(editor.locator('p.editor-img-float')).toHaveCount(0);
 
@@ -44,53 +45,6 @@ test('image toolbar can keep a diagram inline with its label', async ({ page }) 
   await expect
     .poll(() => editor.evaluate((el: any) => window.getEditorHtml(el)))
     .not.toContain('img-selected');
-});
-
-test('image toolbar applies old CMS float-none behavior', async ({ page }) => {
-  await page.setViewportSize({ width: 1400, height: 900 });
-  await page.request.post('http://localhost:8080/dev-login');
-  await page.goto('http://localhost:8080/topic/add-problem?topic_id=3');
-
-  const editor = page.locator('#questionDiv .editor');
-  await editor.evaluate((el) => {
-    el.innerHTML = `
-      <table style="width: 100%; border-collapse: collapse;">
-        <tbody>
-          <tr>
-            <td style="border: 1px solid black; height: 120px;">
-              <span id="option-label">(A)</span>
-              <img alt="movable-diagram" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4AWP8z8Dwn4EIwESJ5lEDAN9OCJm5N4+jAAAAAElFTkSuQmCC" style="width: 80px; max-width: 80px; height: auto;">
-            </td>
-          </tr>
-        </tbody>
-      </table>`;
-  });
-
-  const image = page.locator('#questionDiv .editor img[alt="movable-diagram"]');
-  await image.click();
-  await page.locator('#questionDiv').getByTitle('Float None').click();
-
-  await expect(image).toHaveCSS('float', 'none');
-  await expect(image).not.toHaveClass(/editor-img-free/);
-  await expect(image).toHaveCSS('outline-style', 'none');
-
-  const overlay = page.locator('#questionDiv .img-resize-overlay');
-  await expect.poll(async () => {
-    const [imageBox, overlayBox] = await Promise.all([
-      image.boundingBox(),
-      overlay.boundingBox(),
-    ]);
-    const leftDelta = Math.abs(Math.round((imageBox?.x ?? 0) - (overlayBox?.x ?? 0)));
-    const topDelta = Math.abs(Math.round((imageBox?.y ?? 0) - (overlayBox?.y ?? 0)));
-    return leftDelta <= 2 && topDelta <= 2;
-  }).toBe(true);
-
-  const savedHtml = await editor.evaluate((el: any) => window.getEditorHtml(el));
-  expect(savedHtml).toContain('float: none');
-  expect(savedHtml).not.toContain('position: absolute');
-  expect(savedHtml).not.toContain('editor-img-free');
-  expect(savedHtml).not.toContain('draggable');
-  expect(savedHtml).not.toContain('img-selected');
 });
 
 test('resizing the editor keeps the preview matched', async ({ page }) => {

--- a/tests/editor-image-front.spec.ts
+++ b/tests/editor-image-front.spec.ts
@@ -79,6 +79,18 @@ test('image toolbar can make a diagram free movable inside the editor', async ({
   expect(after.y - before.y).toBeGreaterThan(10);
   await expect(image).toHaveCSS('position', 'relative');
   await expect(image).toHaveCSS('float', 'none');
+  await expect(image).toHaveCSS('outline-style', 'none');
+
+  const overlay = page.locator('#questionDiv .img-resize-overlay');
+  await expect.poll(async () => {
+    const [imageBox, overlayBox] = await Promise.all([
+      image.boundingBox(),
+      overlay.boundingBox(),
+    ]);
+    const leftDelta = Math.abs(Math.round((imageBox?.x ?? 0) - (overlayBox?.x ?? 0)));
+    const topDelta = Math.abs(Math.round((imageBox?.y ?? 0) - (overlayBox?.y ?? 0)));
+    return leftDelta <= 2 && topDelta <= 2;
+  }).toBe(true);
 
   const savedHtml = await editor.evaluate((el: any) => window.getEditorHtml(el));
   expect(savedHtml).toContain('position: relative');

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -1,6 +1,6 @@
 {{ define "content" }}
 {{ $isEdit := (ne .ProblemPtr nil) }}
-<form class="card card-pad max-w-6xl mx-auto" onsubmit="createProblem(event,
+<form class="card card-pad w-full" onsubmit="createProblem(event,
         {{if .TopicPtr}}
         <!-- add problem -->
             {{.TopicPtr.ID}}, {{.TopicPtr.ChapterID}}, null

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -228,7 +228,7 @@
         <div class="img-edit-toolbar" role="toolbar" aria-label="Image options">
             <button type="button" data-img-align="left" title="Align Left"><i class="fas fa-align-left"></i></button>
             <button type="button" data-img-align="inline" title="Inline With Text"><i class="fas fa-text-width"></i></button>
-            <button type="button" data-img-align="free" title="Float None / Move"><i class="fas fa-arrows-alt"></i></button>
+            <button type="button" data-img-align="free" title="Float None"><i class="fas fa-align-justify"></i></button>
             <button type="button" data-img-align="justify" title="Justify"><i class="fas fa-align-justify"></i></button>
             <button type="button" data-img-align="right" title="Align Right"><i class="fas fa-align-right"></i></button>
             <span class="img-edit-sep"></span>

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -227,6 +227,7 @@
         <!-- Image editing UI (positioned over the editor by JS) -->
         <div class="img-edit-toolbar" role="toolbar" aria-label="Image options">
             <button type="button" data-img-align="left" title="Align Left"><i class="fas fa-align-left"></i></button>
+            <button type="button" data-img-align="inline" title="Inline With Text"><i class="fas fa-text-width"></i></button>
             <button type="button" data-img-align="justify" title="Justify"><i class="fas fa-align-justify"></i></button>
             <button type="button" data-img-align="right" title="Align Right"><i class="fas fa-align-right"></i></button>
             <span class="img-edit-sep"></span>

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -228,6 +228,7 @@
         <div class="img-edit-toolbar" role="toolbar" aria-label="Image options">
             <button type="button" data-img-align="left" title="Align Left"><i class="fas fa-align-left"></i></button>
             <button type="button" data-img-align="inline" title="Inline With Text"><i class="fas fa-text-width"></i></button>
+            <button type="button" data-img-align="free" title="Float None / Move"><i class="fas fa-arrows-alt"></i></button>
             <button type="button" data-img-align="justify" title="Justify"><i class="fas fa-align-justify"></i></button>
             <button type="button" data-img-align="right" title="Align Right"><i class="fas fa-align-right"></i></button>
             <span class="img-edit-sep"></span>

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -228,7 +228,6 @@
         <div class="img-edit-toolbar" role="toolbar" aria-label="Image options">
             <button type="button" data-img-align="left" title="Align Left"><i class="fas fa-align-left"></i></button>
             <button type="button" data-img-align="inline" title="Inline With Text"><i class="fas fa-text-width"></i></button>
-            <button type="button" data-img-align="free" title="Float None"><i class="fas fa-align-justify"></i></button>
             <button type="button" data-img-align="justify" title="Justify"><i class="fas fa-align-justify"></i></button>
             <button type="button" data-img-align="right" title="Align Right"><i class="fas fa-align-right"></i></button>
             <span class="img-edit-sep"></span>

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -110,6 +110,7 @@ function initImageEditing(editor, editorWrapper) {
             return;
         }
 
+        renderMath(editor);
         requestAnimationFrame(() => {
             if (selectedImg) positionUI(selectedImg);
         });
@@ -248,7 +249,12 @@ function placeCaretAfterImage(img) {
     sel.addRange(range);
 }
 
+function clearInlineImageStyles(img) {
+    img.style.verticalAlign = '';
+}
+
 function applyFloatStyles(img, align) {
+    clearInlineImageStyles(img);
     img.style.flexBasis = '';
     img.style.display = 'block';
 
@@ -262,7 +268,14 @@ function applyFloatStyles(img, align) {
 }
 
 function applyImageAlign(img, align, editor) {
+    if (align === 'inline') {
+        applyInlineImage(img);
+        placeCaretAfterImage(img);
+        return;
+    }
+
     if (align === 'justify') {
+        clearInlineImageStyles(img);
         let block = getImageBlock(img);
         flattenTextSpan(block || img.parentElement);
 
@@ -291,6 +304,21 @@ function applyImageAlign(img, align, editor) {
 
     applyFloatStyles(img, align);
     placeCaretAfterImage(img);
+}
+
+function applyInlineImage(img) {
+    const block = getImageBlock(img);
+    if (block) {
+        flattenTextSpan(block);
+        block.replaceWith(img);
+    }
+
+    img.style.float = 'none';
+    img.style.display = 'inline-block';
+    img.style.verticalAlign = 'middle';
+    img.style.margin = '0 0.25em';
+    img.style.height = 'auto';
+    img.style.flexBasis = '';
 }
 
 function applyImageSize(img, percent) {

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -253,15 +253,7 @@ function clearInlineImageStyles(img) {
     img.style.verticalAlign = '';
 }
 
-function clearImagePositionStyles(img) {
-    img.style.position = '';
-    img.style.left = '';
-    img.style.top = '';
-    img.style.zIndex = '';
-}
-
 function applyFloatStyles(img, align) {
-    clearImagePositionStyles(img);
     clearInlineImageStyles(img);
     img.style.flexBasis = '';
     img.style.display = 'block';
@@ -276,12 +268,6 @@ function applyFloatStyles(img, align) {
 }
 
 function applyImageAlign(img, align, editor) {
-    if (align === 'free') {
-        applyFloatNoneImage(img);
-        placeCaretAfterImage(img);
-        return;
-    }
-
     if (align === 'inline') {
         applyInlineImage(img);
         placeCaretAfterImage(img);
@@ -289,7 +275,6 @@ function applyImageAlign(img, align, editor) {
     }
 
     if (align === 'justify') {
-        clearImagePositionStyles(img);
         clearInlineImageStyles(img);
         let block = getImageBlock(img);
         flattenTextSpan(block || img.parentElement);
@@ -322,7 +307,6 @@ function applyImageAlign(img, align, editor) {
 }
 
 function applyInlineImage(img) {
-    clearImagePositionStyles(img);
     const block = getImageBlock(img);
     if (block) {
         flattenTextSpan(block);
@@ -331,22 +315,6 @@ function applyInlineImage(img) {
 
     img.style.float = 'none';
     img.style.display = 'inline-block';
-    img.style.verticalAlign = 'middle';
-    img.style.margin = '0 0.25em';
-    img.style.height = 'auto';
-    img.style.flexBasis = '';
-}
-
-function applyFloatNoneImage(img) {
-    const block = getImageBlock(img);
-    if (block) {
-        flattenTextSpan(block);
-        block.replaceWith(img);
-    }
-
-    img.style.float = 'none';
-    img.style.display = '';
-    clearImagePositionStyles(img);
     img.style.verticalAlign = 'middle';
     img.style.margin = '0 0.25em';
     img.style.height = 'auto';

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -108,16 +108,13 @@ function initImageEditing(editor, editorWrapper) {
         e.preventDefault();
         selectImage(img);
 
-        const editorRect = editor.getBoundingClientRect();
         const imgRect = img.getBoundingClientRect();
         const startX = e.clientX;
         const startY = e.clientY;
-        const startLeft = parseFloat(img.style.left || '0') || 0;
-        const startTop = parseFloat(img.style.top || '0') || 0;
-        const minDx = editorRect.left - imgRect.left;
-        const maxDx = editorRect.right - imgRect.right;
-        const minDy = editorRect.top - imgRect.top;
-        const maxDy = editorRect.bottom - imgRect.bottom;
+        const startLeft = offsetToPx(img.style.left, editor.clientWidth);
+        const startTop = offsetToPx(img.style.top, editor.clientHeight);
+        const maxLeft = Math.max(0, editor.clientWidth - imgRect.width);
+        const maxTop = Math.max(0, editor.clientHeight - imgRect.height);
 
         moveState = { didMove: false };
 
@@ -132,12 +129,11 @@ function initImageEditing(editor, editorWrapper) {
             img.style.cursor = 'grabbing';
             window.getSelection()?.removeAllRanges();
 
-            const dx = Math.min(Math.max(rawDx, minDx), maxDx);
-            const dy = Math.min(Math.max(rawDy, minDy), maxDy);
-            const leftPercent = startLeft + (dx / Math.max(editorRect.width, 1)) * 100;
+            const left = clamp(startLeft + rawDx, 0, maxLeft);
+            const top = clamp(startTop + rawDy, 0, maxTop);
 
-            img.style.left = leftPercent.toFixed(2).replace(/\.?0+$/, '') + '%';
-            img.style.top = Math.round(startTop + dy) + 'px';
+            img.style.left = pxToPercent(left, editor.clientWidth);
+            img.style.top = Math.round(top) + 'px';
             positionUI(img);
         };
 
@@ -349,7 +345,7 @@ function applyFloatStyles(img, align) {
 
 function applyImageAlign(img, align, editor) {
     if (align === 'free') {
-        applyFreeMoveImage(img);
+        applyFreeMoveImage(img, editor);
         placeCaretAfterImage(img);
         return;
     }
@@ -409,19 +405,24 @@ function applyInlineImage(img) {
     img.style.flexBasis = '';
 }
 
-function applyFreeMoveImage(img) {
+function applyFreeMoveImage(img, editor) {
     const block = getImageBlock(img);
     if (block) {
         flattenTextSpan(block);
         block.replaceWith(img);
     }
 
+    const editorRect = editor.getBoundingClientRect();
+    const imgRect = img.getBoundingClientRect();
+    const left = clamp(imgRect.left - editorRect.left + editor.scrollLeft, 0, editor.clientWidth - imgRect.width);
+    const top = clamp(imgRect.top - editorRect.top + editor.scrollTop, 0, editor.clientHeight - imgRect.height);
+
     img.classList.add('editor-img-free');
     img.style.float = 'none';
     img.style.display = 'inline-block';
-    img.style.position = 'relative';
-    img.style.left = img.style.left || '0%';
-    img.style.top = img.style.top || '0px';
+    img.style.position = 'absolute';
+    img.style.left = pxToPercent(left, editor.clientWidth);
+    img.style.top = Math.round(top) + 'px';
     img.style.zIndex = '1';
     img.style.verticalAlign = 'middle';
     img.style.margin = '0 0.25em';
@@ -430,7 +431,22 @@ function applyFreeMoveImage(img) {
 }
 
 function isFreeMoveImage(img) {
-    return img.classList.contains('editor-img-free') || img.style.position === 'relative';
+    return img.classList.contains('editor-img-free') || img.style.position === 'absolute';
+}
+
+function offsetToPx(value, basis) {
+    if (!value) return 0;
+    const number = parseFloat(value);
+    if (!Number.isFinite(number)) return 0;
+    return value.trim().endsWith('%') ? (number / 100) * Math.max(basis, 1) : number;
+}
+
+function pxToPercent(value, basis) {
+    return ((value / Math.max(basis, 1)) * 100).toFixed(2).replace(/\.?0+$/, '') + '%';
+}
+
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), Math.max(min, max));
 }
 
 function applyImageSize(img, percent) {

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -27,6 +27,7 @@ function initImageEditing(editor, editorWrapper) {
     if (!imgToolbar || !resizeOverlay) return;
 
     let selectedImg = null;
+    let moveState = null;
 
     function positionUI(img) {
         const wRect = editorWrapper.getBoundingClientRect();
@@ -60,6 +61,11 @@ function initImageEditing(editor, editorWrapper) {
     }
 
     editor.addEventListener('click', (e) => {
+        if (moveState?.didMove) {
+            moveState.didMove = false;
+            return;
+        }
+
         if (e.target.tagName === 'IMG') {
             selectImage(e.target);
         } else {
@@ -68,7 +74,10 @@ function initImageEditing(editor, editorWrapper) {
     });
 
     editor.addEventListener('mousedown', (e) => {
-        if (e.target.tagName === 'IMG') return;
+        if (e.target.tagName === 'IMG') {
+            startFreeImageMove(e, e.target);
+            return;
+        }
 
         for (const img of editor.querySelectorAll('img')) {
             const float = img.style.float;
@@ -86,6 +95,68 @@ function initImageEditing(editor, editorWrapper) {
             }
         }
     });
+
+    editor.addEventListener('dragstart', (e) => {
+        if (e.target.tagName === 'IMG' && isFreeMoveImage(e.target)) {
+            e.preventDefault();
+        }
+    });
+
+    function startFreeImageMove(e, img) {
+        if (!isFreeMoveImage(img)) return;
+
+        e.preventDefault();
+        selectImage(img);
+
+        const editorRect = editor.getBoundingClientRect();
+        const imgRect = img.getBoundingClientRect();
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const startLeft = parseFloat(img.style.left || '0') || 0;
+        const startTop = parseFloat(img.style.top || '0') || 0;
+        const minDx = editorRect.left - imgRect.left;
+        const maxDx = editorRect.right - imgRect.right;
+        const minDy = editorRect.top - imgRect.top;
+        const maxDy = editorRect.bottom - imgRect.bottom;
+
+        moveState = { didMove: false };
+
+        const onMouseMove = (ev) => {
+            const rawDx = ev.clientX - startX;
+            const rawDy = ev.clientY - startY;
+            if (!moveState.didMove && Math.abs(rawDx) + Math.abs(rawDy) < 4) return;
+
+            ev.preventDefault();
+            moveState.didMove = true;
+            editor.style.userSelect = 'none';
+            img.style.cursor = 'grabbing';
+            window.getSelection()?.removeAllRanges();
+
+            const dx = Math.min(Math.max(rawDx, minDx), maxDx);
+            const dy = Math.min(Math.max(rawDy, minDy), maxDy);
+            const leftPercent = startLeft + (dx / Math.max(editorRect.width, 1)) * 100;
+
+            img.style.left = leftPercent.toFixed(2).replace(/\.?0+$/, '') + '%';
+            img.style.top = Math.round(startTop + dy) + 'px';
+            positionUI(img);
+        };
+
+        const onMouseUp = () => {
+            window.removeEventListener('mousemove', onMouseMove);
+            window.removeEventListener('mouseup', onMouseUp);
+            editor.style.userSelect = '';
+            img.style.cursor = '';
+
+            if (moveState.didMove) {
+                window.getSelection()?.removeAllRanges();
+                renderMath(editor);
+                requestAnimationFrame(() => positionUI(img));
+            }
+        };
+
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('mouseup', onMouseUp);
+    }
 
     editor.addEventListener('scroll', () => {
         if (selectedImg) positionUI(selectedImg);
@@ -253,7 +324,16 @@ function clearInlineImageStyles(img) {
     img.style.verticalAlign = '';
 }
 
+function clearFreeMoveStyles(img) {
+    img.classList.remove('editor-img-free');
+    img.style.position = '';
+    img.style.left = '';
+    img.style.top = '';
+    img.style.zIndex = '';
+}
+
 function applyFloatStyles(img, align) {
+    clearFreeMoveStyles(img);
     clearInlineImageStyles(img);
     img.style.flexBasis = '';
     img.style.display = 'block';
@@ -268,6 +348,12 @@ function applyFloatStyles(img, align) {
 }
 
 function applyImageAlign(img, align, editor) {
+    if (align === 'free') {
+        applyFreeMoveImage(img);
+        placeCaretAfterImage(img);
+        return;
+    }
+
     if (align === 'inline') {
         applyInlineImage(img);
         placeCaretAfterImage(img);
@@ -275,6 +361,7 @@ function applyImageAlign(img, align, editor) {
     }
 
     if (align === 'justify') {
+        clearFreeMoveStyles(img);
         clearInlineImageStyles(img);
         let block = getImageBlock(img);
         flattenTextSpan(block || img.parentElement);
@@ -307,6 +394,7 @@ function applyImageAlign(img, align, editor) {
 }
 
 function applyInlineImage(img) {
+    clearFreeMoveStyles(img);
     const block = getImageBlock(img);
     if (block) {
         flattenTextSpan(block);
@@ -319,6 +407,30 @@ function applyInlineImage(img) {
     img.style.margin = '0 0.25em';
     img.style.height = 'auto';
     img.style.flexBasis = '';
+}
+
+function applyFreeMoveImage(img) {
+    const block = getImageBlock(img);
+    if (block) {
+        flattenTextSpan(block);
+        block.replaceWith(img);
+    }
+
+    img.classList.add('editor-img-free');
+    img.style.float = 'none';
+    img.style.display = 'inline-block';
+    img.style.position = 'relative';
+    img.style.left = img.style.left || '0%';
+    img.style.top = img.style.top || '0px';
+    img.style.zIndex = '1';
+    img.style.verticalAlign = 'middle';
+    img.style.margin = '0 0.25em';
+    img.style.height = 'auto';
+    img.style.flexBasis = '';
+}
+
+function isFreeMoveImage(img) {
+    return img.classList.contains('editor-img-free') || img.style.position === 'relative';
 }
 
 function applyImageSize(img, percent) {

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -27,7 +27,6 @@ function initImageEditing(editor, editorWrapper) {
     if (!imgToolbar || !resizeOverlay) return;
 
     let selectedImg = null;
-    let moveState = null;
 
     function positionUI(img) {
         const wRect = editorWrapper.getBoundingClientRect();
@@ -61,11 +60,6 @@ function initImageEditing(editor, editorWrapper) {
     }
 
     editor.addEventListener('click', (e) => {
-        if (moveState?.didMove) {
-            moveState.didMove = false;
-            return;
-        }
-
         if (e.target.tagName === 'IMG') {
             selectImage(e.target);
         } else {
@@ -74,10 +68,7 @@ function initImageEditing(editor, editorWrapper) {
     });
 
     editor.addEventListener('mousedown', (e) => {
-        if (e.target.tagName === 'IMG') {
-            startFreeImageMove(e, e.target);
-            return;
-        }
+        if (e.target.tagName === 'IMG') return;
 
         for (const img of editor.querySelectorAll('img')) {
             const float = img.style.float;
@@ -95,64 +86,6 @@ function initImageEditing(editor, editorWrapper) {
             }
         }
     });
-
-    editor.addEventListener('dragstart', (e) => {
-        if (e.target.tagName === 'IMG' && isFreeMoveImage(e.target)) {
-            e.preventDefault();
-        }
-    });
-
-    function startFreeImageMove(e, img) {
-        if (!isFreeMoveImage(img)) return;
-
-        e.preventDefault();
-        selectImage(img);
-
-        const imgRect = img.getBoundingClientRect();
-        const startX = e.clientX;
-        const startY = e.clientY;
-        const startLeft = offsetToPx(img.style.left, editor.clientWidth);
-        const startTop = offsetToPx(img.style.top, editor.clientHeight);
-        const maxLeft = Math.max(0, editor.clientWidth - imgRect.width);
-        const maxTop = Math.max(0, editor.clientHeight - imgRect.height);
-
-        moveState = { didMove: false };
-
-        const onMouseMove = (ev) => {
-            const rawDx = ev.clientX - startX;
-            const rawDy = ev.clientY - startY;
-            if (!moveState.didMove && Math.abs(rawDx) + Math.abs(rawDy) < 4) return;
-
-            ev.preventDefault();
-            moveState.didMove = true;
-            editor.style.userSelect = 'none';
-            img.style.cursor = 'grabbing';
-            window.getSelection()?.removeAllRanges();
-
-            const left = clamp(startLeft + rawDx, 0, maxLeft);
-            const top = clamp(startTop + rawDy, 0, maxTop);
-
-            img.style.left = pxToPercent(left, editor.clientWidth);
-            img.style.top = Math.round(top) + 'px';
-            positionUI(img);
-        };
-
-        const onMouseUp = () => {
-            window.removeEventListener('mousemove', onMouseMove);
-            window.removeEventListener('mouseup', onMouseUp);
-            editor.style.userSelect = '';
-            img.style.cursor = '';
-
-            if (moveState.didMove) {
-                window.getSelection()?.removeAllRanges();
-                renderMath(editor);
-                requestAnimationFrame(() => positionUI(img));
-            }
-        };
-
-        window.addEventListener('mousemove', onMouseMove);
-        window.addEventListener('mouseup', onMouseUp);
-    }
 
     editor.addEventListener('scroll', () => {
         if (selectedImg) positionUI(selectedImg);
@@ -320,8 +253,7 @@ function clearInlineImageStyles(img) {
     img.style.verticalAlign = '';
 }
 
-function clearFreeMoveStyles(img) {
-    img.classList.remove('editor-img-free');
+function clearImagePositionStyles(img) {
     img.style.position = '';
     img.style.left = '';
     img.style.top = '';
@@ -329,7 +261,7 @@ function clearFreeMoveStyles(img) {
 }
 
 function applyFloatStyles(img, align) {
-    clearFreeMoveStyles(img);
+    clearImagePositionStyles(img);
     clearInlineImageStyles(img);
     img.style.flexBasis = '';
     img.style.display = 'block';
@@ -345,7 +277,7 @@ function applyFloatStyles(img, align) {
 
 function applyImageAlign(img, align, editor) {
     if (align === 'free') {
-        applyFreeMoveImage(img, editor);
+        applyFloatNoneImage(img);
         placeCaretAfterImage(img);
         return;
     }
@@ -357,7 +289,7 @@ function applyImageAlign(img, align, editor) {
     }
 
     if (align === 'justify') {
-        clearFreeMoveStyles(img);
+        clearImagePositionStyles(img);
         clearInlineImageStyles(img);
         let block = getImageBlock(img);
         flattenTextSpan(block || img.parentElement);
@@ -390,7 +322,7 @@ function applyImageAlign(img, align, editor) {
 }
 
 function applyInlineImage(img) {
-    clearFreeMoveStyles(img);
+    clearImagePositionStyles(img);
     const block = getImageBlock(img);
     if (block) {
         flattenTextSpan(block);
@@ -405,48 +337,20 @@ function applyInlineImage(img) {
     img.style.flexBasis = '';
 }
 
-function applyFreeMoveImage(img, editor) {
+function applyFloatNoneImage(img) {
     const block = getImageBlock(img);
     if (block) {
         flattenTextSpan(block);
         block.replaceWith(img);
     }
 
-    const editorRect = editor.getBoundingClientRect();
-    const imgRect = img.getBoundingClientRect();
-    const left = clamp(imgRect.left - editorRect.left + editor.scrollLeft, 0, editor.clientWidth - imgRect.width);
-    const top = clamp(imgRect.top - editorRect.top + editor.scrollTop, 0, editor.clientHeight - imgRect.height);
-
-    img.classList.add('editor-img-free');
     img.style.float = 'none';
-    img.style.display = 'inline-block';
-    img.style.position = 'absolute';
-    img.style.left = pxToPercent(left, editor.clientWidth);
-    img.style.top = Math.round(top) + 'px';
-    img.style.zIndex = '1';
+    img.style.display = '';
+    clearImagePositionStyles(img);
     img.style.verticalAlign = 'middle';
     img.style.margin = '0 0.25em';
     img.style.height = 'auto';
     img.style.flexBasis = '';
-}
-
-function isFreeMoveImage(img) {
-    return img.classList.contains('editor-img-free') || img.style.position === 'absolute';
-}
-
-function offsetToPx(value, basis) {
-    if (!value) return 0;
-    const number = parseFloat(value);
-    if (!Number.isFinite(number)) return 0;
-    return value.trim().endsWith('%') ? (number / 100) * Math.max(basis, 1) : number;
-}
-
-function pxToPercent(value, basis) {
-    return ((value / Math.max(basis, 1)) * 100).toFixed(2).replace(/\.?0+$/, '') + '%';
-}
-
-function clamp(value, min, max) {
-    return Math.min(Math.max(value, min), Math.max(min, max));
 }
 
 function applyImageSize(img, percent) {

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -1,5 +1,8 @@
 function getEditorHtml(editor) {
     const clone = editor.cloneNode(true);
+    clone.querySelectorAll('img.img-selected').forEach((img) => {
+        img.classList.remove('img-selected');
+    });
     if (typeof serializeMathFields === 'function') {
         serializeMathFields(clone);
     }
@@ -499,6 +502,7 @@ window.initializeRichTextEditors = function (root = document) {
         output.classList.toggle("hidden", !visible);
         editorWrapper.classList.toggle("w-full", !visible);
         editorWrapper.classList.toggle("w-1/2", visible);
+        if (visible) requestAnimationFrame(syncPreviewSize);
     }
 
     const codeViewBtn = toolbar.querySelector(".codeViewBtn");
@@ -508,6 +512,42 @@ window.initializeRichTextEditors = function (root = document) {
     });
 
     const codeView = editorWrapper.querySelector(".codeView");
+
+    function activeEditorSurface() {
+        return codeView.classList.contains("hidden") ? editor : codeView;
+    }
+
+    function applyResizableBounds() {
+        const previewVisible = isPreviewVisible && !output.classList.contains("hidden");
+        const gap = parseFloat(getComputedStyle(container).columnGap || getComputedStyle(container).gap || '0') || 0;
+        const maxWidth = Math.floor((container.clientWidth - (previewVisible ? gap : 0)) / (previewVisible ? 2 : 1));
+
+        [editor, codeView, editorWrapper, output].forEach((el) => {
+            el.style.maxWidth = maxWidth + 'px';
+        });
+    }
+
+    function syncPreviewSize() {
+        applyResizableBounds();
+        if (!isPreviewVisible || output.classList.contains("hidden")) return;
+
+        const surface = activeEditorSurface();
+        const rect = surface.getBoundingClientRect();
+        if (!rect.width || !rect.height) return;
+
+        output.style.height = rect.height + 'px';
+        if (surface.style.width) {
+            editorWrapper.style.width = rect.width + 'px';
+            output.style.width = rect.width + 'px';
+            output.style.flex = '0 0 ' + rect.width + 'px';
+        }
+    }
+
+    const resizeObserver = new ResizeObserver(syncPreviewSize);
+    resizeObserver.observe(editor);
+    resizeObserver.observe(codeView);
+    window.addEventListener('resize', syncPreviewSize);
+    syncPreviewSize();
 
     function toggleCodeView() {
         if (codeView.classList.contains("hidden")) {
@@ -519,6 +559,7 @@ window.initializeRichTextEditors = function (root = document) {
             codeView.classList.add("hidden");
             editor.classList.remove("hidden");
         }
+        syncPreviewSize();
     }
 
     function formatHTML(html) {


### PR DESCRIPTION
## Problem

In the problem editor, diagrams after labels like `(A)` were getting forced onto the next line/block. The needed layout is closer to:

```text
(A) diagram
```

instead of:

```text
(A)
diagram
```

Also, the editor area was fixed and small, so larger tables/images were hard to inspect without scrolling inside the editor. The add/edit problem card was capped at `max-w-6xl`, leaving unused horizontal space. When resizing was added, the editor/preview could also stretch past the card boundary.

## Solution

- Reverted the later `Float None` / custom image movement experiment.
- Kept the original `Inline With Text` image toolbar option.
- The option unwraps an image from the editor's float paragraph and keeps it inline with nearby text/labels.
- Removed the duplicate selected-image outline, so selected images show only one resize/selection box.
- Made the editor and code-view surfaces resizable.
- When the editor is resized, the preview automatically gets the same width and height.
- Clamped horizontal resizing so editor + preview stay inside the problem card.
- Changed the add/edit problem form to use the available page width.
- Save still removes the temporary `img-selected` editor class from stored HTML.

## Screenshots

### Before: image below label
<img width="1486" height="322" alt="image" src="https://github.com/user-attachments/assets/b7704493-e554-4a17-9262-0176b0ddd15a" />

### Inline with label
<img width="1486" height="322" alt="image" src="https://github.com/user-attachments/assets/b90587c0-12d4-4146-b682-9643e5b3de14" />

### Resizable editor and matching preview
<img width="1394" height="643" alt="image" src="https://github.com/user-attachments/assets/4abec01c-f9f2-4af7-8455-e431e3bf85b8" />

## Stack

Stacked on #146.
Base branch: `codex/issue-22-piecewise-template`

## Validation

- `npx playwright test tests/editor-image-front.spec.ts tests/editor-math-piecewise.spec.ts --project=chromium`
- `go test ./...`
- `go build ./...`
- `npm run build:css`
- `npx -y mex-agent check --quiet`
