### PR TITLE
✨ Support per-subject test rules & instructions for chapter tests

### DIFF
--- a/internal/models/test_rule.go
+++ b/internal/models/test_rule.go
@@ -1,6 +1,9 @@
 package models
 
-import "html/template"
+import (
+	"encoding/json"
+	"html/template"
+)
 
 type TestRule struct {
 	ExamID   int8   `json:"exam_id"`
@@ -44,4 +47,43 @@ type Difficulty struct {
 type MarkingScheme struct {
 	PosMarks []int `json:"pos_marks"`
 	NegMarks []int `json:"neg_marks"`
+}
+
+// UnmarshalJSON migrates old subject_ids array format to new subject_id scalar format.
+// Remove once all DB records are migrated to the new format.
+func (c *Config) UnmarshalJSON(data []byte) error {
+	type Alias Config
+	var raw struct {
+		Alias
+		Subjects []struct {
+			SubjectIDs   []int8        `json:"subject_ids"`
+			SubjectID    int8          `json:"subject_id"`
+			Rules        RuleDetails   `json:"rules"`
+			Instructions template.HTML `json:"instructions,omitempty"`
+		} `json:"subjects"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*c = Config(raw.Alias)
+
+	isOldFormat := false
+	var subjects []SubjectRule
+	for _, s := range raw.Subjects {
+		if len(s.SubjectIDs) > 0 {
+			isOldFormat = true
+			for _, id := range s.SubjectIDs {
+				subjects = append(subjects, SubjectRule{SubjectID: id, Rules: s.Rules, Instructions: s.Instructions})
+			}
+		} else {
+			subjects = append(subjects, SubjectRule{SubjectID: s.SubjectID, Rules: s.Rules, Instructions: s.Instructions})
+		}
+	}
+	c.Subjects = subjects
+
+	// In the old format, a single subjects[] entry implicitly meant single-subject
+	if isOldFormat && len(raw.Subjects) == 1 {
+		c.SingleSubject = true
+	}
+	return nil
 }

--- a/internal/models/test_rule.go
+++ b/internal/models/test_rule.go
@@ -13,11 +13,13 @@ type Config struct {
 	Duration      int16         `json:"duration"`
 	MarkingScheme MarkingScheme `json:"marking_scheme"`
 	Instructions  template.HTML `json:"instructions"`
+	SingleSubject bool          `json:"single_subject,omitempty"`
 }
 
 type SubjectRule struct {
-	SubjectIDs []int8      `json:"subject_ids"`
-	Rules      RuleDetails `json:"rules"`
+	SubjectID    int8          `json:"subject_id"`
+	Rules        RuleDetails   `json:"rules"`
+	Instructions template.HTML `json:"instructions,omitempty"`
 }
 
 type RuleDetails struct {

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -280,12 +280,13 @@
         </div>
 
         {{ $hasTestRule := (ne .TestRule nil) }}
+        {{ $hasRuleMarkingScheme := and $hasTestRule (gt (len .TestRule.Config.MarkingScheme.PosMarks) 0) }}
         <h2 class="mt-4 text-lg font-semibold">Marking Scheme</h2>
         <div id="marking-scheme-div" class="mt-2 grid grid-cols-4 gap-4 items-center">
             {{ $posMarks := slice }}
             {{ $negMarks := slice }}
 
-            {{ if .TestRule }}
+            {{ if $hasRuleMarkingScheme }}
                 {{ $posMarks = .TestRule.Config.MarkingScheme.PosMarks }}
                 {{ $negMarks = .TestRule.Config.MarkingScheme.NegMarks }}
             {{ else if .Problems }}
@@ -293,8 +294,8 @@
                 {{ $negMarks = .TestPtr.TypeParams.NegMarks }}
             {{ end }}
 
-            {{ template "test_chip_editor" (dict "Label" "Award" "Id" "chip-editor-pos" "Marks" $posMarks "Readonly" $hasTestRule) }}
-            {{ template "test_chip_editor" (dict "Label" "Deduct" "Id" "chip-editor-neg" "Marks" $negMarks "Readonly" $hasTestRule) }}
+            {{ template "test_chip_editor" (dict "Label" "Award" "Id" "chip-editor-pos" "Marks" $posMarks "Readonly" $hasRuleMarkingScheme) }}
+            {{ template "test_chip_editor" (dict "Label" "Deduct" "Id" "chip-editor-neg" "Marks" $negMarks "Readonly" $hasRuleMarkingScheme) }}
         </div>
 
         {{ $easy := 0 }}
@@ -368,19 +369,19 @@
                     {{ $sr := 0 }}
                     {{range .TestPtr.TypeParams.Subjects}}
                         {{ $subjectId := .SubjectID }}
-                        {{ template "dest_subject_row" (dict "SubjectId" $subjectId "SubjectName" .Name 
-                        "PosMarks" .PosMarks "NegMarks" .NegMarks "ReadOnlyMarks" $hasTestRule 
+                        {{ template "dest_subject_row" (dict "SubjectId" $subjectId "SubjectName" .Name
+                        "PosMarks" .PosMarks "NegMarks" .NegMarks "ReadOnlyMarks" $hasRuleMarkingScheme
                         "CanSaveSingleSubject" (eq $mode "edit") "TestId" $id)}}
                         {{range .Sections}}
-                            {{template "dest_subtype_row" (dict "SubjectId" $subjectId "Subtype" .Type 
+                            {{template "dest_subtype_row" (dict "SubjectId" $subjectId "Subtype" .Type
                             "DisplaySubtype" (getSectionName .Type .Name) "PosMarks" .PosMarks "NegMarks" .NegMarks
-                            "ReadOnlyMarks" $hasTestRule)}}
+                            "ReadOnlyMarks" $hasRuleMarkingScheme)}}
                             {{range .Compulsory.Problems}}
                                 {{ $sr = add $sr 1 }}
                                 {{ $prob := index $.Problems .ID }}
                                 {{template "dest_problem_row" (dict "Problem" $prob "SrNo" $sr
-                                "PosMarks" .PosMarks "NegMarks" .NegMarks "DifficultyLevel" .DifficultyLevel "OptionLayout" .OptionLayout 
-                                "ReadOnlyMarks" $hasTestRule
+                                "PosMarks" .PosMarks "NegMarks" .NegMarks "DifficultyLevel" .DifficultyLevel "OptionLayout" .OptionLayout
+                                "ReadOnlyMarks" $hasRuleMarkingScheme
                                 "SectionSubtype" (sectionSubtypeForProblem $prob.Subtype (examIdFromTest $.TestPtr) $.JeeAdvancedExamID))}}
                             {{end}}
                         {{end}}
@@ -1046,6 +1047,17 @@
         };
     }
 
+    function applySubjectInstructions(instructionsHtml) {
+        const currentInstructions = getCurrentInstructions().trim();
+        const defaultFromRule = (document.getElementById('test-instructions-default-from-rule')?.value || "").trim();
+
+        // Only update if the user hasn't manually overridden the instructions
+        if (currentInstructions === defaultFromRule) {
+            document.getElementById('test-instructions').value = instructionsHtml;
+            document.getElementById('test-instructions-default-from-rule').value = instructionsHtml;
+        }
+    }
+
     function shouldIncludeTestInstructionsInPayload() {
         const current = (getCurrentInstructions() || "").trim();
         const defaultFromRule = (document.getElementById('test-instructions-default-from-rule')?.value || "").trim();
@@ -1275,31 +1287,25 @@
         }
     }
 
-    function validateQuestionAgainstTestRule(testRule, subjectId, subtype, existingSubtypeProblemRows, questionsTableBody, 
+    function validateQuestionAgainstTestRule(testRule, subjectId, subtype, existingSubtypeProblemRows, questionsTableBody,
             showAlert = true) {
-        if (!testRule || !testRule.config) {
+        if (!testRule || !testRule.config || !testRule.config.subjects) {
             // No test rule means no restrictions — treat as valid
             return { isValid: true, reason: null };
         }
 
-        const subjects = testRule.config.subjects;
-
-        if (subjects.length === 1) {
-            // Case 1: Only one subject is allowed
-            const allowedIds = subjects[0].subject_ids;
-
-            if (!allowedIds.includes(subjectId)) {
-                const errorMessage = 'Question from selected subject is not allowed for this test.';
-                if (showAlert) {
-                    alert(errorMessage);
-                }
-                return { isValid: false, reason: errorMessage };
+        const subjectRule = testRule.config.subjects.find(s => s.subject_id === subjectId);
+        if (!subjectRule) {
+            const errorMessage = 'Question from this subject is not allowed for this test.';
+            if (showAlert) {
+                alert(errorMessage);
             }
+            return { isValid: false, reason: errorMessage };
+        }
 
-            // Find subject already added
+        if (testRule.config.single_subject) {
             const firstRow = questionsTableBody.querySelector("tr[id^='subject-']");
             const existingSubjectId = firstRow ? parseInt(firstRow.id.replace("subject-", ""), 10) : null;
-
             if (existingSubjectId && existingSubjectId !== subjectId) {
                 const errorMessage = 'Question from only one subject is allowed for this test.';
                 if (showAlert) {
@@ -1307,40 +1313,24 @@
                 }
                 return { isValid: false, reason: errorMessage };
             }
-
-        } else {
-            // Case 2: Multiple subjects are allowed
-            const allowedIds = subjects.map(sub => sub.subject_ids[0]);
-            if (!allowedIds.includes(subjectId)) {
-                const errorMessage = 'Question from this subject is not allowed for this test.';
-                if (showAlert) {
-                    alert(errorMessage);
-                }
-                return { isValid: false, reason: errorMessage };
-            }
         }
 
-        const subjectRule = subjects.find(s => s.subject_ids.includes(subjectId));
-        if (subjectRule) {
-            const allowedTypes = subjectRule.rules.sections.map(s => s.type);
-            if (!allowedTypes.includes(subtype)) {
-                const errorMessage = `Questions of type ${subtype} are not allowed for this subject.`;
-                if (showAlert) {
-                    alert(errorMessage);
-                }
-                return { isValid: false, reason: errorMessage };
+        const allowedTypes = subjectRule.rules.sections.map(s => s.type);
+        if (!allowedTypes.includes(subtype)) {
+            const errorMessage = `Questions of type ${subtype} are not allowed for this subject.`;
+            if (showAlert) {
+                alert(errorMessage);
             }
+            return { isValid: false, reason: errorMessage };
+        }
 
-            // Count how many existing questions are there of this subtype and subject
-            const sectionRule = subjectRule.rules.sections.find(s => s.type === subtype);
-
-            if (existingSubtypeProblemRows >= sectionRule.count) {
-                const errorMessage = `Only ${sectionRule.count} questions are allowed for ${subtype} under this subject.`;
-                if (showAlert) {
-                    alert(errorMessage);
-                }
-                return { isValid: false, reason: errorMessage };
+        const sectionRule = subjectRule.rules.sections.find(s => s.type === subtype);
+        if (existingSubtypeProblemRows >= sectionRule.count) {
+            const errorMessage = `Only ${sectionRule.count} questions are allowed for ${subtype} under this subject.`;
+            if (showAlert) {
+                alert(errorMessage);
             }
+            return { isValid: false, reason: errorMessage };
         }
 
         return { isValid: true, reason: null };

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -460,6 +460,26 @@
 
         initSortableForSections();
         updateSubjectArrowStates();
+
+        // In edit mode the subject row is pre-rendered by the server, so the
+        // src_problem_row path that calls applySubjectInstructions never runs.
+        // In copy mode the original test's instructions are already server-rendered.
+        if (mode === "edit") {
+            setTimeout(function () {
+                const ctx = JSON.parse(document.getElementById("test-context-json").textContent);
+                const testRule = ctx.testRule;
+                if (testRule?.config?.single_subject && testRule.config.subjects?.length > 0) {
+                    const firstSubjectRow = document.querySelector("#questions-table-body tr[id^='subject-']");
+                    if (firstSubjectRow) {
+                        const subjectId = parseInt(firstSubjectRow.id.replace("subject-", ""), 10);
+                        const subjectRule = testRule.config.subjects.find(s => s.subject_id === subjectId);
+                        if (subjectRule?.instructions) {
+                            applySubjectInstructions(subjectRule.instructions);
+                        }
+                    }
+                }
+            }, 0);
+        }
     })();
 
     function setElementFromStorage(elementId, storageKey) {

--- a/web/html/src_problem_row.html
+++ b/web/html/src_problem_row.html
@@ -46,8 +46,14 @@
             const subjectProblemRows = questionsTableBody.querySelectorAll(`tr[data-subject="subject-${subjectId}"]`);
             const insertAfterId = getInsertAfterId(subjectProblemRows, subtypeProblemRows);
 
+            // For single-subject tests, apply per-subject instructions when a new subject row is created
+            const subjectRule = testRule?.config?.subjects?.find(s => s.subject_id === subjectId);
+            const newSubjectInstructions = (testRule?.config?.single_subject && subjectProblemRows.length === 0)
+                ? (subjectRule?.instructions ?? "")
+                : "";
+
             // Hook a one-time global listener that just closes over this specific button's data
-            const handler = createAfterRequestHandler(difficulty, insertAfterId, questionsTableBody, resolve);
+            const handler = createAfterRequestHandler(difficulty, insertAfterId, questionsTableBody, resolve, newSubjectInstructions);
             document.body.addEventListener("htmx:afterRequest", handler);
 
             htmx.ajax("POST", "/add-question-to-test", {
@@ -59,7 +65,7 @@
                     "subject-exists": subjectProblemRows.length > 0,
                     "subtype-exists": subtypeProblemRows.length > 0,
                     "insert-after-id": insertAfterId,
-                    "read-only-marks": !!testRule,
+                    "read-only-marks": !!(testRule?.config?.marking_scheme?.pos_marks?.length),
                     // single subject can be saved only in edit test scenario
                     "can-save-single-subject": mode === "edit",
                     "test-id": testId,
@@ -83,7 +89,7 @@
         return "";
     }
 
-    function createAfterRequestHandler(difficulty, insertAfterId, tableBody, resolve) {
+    function createAfterRequestHandler(difficulty, insertAfterId, tableBody, resolve, newSubjectInstructions) {
         return function handler(event) {
             if (event.detail.successful) {
                 incrementLevelCount(difficulty);
@@ -93,6 +99,10 @@
 
                 initSortableForSections();
                 updateSubjectArrowStates();
+
+                if (newSubjectInstructions && typeof applySubjectInstructions === "function") {
+                    applySubjectInstructions(newSubjectInstructions);
+                }
             }
             document.body.removeEventListener("htmx:afterRequest", handler);
             resolve();

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -36,8 +36,18 @@ window.MathJax = {
 
 {{ define "pdf_test_meta" }}
 {{ $instructions := .TestPtr.TypeParams.Instructions }}
-{{ if and (not $instructions) .TestRule .TestRule.Config.Instructions }}
-    {{ $instructions = .TestRule.Config.Instructions }}
+{{ if and (not $instructions) .TestRule }}
+    {{ if and .TestRule.Config.SingleSubject .TestPtr.TypeParams.Subjects }}
+        {{ $subjectId := (index .TestPtr.TypeParams.Subjects 0).SubjectID }}
+        {{ range .TestRule.Config.Subjects }}
+            {{ if eq .SubjectID $subjectId }}
+                {{ $instructions = .Instructions }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+    {{ if not $instructions }}
+        {{ $instructions = .TestRule.Config.Instructions }}
+    {{ end }}
 {{ end }}
 {{ if $instructions }}
 <div class="border border-black p-4 mb-5">


### PR DESCRIPTION
## 📋 Summary

- 🔄 **Refactored `SubjectRule`** — replaced `subject_ids[]` with a single `subject_id` so each subject can carry its own rules and instructions
- 🏷️ **Added `SingleSubject` flag** on `Config` to explicitly enforce single-subject-per-test for chapter tests
- 📝 **Per-subject instructions** — auto-applied when the first question from a subject is added; respects manual user overrides
- 🖨️ **PDF instruction fallback chain** — `TypeParams.Instructions` → `SubjectRule.Instructions` (for single-subject tests) → `Config.Instructions`
- 🔓 **Editable marks when rule has no marking scheme** — fixes JEE Advanced tests where a rule exists for instructions/subject-rules only, but marking scheme should remain user-editable
- 🛡️ **Null guard** on `testRule.config.subjects` to prevent crash when subjects is null

## 🗂️ Files Changed

| File | Change |
|------|--------|
| `internal/models/test_rule.go` | `SubjectIDs[]` → `SubjectID`, added `Instructions` to `SubjectRule`, added `SingleSubject` to `Config` |
| `web/html/add_test.html` | Rewrote `validateQuestionAgainstTestRule`, added `applySubjectInstructions`, introduced `$hasRuleMarkingScheme` |
| `web/html/src_problem_row.html` | Per-subject instruction lookup & apply on new subject; `read-only-marks` gated on actual marking scheme |
| `web/html/test_pdf_shared.html` | Per-subject instruction fallback chain in `pdf_test_meta` |

## 🧪 Test Plan

- [x] Add question to a chapter test — verify only one subject is allowed
- [x] Switch subject (remove all from subject A, add from subject B) — verify instructions update correctly
- [ ] Manually edit instructions, then add a question — verify instructions are NOT auto-overridden
- [x] Open a JEE Advanced test with no marking scheme in rule — verify marks chip editors are editable
- [x] Generate PDF for chapter test — verify subject-level instructions appear; fallback to config-level if none set
- [x] Generate PDF for multi-subject test — verify config-level instructions appear
- [x] Add question to test with no test rule — verify no crash