### PR TITLE
✨ Feat: customizable row count for piecewise/cases math template

### DIFF
--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -203,11 +203,20 @@
                     </button>
                 </div>
                 <div
-                    class="mathTemplateDropdown absolute right-0 mt-1 hidden bg-bg-card border border-border rounded-sm shadow-card p-2 z-50 w-44">
-                    <button type="button" data-math-template="piecewise"
-                        class="w-full px-2 py-1 text-left hover:bg-brand-blue-bg rounded-sm">
-                        Piecewise / Cases
-                    </button>
+                    class="mathTemplateDropdown absolute right-0 mt-1 hidden bg-bg-card border border-border rounded-sm shadow-card p-2 z-50 w-56">
+                    <div class="flex items-center gap-1 px-2 py-1 hover:bg-brand-blue-bg rounded-sm">
+                        <span class="flex-1 text-left text-sm whitespace-nowrap">Piecewise / Cases</span>
+                        <input type="number" min="2" max="10" value="2"
+                            class="piecewise-rows w-10 border border-border rounded-sm text-xs px-1 py-0.5 text-center"
+                            onclick="event.stopPropagation()"
+                            oninput="this.value = Math.min(10, Math.max(2, parseInt(this.value) || 2));"
+                            onkeydown="if(event.key==='Enter'){event.preventDefault();event.stopPropagation();this.nextElementSibling.click();}"
+                            title="Number of rows">
+                        <button type="button" data-math-template="piecewise" title="Insert"
+                            class="text-accent hover:text-accent-hover px-1">
+                            <i class="fas fa-arrow-right text-xs"></i>
+                        </button>
+                    </div>
                 </div>
             </div>
 

--- a/web/static/js/editor-math.js
+++ b/web/static/js/editor-math.js
@@ -123,9 +123,10 @@ function latexSpanFromText(latex) {
     return span;
 }
 
-const mathTemplates = {
-    piecewise: 'f(x)=\\begin{cases}#? & #? \\\\ #? & #?\\end{cases}',
-};
+function buildPiecewiseLatex(rows) {
+    const rowLatex = Array.from({ length: rows }, () => '#? & #?').join(' \\\\ ');
+    return `f(x)=\\begin{cases}${rowLatex}\\end{cases}`;
+}
 
 function getLatexFromMathJaxContainer(container) {
     const dataTex = container.getAttribute('data-tex');
@@ -272,8 +273,11 @@ function insertMath(editor) {
     insertMathFieldAtCursor(editor);
 }
 
-function insertMathTemplate(editor, templateName) {
-    const latex = mathTemplates[templateName];
+function insertMathTemplate(editor, templateName, rows) {
+    let latex;
+    if (templateName === 'piecewise') {
+        latex = buildPiecewiseLatex(Math.max(2, parseInt(rows) || 2));
+    }
     if (!latex) return;
     insertMathFieldAtCursor(editor, latex);
 }

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -619,7 +619,8 @@ window.initializeRichTextEditors = function (root = document) {
                 e.preventDefault();
                 e.stopPropagation();
                 restoreSelection();
-                insertMathTemplate(editor, btn.dataset.mathTemplate);
+                const rows = btn.closest('div')?.querySelector('.piecewise-rows')?.value;
+                insertMathTemplate(editor, btn.dataset.mathTemplate, rows);
                 mathTemplateDropdown.classList.add('hidden');
             });
         });


### PR DESCRIPTION
## Summary

- 🔢 **Piecewise row picker**: The math template dropdown now shows a number input (range 2–10, default 2) alongside the "Piecewise / Cases" option, letting users choose how many rows to insert before clicking the arrow button or pressing Enter.
- 🧮 **Dynamic LaTeX generation**: Replaced the hardcoded 2-row `cases` template with `buildPiecewiseLatex(rows)` which generates the correct `\begin{cases}...\end{cases}` LaTeX for any row count.
- ⌨️ **Enter key support**: Pressing Enter in the row count input triggers insertion, same as clicking the arrow.
- 🛡️ **Input clamping**: `oninput` clamps the value to 2–10, preventing invalid inputs.

## Test plan

- [x] Open the math template dropdown in the editor
- [x] Verify the "Piecewise / Cases" row shows a number input and arrow button
- [x] Set row count to 3 and click the arrow — confirm 3 rows are inserted
- [x] Set row count to 5 and press Enter — confirm 5 rows are inserted
- [x] Type a value > 10 — confirm it clamps to 10
- [x] Verify default (2 rows) still works without changing the input

🤖 Generated with [Claude Code](https://claude.com/claude-code)