### PR TITLE
🐛 Fix option label vertical alignment in PDF

### DIFF
--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -104,7 +104,7 @@ window.MathJax = {
 
         <div class="grid gap-x-4 gap-y-1 {{ $gridClass }}">
             {{ range $index, $option := .Problem.MetaData.Options }}
-            <div class="flex items-center">
+            <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
                 <div class="flex-1 whitespace-pre-wrap">{{ $option }}</div>
             </div>


### PR DESCRIPTION
## Summary
- 🐛 `items-center` misaligned the label for multi-line options (centered it across all lines)
- 🐛 `items-start` misaligned the label when the first line had content taller than normal text (e.g. equations)
- ✅ Changed to `items-baseline` so the label always aligns with the baseline of the first line regardless of its content