### PR TITLE
🚀 Increase nginx client_max_body_size to 10m

### DIFF
--- a/terraform/user-data.sh
+++ b/terraform/user-data.sh
@@ -220,6 +220,7 @@ server {
         proxy_request_buffering off;
         proxy_http_version 1.1;
         proxy_intercept_errors on;
+        client_max_body_size 10m;
     }
 }
 EOF
@@ -246,6 +247,7 @@ server {
         proxy_request_buffering off;
         proxy_http_version 1.1;
         proxy_intercept_errors on;
+        client_max_body_size 10m;
     }
 }
 EOF
@@ -333,6 +335,7 @@ server {
         proxy_request_buffering off;
         proxy_http_version 1.1;
         proxy_intercept_errors on;
+        client_max_body_size 10m;
     }
 }
 EOF


### PR DESCRIPTION
## Summary
- 🔧 Adds `client_max_body_size 10m` to all three nginx proxy location blocks in `user-data.sh`
- 🌐 Covers the initial HTTPS config, HTTP-only fallback, and post-certbot HTTPS config
- 🐛 Fixes request rejections for payloads larger than nginx's default 1m limit