### PR TITLE
🐛 Fix: Uneditable duration for JEE Advanced chapter tests; Remove subject_ids migration shim

### DIFF
--- a/internal/models/test_rule.go
+++ b/internal/models/test_rule.go
@@ -1,9 +1,6 @@
 package models
 
-import (
-	"encoding/json"
-	"html/template"
-)
+import "html/template"
 
 type TestRule struct {
 	ExamID   int8   `json:"exam_id"`
@@ -47,43 +44,4 @@ type Difficulty struct {
 type MarkingScheme struct {
 	PosMarks []int `json:"pos_marks"`
 	NegMarks []int `json:"neg_marks"`
-}
-
-// UnmarshalJSON migrates old subject_ids array format to new subject_id scalar format.
-// Remove once all DB records are migrated to the new format.
-func (c *Config) UnmarshalJSON(data []byte) error {
-	type Alias Config
-	var raw struct {
-		Alias
-		Subjects []struct {
-			SubjectIDs   []int8        `json:"subject_ids"`
-			SubjectID    int8          `json:"subject_id"`
-			Rules        RuleDetails   `json:"rules"`
-			Instructions template.HTML `json:"instructions,omitempty"`
-		} `json:"subjects"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	*c = Config(raw.Alias)
-
-	isOldFormat := false
-	var subjects []SubjectRule
-	for _, s := range raw.Subjects {
-		if len(s.SubjectIDs) > 0 {
-			isOldFormat = true
-			for _, id := range s.SubjectIDs {
-				subjects = append(subjects, SubjectRule{SubjectID: id, Rules: s.Rules, Instructions: s.Instructions})
-			}
-		} else {
-			subjects = append(subjects, SubjectRule{SubjectID: s.SubjectID, Rules: s.Rules, Instructions: s.Instructions})
-		}
-	}
-	c.Subjects = subjects
-
-	// In the old format, a single subjects[] entry implicitly meant single-subject
-	if isOldFormat && len(raw.Subjects) == 1 {
-		c.SingleSubject = true
-	}
-	return nil
 }

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -404,7 +404,7 @@
             <label class="text-sm font-medium">Duration (mins):</label>
             <input id="duration" type="number" class="w-1/4 border rounded-sm p-2" placeholder="60"
                 value="{{ $duration }}" 
-                {{ if .TestRule }}readonly{{ end }}
+                {{ if and .TestRule .TestRule.Config.Duration }}readonly{{ end }}
                 onchange="sessionStorage.setItem('selectedDuration', this.value);">
             <label class="text-sm font-medium">Total Marks:</label>
             <label id="total-marks" class="p-2">{{if .Problems}}{{.TestPtr.TypeParams.Marks}}{{else}}0{{end}}</label>


### PR DESCRIPTION
## Changes

- 🔓 **Duration input**: Fixed duration field being readonly when a test rule exists but has no duration configured. Previously any test rule (e.g. instructions-only) would lock the field; now it only locks when the rule explicitly sets a duration.

- 🧹 **Migration cleanup**: Removed the `UnmarshalJSON` shim on `Config` that migrated old `subject_ids` array format to the new `subject_id` scalar. Both the code and DB records are fully on the new format, so the shim is no longer needed.