### PR TITLE
✨ Feat: Display chapter and topic code & name on problem and topic pages

### DIFF
--- a/di/app_component.go
+++ b/di/app_component.go
@@ -73,7 +73,7 @@ func NewAppComponent() (*AppComponent, error) {
 	adminUsersHandler := handlers.NewAdminUsersHandler(usersRepo)
 	chaptersHandler := handlers.NewChaptersHandler(chaptersService, topicsService)
 	resourcesHandler := handlers.NewResourcesHandler(resourcesService)
-	topicsHandler := handlers.NewTopicsHandler(topicsService)
+	topicsHandler := handlers.NewTopicsHandler(topicsService, chaptersService)
 	conceptsHandler := handlers.NewConceptsHandler(conceptsService)
 	curriculumsHandler := handlers.NewCurriculumsHandler(curriculumsService)
 	gradesHandler := handlers.NewGradesHandler(gradesService)
@@ -82,7 +82,7 @@ func NewAppComponent() (*AppComponent, error) {
 	testsHandler := handlers.NewTestsHandler(testsService, subjectsService, problemsService, testRulesService,
 		curriculumsService, gradesService, examsService)
 	problemsHandler := handlers.NewProblemsHandler(problemsService, skillsService, subjectsService, topicsService,
-		tagsService)
+		chaptersService, tagsService)
 	tagsHandler := handlers.NewTagsHandler(tagsService)
 	examsHandler := handlers.NewExamsHandler(examsService)
 

--- a/internal/dto/problem_dto.go
+++ b/internal/dto/problem_dto.go
@@ -6,6 +6,7 @@ type ProblemData struct {
 	HomeData
 	ProblemPtr *models.Problem
 	TopicPtr   *models.Topic
+	ChapterPtr *models.Chapter
 }
 
 type CopyProblemModalData struct {

--- a/internal/dto/topic_dto.go
+++ b/internal/dto/topic_dto.go
@@ -4,5 +4,6 @@ import "github.com/avantifellows/nex-gen-cms/internal/models"
 
 type TopicData struct {
 	HomeData
-	TopicPtr *models.Topic
+	TopicPtr   *models.Topic
+	ChapterPtr *models.Chapter
 }

--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -18,10 +18,6 @@ import (
 	"github.com/avantifellows/nex-gen-cms/utils"
 )
 
-const chaptersEndPoint = "chapter"
-
-const chaptersKey = "chapters"
-
 const chaptersTemplate = "chapters.html"
 const chapterRowTemplate = "chapter_row.html"
 const editChapterTemplate = "edit_chapter.html"
@@ -60,7 +56,7 @@ func (h *ChaptersHandler) GetChapters(responseWriter http.ResponseWriter, reques
 	if !ok {
 		return
 	}
-	chapters, err := h.chaptersService.GetList(chaptersEndPoint+queryParams, chaptersKey, false, true)
+	chapters, err := h.chaptersService.GetList(handlerutils.ChaptersEndPoint+queryParams, handlerutils.ChaptersKey, false, true)
 
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching chapters: %v", err), http.StatusInternalServerError)
@@ -163,7 +159,7 @@ func (h *ChaptersHandler) UpdateChapter(responseWriter http.ResponseWriter, requ
 	dummyChapterPtr := &models.Chapter{}
 	chapterMap := dummyChapterPtr.BuildMap(chapterCode, chapterName)
 
-	_, err = h.chaptersService.UpdateObject(chapterIdStr, chaptersEndPoint, chapterMap, chaptersKey,
+	_, err = h.chaptersService.UpdateObject(chapterIdStr, handlerutils.ChaptersEndPoint, chapterMap, handlerutils.ChaptersKey,
 		func(chapter *models.Chapter) bool {
 			return (*chapter).ID == chapterId
 		})
@@ -198,7 +194,7 @@ func (h *ChaptersHandler) AddChapter(responseWriter http.ResponseWriter, request
 	}
 	newChapterPtr := models.NewChapter(chapterCode, chapterName, curriculumId, gradeId, subjectId)
 
-	newChapterPtr, err = h.chaptersService.AddObject(newChapterPtr, chaptersKey, chaptersEndPoint)
+	newChapterPtr, err = h.chaptersService.AddObject(newChapterPtr, handlerutils.ChaptersKey, handlerutils.ChaptersEndPoint)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error adding chapter: %v", err), http.StatusInternalServerError)
 		return
@@ -222,7 +218,7 @@ func (h *ChaptersHandler) ArchiveChapter(responseWriter http.ResponseWriter, req
 		"cms_status_id": constants.StatusArchived,
 	}
 
-	err = h.chaptersService.ArchiveObject(chapterIdStr, chaptersEndPoint, chapterMap, chaptersKey,
+	err = h.chaptersService.ArchiveObject(chapterIdStr, handlerutils.ChaptersEndPoint, chapterMap, handlerutils.ChaptersKey,
 		func(chapter *models.Chapter) bool {
 			return (*chapter).ID != chapterId
 		})
@@ -265,24 +261,10 @@ func sortChapters(chapterPtrs []*models.Chapter, sortColumn string, sortOrder st
 func (h *ChaptersHandler) getChapter(request *http.Request) (*models.Chapter, int, error) {
 	urlVals := request.URL.Query()
 	chapterIdStr := urlVals.Get("id")
-
 	if chapterIdStr == "" {
 		chapterIdStr = urlVals.Get("chapter-dropdown")
 	}
-	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
-	if err != nil {
-		return nil, http.StatusBadRequest, fmt.Errorf("invalid Chapter ID: %w", err)
-	}
-
-	selectedChapterPtr, err := h.chaptersService.GetObject(chapterIdStr,
-		func(chapter *models.Chapter) bool {
-			return (*chapter).ID == chapterId
-		}, chaptersKey, chaptersEndPoint)
-	if err != nil {
-		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching chapter: %v", err)
-	}
-
-	return selectedChapterPtr, http.StatusOK, nil
+	return handlerutils.GetChapterById(chapterIdStr, h.chaptersService)
 }
 
 func (h *ChaptersHandler) GetChapter(responseWriter http.ResponseWriter, request *http.Request) {

--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -264,7 +264,7 @@ func (h *ChaptersHandler) getChapter(request *http.Request) (*models.Chapter, in
 	if chapterIdStr == "" {
 		chapterIdStr = urlVals.Get("chapter-dropdown")
 	}
-	return handlerutils.GetChapterById(chapterIdStr, h.chaptersService)
+	return handlerutils.GetChapterByID(chapterIdStr, h.chaptersService)
 }
 
 func (h *ChaptersHandler) GetChapter(responseWriter http.ResponseWriter, request *http.Request) {

--- a/internal/handlers/handlerutils/chapter_util.go
+++ b/internal/handlers/handlerutils/chapter_util.go
@@ -1,9 +1,6 @@
 package handlerutils
 
 import (
-	"fmt"
-	"net/http"
-
 	"github.com/avantifellows/nex-gen-cms/internal/models"
 	"github.com/avantifellows/nex-gen-cms/internal/services"
 	"github.com/avantifellows/nex-gen-cms/utils"
@@ -12,19 +9,14 @@ import (
 const ChaptersEndPoint = "chapter"
 const ChaptersKey = "chapters"
 
-func GetChapterById(chapterIdStr string, chaptersService *services.Service[models.Chapter]) (*models.Chapter, int, error) {
-	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
-	if err != nil {
-		return nil, http.StatusBadRequest, fmt.Errorf("invalid Chapter ID: %w", err)
-	}
-
-	selectedChapterPtr, err := chaptersService.GetObject(chapterIdStr,
-		func(chapter *models.Chapter) bool {
-			return (*chapter).ID == chapterId
-		}, ChaptersKey, ChaptersEndPoint)
-	if err != nil {
-		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching chapter: %v", err)
-	}
-
-	return selectedChapterPtr, http.StatusOK, nil
+func GetChapterByID(chapterIDStr string, chaptersService *services.Service[models.Chapter]) (*models.Chapter, int, error) {
+	return GetEntityById(
+		chapterIDStr,
+		chaptersService,
+		ChaptersKey,
+		ChaptersEndPoint,
+		utils.StringToIntType[int16],
+		func(c *models.Chapter, id int16) bool { return c.ID == id },
+		"Chapter",
+	)
 }

--- a/internal/handlers/handlerutils/chapter_util.go
+++ b/internal/handlers/handlerutils/chapter_util.go
@@ -1,0 +1,30 @@
+package handlerutils
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/avantifellows/nex-gen-cms/internal/models"
+	"github.com/avantifellows/nex-gen-cms/internal/services"
+	"github.com/avantifellows/nex-gen-cms/utils"
+)
+
+const ChaptersEndPoint = "chapter"
+const ChaptersKey = "chapters"
+
+func GetChapterById(chapterIdStr string, chaptersService *services.Service[models.Chapter]) (*models.Chapter, int, error) {
+	chapterId, err := utils.StringToIntType[int16](chapterIdStr)
+	if err != nil {
+		return nil, http.StatusBadRequest, fmt.Errorf("invalid Chapter ID: %w", err)
+	}
+
+	selectedChapterPtr, err := chaptersService.GetObject(chapterIdStr,
+		func(chapter *models.Chapter) bool {
+			return (*chapter).ID == chapterId
+		}, ChaptersKey, ChaptersEndPoint)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching chapter: %v", err)
+	}
+
+	return selectedChapterPtr, http.StatusOK, nil
+}

--- a/internal/handlers/handlerutils/chapter_util.go
+++ b/internal/handlers/handlerutils/chapter_util.go
@@ -10,7 +10,7 @@ const ChaptersEndPoint = "chapter"
 const ChaptersKey = "chapters"
 
 func GetChapterByID(chapterIDStr string, chaptersService *services.Service[models.Chapter]) (*models.Chapter, int, error) {
-	return GetEntityById(
+	return GetEntityByID(
 		chapterIDStr,
 		chaptersService,
 		ChaptersKey,

--- a/internal/handlers/handlerutils/entity_util.go
+++ b/internal/handlers/handlerutils/entity_util.go
@@ -7,7 +7,7 @@ import (
 	"github.com/avantifellows/nex-gen-cms/internal/services"
 )
 
-func GetEntityById[T any, ID comparable](
+func GetEntityByID[T any, ID comparable](
 	idStr string,
 	service *services.Service[T],
 	cacheKey string,

--- a/internal/handlers/handlerutils/entity_util.go
+++ b/internal/handlers/handlerutils/entity_util.go
@@ -1,0 +1,32 @@
+package handlerutils
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/avantifellows/nex-gen-cms/internal/services"
+)
+
+func GetEntityById[T any, ID comparable](
+	idStr string,
+	service *services.Service[T],
+	cacheKey string,
+	endpoint string,
+	idParser func(string) (ID, error),
+	idMatcher func(*T, ID) bool,
+	entityName string,
+) (*T, int, error) {
+	id, err := idParser(idStr)
+	if err != nil {
+		return nil, http.StatusBadRequest, fmt.Errorf("invalid %s ID: %w", entityName, err)
+	}
+
+	entityPtr, err := service.GetObject(idStr, func(e *T) bool {
+		return idMatcher(e, id)
+	}, cacheKey, endpoint)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching %s: %w", entityName, err)
+	}
+
+	return entityPtr, http.StatusOK, nil
+}

--- a/internal/handlers/handlerutils/topic_util.go
+++ b/internal/handlers/handlerutils/topic_util.go
@@ -1,9 +1,6 @@
 package handlerutils
 
 import (
-	"fmt"
-	"net/http"
-
 	"github.com/avantifellows/nex-gen-cms/internal/models"
 	"github.com/avantifellows/nex-gen-cms/internal/services"
 	"github.com/avantifellows/nex-gen-cms/utils"
@@ -12,19 +9,14 @@ import (
 const TopicsEndPoint = "topic"
 const TopicsKey = "topics"
 
-func GetTopicById(topicIdStr string, topicsService *services.Service[models.Topic]) (*models.Topic, int, error) {
-	topicId, err := utils.StringToIntType[int16](topicIdStr)
-	if err != nil {
-		return nil, http.StatusBadRequest, fmt.Errorf("invalid Topic ID: %w", err)
-	}
-
-	selectedTopicPtr, err := topicsService.GetObject(topicIdStr,
-		func(topic *models.Topic) bool {
-			return (*topic).ID == topicId
-		}, TopicsKey, TopicsEndPoint)
-	if err != nil {
-		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching topic: %v", err)
-	}
-
-	return selectedTopicPtr, http.StatusOK, nil
+func GetTopicByID(topicIDStr string, topicsService *services.Service[models.Topic]) (*models.Topic, int, error) {
+	return GetEntityById(
+		topicIDStr,
+		topicsService,
+		TopicsKey,
+		TopicsEndPoint,
+		utils.StringToIntType[int16],
+		func(t *models.Topic, id int16) bool { return t.ID == id },
+		"Topic",
+	)
 }

--- a/internal/handlers/handlerutils/topic_util.go
+++ b/internal/handlers/handlerutils/topic_util.go
@@ -10,7 +10,7 @@ const TopicsEndPoint = "topic"
 const TopicsKey = "topics"
 
 func GetTopicByID(topicIDStr string, topicsService *services.Service[models.Topic]) (*models.Topic, int, error) {
-	return GetEntityById(
+	return GetEntityByID(
 		topicIDStr,
 		topicsService,
 		TopicsKey,

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -70,13 +70,13 @@ func (h *ProblemsHandler) GetProblem(responseWriter http.ResponseWriter, request
 		return
 	}
 
-	topicIdStr := strconv.Itoa(int(selectedProblemPtr.TopicID))
-	selectedTopicPtr, _, _ := handlerutils.GetTopicById(topicIdStr, h.topicsService)
+	topicIDStr := strconv.Itoa(int(selectedProblemPtr.TopicID))
+	selectedTopicPtr, _, _ := handlerutils.GetTopicByID(topicIDStr, h.topicsService)
 
 	var selectedChapterPtr *models.Chapter
 	if selectedTopicPtr != nil {
-		chapterIdStr := strconv.Itoa(int(selectedTopicPtr.ChapterID))
-		selectedChapterPtr, _, _ = handlerutils.GetChapterById(chapterIdStr, h.chaptersService)
+		chapterIDStr := strconv.Itoa(int(selectedTopicPtr.ChapterID))
+		selectedChapterPtr, _, _ = handlerutils.GetChapterByID(chapterIDStr, h.chaptersService)
 	}
 
 	data := dto.ProblemData{
@@ -286,8 +286,8 @@ func (h *ProblemsHandler) LoadTopicProblems(responseWriter http.ResponseWriter, 
 }
 
 func (h *ProblemsHandler) AddProblem(responseWriter http.ResponseWriter, request *http.Request) {
-	topicIdStr := request.URL.Query().Get(QUERY_PARAM_TOPIC_ID)
-	selectedTopicPtr, code, err := handlerutils.GetTopicById(topicIdStr, h.topicsService)
+	topicIDStr := request.URL.Query().Get(QUERY_PARAM_TOPIC_ID)
+	selectedTopicPtr, code, err := handlerutils.GetTopicByID(topicIDStr, h.topicsService)
 	if err != nil {
 		http.Error(responseWriter, err.Error(), code)
 		return
@@ -539,8 +539,8 @@ func (h *ProblemsHandler) CopyProblem(responseWriter http.ResponseWriter, reques
 		return
 	}
 
-	topicIdStr := urlValues.Get(QUERY_PARAM_TOPIC_ID)
-	selectedTopicPtr, code, err := handlerutils.GetTopicById(topicIdStr, h.topicsService)
+	topicIDStr := urlValues.Get(QUERY_PARAM_TOPIC_ID)
+	selectedTopicPtr, code, err := handlerutils.GetTopicByID(topicIDStr, h.topicsService)
 	if err != nil {
 		http.Error(responseWriter, err.Error(), code)
 		return

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -50,14 +50,17 @@ type ProblemsHandler struct {
 	skillsService   *services.Service[models.Skill]
 	subjectsService *services.Service[models.Subject]
 	topicsService   *services.Service[models.Topic]
+	chaptersService *services.Service[models.Chapter]
 	tagsService     *services.Service[models.Tag]
 }
 
 func NewProblemsHandler(problemsService *services.Service[models.Problem],
 	skillsService *services.Service[models.Skill], subjectsService *services.Service[models.Subject],
-	topicsService *services.Service[models.Topic], tagsService *services.Service[models.Tag]) *ProblemsHandler {
+	topicsService *services.Service[models.Topic], chaptersService *services.Service[models.Chapter],
+	tagsService *services.Service[models.Tag]) *ProblemsHandler {
 	return &ProblemsHandler{problemsService: problemsService, skillsService: skillsService,
-		subjectsService: subjectsService, topicsService: topicsService, tagsService: tagsService}
+		subjectsService: subjectsService, topicsService: topicsService, chaptersService: chaptersService,
+		tagsService: tagsService}
 }
 
 func (h *ProblemsHandler) GetProblem(responseWriter http.ResponseWriter, request *http.Request) {
@@ -67,6 +70,15 @@ func (h *ProblemsHandler) GetProblem(responseWriter http.ResponseWriter, request
 		return
 	}
 
+	topicIdStr := strconv.Itoa(int(selectedProblemPtr.TopicID))
+	selectedTopicPtr, _, _ := handlerutils.GetTopicById(topicIdStr, h.topicsService)
+
+	var selectedChapterPtr *models.Chapter
+	if selectedTopicPtr != nil {
+		chapterIdStr := strconv.Itoa(int(selectedTopicPtr.ChapterID))
+		selectedChapterPtr, _, _ = handlerutils.GetChapterById(chapterIdStr, h.chaptersService)
+	}
+
 	data := dto.ProblemData{
 		HomeData: dto.HomeData{
 			CurriculumID: selectedProblemPtr.CurriculumID,
@@ -74,6 +86,8 @@ func (h *ProblemsHandler) GetProblem(responseWriter http.ResponseWriter, request
 			SubjectID:    selectedProblemPtr.SubjectID,
 		},
 		ProblemPtr: selectedProblemPtr,
+		TopicPtr:   selectedTopicPtr,
+		ChapterPtr: selectedChapterPtr,
 	}
 
 	views.ExecuteTemplates(responseWriter, data, template.FuncMap{

--- a/internal/handlers/topic_handler.go
+++ b/internal/handlers/topic_handler.go
@@ -26,12 +26,14 @@ const topicDropdownTemplate = "topic_dropdown.html"
 const topicTemplate = "topic.html"
 
 type TopicsHandler struct {
-	service *services.Service[models.Topic]
+	service         *services.Service[models.Topic]
+	chaptersService *services.Service[models.Chapter]
 }
 
-func NewTopicsHandler(service *services.Service[models.Topic]) *TopicsHandler {
+func NewTopicsHandler(service *services.Service[models.Topic], chaptersService *services.Service[models.Chapter]) *TopicsHandler {
 	return &TopicsHandler{
-		service: service,
+		service:         service,
+		chaptersService: chaptersService,
 	}
 }
 
@@ -192,13 +194,17 @@ func (h *TopicsHandler) GetTopic(responseWriter http.ResponseWriter, request *ht
 		http.Error(responseWriter, "Invalid grade ID", http.StatusBadRequest)
 		return
 	}
+	chapterIdStr := fmt.Sprintf("%d", selectedTopicPtr.ChapterID)
+	selectedChapterPtr, _, _ := handlerutils.GetChapterById(chapterIdStr, h.chaptersService)
+
 	data := dto.TopicData{
 		HomeData: dto.HomeData{
 			CurriculumID: curriculumId,
 			GradeID:      gradeId,
 			SubjectID:    subjectId,
 		},
-		TopicPtr: selectedTopicPtr,
+		TopicPtr:   selectedTopicPtr,
+		ChapterPtr: selectedChapterPtr,
 	}
 	views.ExecuteTemplates(responseWriter, data, template.FuncMap{
 		"getName": getTopicName,

--- a/internal/handlers/topic_handler.go
+++ b/internal/handlers/topic_handler.go
@@ -114,7 +114,7 @@ func (h *TopicsHandler) ArchiveTopic(responseWriter http.ResponseWriter, request
 }
 
 func (h *TopicsHandler) EditTopic(responseWriter http.ResponseWriter, request *http.Request) {
-	selectedTopicPtr, code, err := handlerutils.GetTopicById(request.URL.Query().Get("id"), h.service)
+	selectedTopicPtr, code, err := handlerutils.GetTopicByID(request.URL.Query().Get("id"), h.service)
 	if err != nil {
 		http.Error(responseWriter, err.Error(), code)
 		return
@@ -178,7 +178,7 @@ func sortTopics(topics []*models.Topic, sortColumn string, sortOrder string) {
 }
 
 func (h *TopicsHandler) GetTopic(responseWriter http.ResponseWriter, request *http.Request) {
-	selectedTopicPtr, code, err := handlerutils.GetTopicById(request.URL.Query().Get("id"), h.service)
+	selectedTopicPtr, code, err := handlerutils.GetTopicByID(request.URL.Query().Get("id"), h.service)
 	if err != nil {
 		http.Error(responseWriter, err.Error(), code)
 		return
@@ -194,8 +194,8 @@ func (h *TopicsHandler) GetTopic(responseWriter http.ResponseWriter, request *ht
 		http.Error(responseWriter, "Invalid grade ID", http.StatusBadRequest)
 		return
 	}
-	chapterIdStr := fmt.Sprintf("%d", selectedTopicPtr.ChapterID)
-	selectedChapterPtr, _, _ := handlerutils.GetChapterById(chapterIdStr, h.chaptersService)
+	chapterIDStr := fmt.Sprintf("%d", selectedTopicPtr.ChapterID)
+	selectedChapterPtr, _, _ := handlerutils.GetChapterByID(chapterIDStr, h.chaptersService)
 
 	data := dto.TopicData{
 		HomeData: dto.HomeData{

--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -18,6 +18,16 @@
             </button>
         </div>
     </div>
+    {{ if or .ChapterPtr .TopicPtr }}
+    <div class="flex flex-wrap gap-x-6 gap-y-1 mb-4 text-sm text-ink-muted">
+        {{ if .ChapterPtr }}
+        <span><span class="font-semibold text-ink">Chapter:</span> {{ .ChapterPtr.Code }} — {{ .ChapterPtr.GetNameByLang "en" }}</span>
+        {{ end }}
+        {{ if .TopicPtr }}
+        <span><span class="font-semibold text-ink">Topic:</span> {{ .TopicPtr.Code }} — {{ .TopicPtr.GetNameByLang "en" }}</span>
+        {{ end }}
+    </div>
+    {{ end }}
     <div class="card card-pad" data-mathjax="true">
         {{ if and (eq .ProblemPtr.Subtype "comprehension") .ProblemPtr.Paragraph }}
         <h2 class="section-title">Paragraph</h2>

--- a/web/html/topic.html
+++ b/web/html/topic.html
@@ -4,12 +4,9 @@
         <button class="btn-ghost btn-sm" onclick="window.history.back()">
             <i class="fa-solid fa-chevron-left"></i> Back
         </button>
-        <div class="ml-4">
-            <h3 class="text-lg font-bold uppercase tracking-wide text-ink">{{ .TopicPtr.Code }} — {{ getName .TopicPtr "en" }}</h3>
-            {{ if .ChapterPtr }}
-            <p class="text-sm text-ink-muted mt-0.5">Chapter: {{ .ChapterPtr.Code }} — {{ .ChapterPtr.GetNameByLang "en" }}</p>
-            {{ end }}
-        </div>
+        <h3 class="ml-4 text-lg font-bold tracking-wide text-ink">
+            {{ if .ChapterPtr }}<span class="text-ink-muted font-normal">{{ .ChapterPtr.Code }} — {{ .ChapterPtr.GetNameByLang "en" }}</span> / {{ end }}{{ .TopicPtr.Code }} — {{ getName .TopicPtr "en" }}
+        </h3>
     </div>
     <div class="flex flex-wrap gap-3 py-2 border-b border-border">
         <button id="topic-concepts-tab" data-toggle="sub-tab" class="sub-tab active" onclick="onTopicTabClick(this)"

--- a/web/html/topic.html
+++ b/web/html/topic.html
@@ -4,7 +4,12 @@
         <button class="btn-ghost btn-sm" onclick="window.history.back()">
             <i class="fa-solid fa-chevron-left"></i> Back
         </button>
-        <h3 class="ml-4 text-lg font-bold uppercase tracking-wide text-ink">{{ getName .TopicPtr "en" }}</h3>
+        <div class="ml-4">
+            <h3 class="text-lg font-bold uppercase tracking-wide text-ink">{{ .TopicPtr.Code }} — {{ getName .TopicPtr "en" }}</h3>
+            {{ if .ChapterPtr }}
+            <p class="text-sm text-ink-muted mt-0.5">Chapter: {{ .ChapterPtr.Code }} — {{ .ChapterPtr.GetNameByLang "en" }}</p>
+            {{ end }}
+        </div>
     </div>
     <div class="flex flex-wrap gap-3 py-2 border-b border-border">
         <button id="topic-concepts-tab" data-toggle="sub-tab" class="sub-tab active" onclick="onTopicTabClick(this)"


### PR DESCRIPTION
## 🔍 What changed
- 📦 Added `ChapterPtr *models.Chapter` to `ProblemData` and `TopicData` DTOs
- 🛠️ Created `handlerutils.GetChapterById` util (mirrors existing `GetTopicById`)
- 🔧 `ProblemsHandler` and `TopicsHandler` now accept and use a `chaptersService`
- 🔌 `GetProblem` fetches the topic and chapter for the problem; `GetTopic` fetches the chapter for the topic
- ♻️ `chapter_handler.go` refactored: `chaptersEndPoint`/`chaptersKey` constants moved to `handlerutils` (exported), and `getChapter` simplified to delegate to `handlerutils.GetChapterById`
- 🖥️ `problem.html`: shows "Chapter: CODE — Name" and "Topic: CODE — Name" between the header and the card
- 🖥️ `topic.html`: shows `CHAPTER_CODE — Chapter Name / TOPIC_CODE — Topic Name` in a single header line

## 📝 Reviewer notes
- ⚠️ Chapter/topic fetch failures are silently ignored (nil pointer) so the page still renders if lookup fails
- 🔗 `di/app_component.go` wiring updated for both handler constructors