### PR TITLE
✨ Feat: Compress images on insert in rich text editors

### DIFF
--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -1,20 +1,46 @@
+function compressImage(dataUrl, { maxDimension = 1200, quality = 0.90 } = {}) {
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.onload = function () {
+            let { width, height } = img;
+            if (width > maxDimension || height > maxDimension) {
+                if (width >= height) {
+                    height = Math.round(height * maxDimension / width);
+                    width = maxDimension;
+                } else {
+                    width = Math.round(width * maxDimension / height);
+                    height = maxDimension;
+                }
+            }
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            canvas.getContext('2d').drawImage(img, 0, 0, width, height);
+            resolve(canvas.toDataURL('image/webp', quality));
+        };
+        img.src = dataUrl;
+    });
+}
+
 function insertImage(event, editor) {
     const file = event.target.files[0];
     if (!file) return;
 
     const reader = new FileReader();
     reader.onload = function (e) {
-        const img = document.createElement('img');
-        img.src = e.target.result;
+        compressImage(e.target.result).then(compressedSrc => {
+            const img = document.createElement('img');
+            img.src = compressedSrc;
 
-        const range = window.getSelection().getRangeAt(0);
-        const block = buildFloatBlock(img, 'left', editor);
-        applyImageSize(img, 100);
+            const range = window.getSelection().getRangeAt(0);
+            const block = buildFloatBlock(img, 'left', editor);
+            applyImageSize(img, 100);
 
-        range.insertNode(block);
-        placeCaretAfterImage(img);
+            range.insertNode(block);
+            placeCaretAfterImage(img);
 
-        renderMath(editor);
+            renderMath(editor);
+        });
     };
     reader.readAsDataURL(file);
 


### PR DESCRIPTION
## Summary
- 🖼️ Images uploaded via the editor toolbar are now compressed before being inserted using an HTML canvas
- 📦 Output format: WebP at **0.90 quality**, **max 1200px** on the longest dimension (aspect ratio preserved)
- 🌐 Applies to all editors on the add/edit/copy problem page (question, options, solution, paragraph, additional problems)

## Why
🐛 Fixes a live issue where saving a problem with large images hit nginx's request body size limit, resulting in a 413 error:
`client intended to send too large body: 1194182 bytes` on `PATCH /update-problem?id=5394`

Base64-encoded images are stored directly in the DB as part of problem HTML, so large uncompressed uploads bloated the request payload beyond the nginx limit.

## Behaviour
- 🔍 Images smaller than 1200px are not resized — only re-encoded to WebP
- 📐 Images larger than 1200px are scaled down proportionally before encoding
- ✅ No change to the editing experience — compression happens transparently on insert