### PR TITLE
🐛 Section title stays on same page as first question under it in PDF

### DIFF
--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -75,7 +75,7 @@ window.MathJax = {
 {{ end }}
 
 {{ define "pdf_section_header" }}
-<div class="text-center font-semibold text-lg bg-gray-100 border-t-2 border-t-gray-500 border-b border-b-gray-300 py-1 mb-4">
+<div class="text-center font-semibold text-lg bg-gray-100 border-t-2 border-t-gray-500 border-b border-b-gray-300 py-1 mb-4" style="break-after: avoid;">
     {{ capitalize .SubjectName }} - {{ getSectionName .SectionType .SectionName }}
 </div>
 {{ end }}


### PR DESCRIPTION
## 🐛 Problem

Section titles were appearing at the bottom of a page with the first question under it starting on the next page, breaking the visual grouping.

## ✅ Fix

Added `break-after: avoid` inline style to the `pdf_section_header` div in `test_pdf_shared.html`. This tells Chrome's print engine not to insert a page break immediately after a section title, ensuring the first question always stays on the same page as its section header.

## 🧪 Testing

Verified against `11C3 - Periodic Table - Advanced - Question Paper.pdf` — section titles now stay with their first question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)