### PR TITLE
Prod release: PDF fixed font & layout fixes

### DIFF
--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -972,7 +972,9 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 		return
 	}
 	// output.css sets html/body to the app warm beige; question papers need a white page.
-	pdfPageStyle := `<style>html,body{background:#fff!important;background-color:#fff!important;min-height:auto!important}mjx-num{padding-bottom:0.1em!important}mjx-den{padding-top:0.1em!important}</style>`
+	// font/span selectors neutralise inline <font face="..."> and <span style="font-size:...">
+	// injected by rich-text editors and stored verbatim in the DB.
+	pdfPageStyle := `<style>html,body{background:#fff!important;background-color:#fff!important;min-height:auto!important}mjx-num{padding-bottom:0.1em!important}mjx-den{padding-top:0.1em!important}font,span{font-family:inherit!important;font-size:inherit!important}</style>`
 	htmlContent = strings.Replace(htmlContent, "</head>", "<style>"+string(cssBytes)+"</style>"+pdfPageStyle+"</head>", 1)
 
 	headerHTML := fmt.Sprintf(`

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -972,7 +972,7 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 		return
 	}
 	// output.css sets html/body to the app warm beige; question papers need a white page.
-	// font/span selectors neutralise inline <font face="..."> and <span style="font-size:...">
+	// font/span selectors neutralize inline <font face="..."> and <span style="font-size:...">
 	// injected by rich-text editors and stored verbatim in the DB.
 	pdfPageStyle := `<style>html,body{background:#fff!important;background-color:#fff!important;min-height:auto!important}mjx-num{padding-bottom:0.1em!important}mjx-den{padding-top:0.1em!important}font,span{font-family:inherit!important;font-size:inherit!important}</style>`
 	htmlContent = strings.Replace(htmlContent, "</head>", "<style>"+string(cssBytes)+"</style>"+pdfPageStyle+"</head>", 1)

--- a/web/html/answer_sheet.html
+++ b/web/html/answer_sheet.html
@@ -5,7 +5,7 @@
 <title>{{ getName .TestPtr "en" }}</title>
 {{ template "pdf_mathjax_head" . }}
 </head>
-<body class="font-sans text-[14px] m-5 mt-0">
+<body class="font-sans text-[14px] m-5 mt-0" style="font-family: Arial, 'Liberation Sans', sans-serif; font-size: 14px;">
     {{ template "pdf_test_header" . }}
 
     <!-- Table for Answer Sheet -->

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -6,8 +6,9 @@
 
         <!-- Toolbar with icons -->
         <div class="toolbar bg-bg-card-alt border-b border-border flex flex-wrap gap-2 p-2">
+            {{/* Font family hidden — PDF overrides all inline font styles via CSS. Remove 'hidden' to re-enable. */}}
             <select title="Font Family"
-                class="fontSelector border border-border rounded-sm px-2 py-1 text-sm cursor-pointer">
+                class="fontSelector hidden border border-border rounded-sm px-2 py-1 text-sm cursor-pointer">
                 <option value="Arial" style="font-family: Arial;">Arial</option>
                 <option value="'Courier New', monospace" style="font-family: 'Courier New', monospace;">Courier New
                 </option>
@@ -29,9 +30,10 @@
                         class="fas fa-underline"></i></button>
             </div>
 
+            {{/* Font size hidden — PDF overrides all inline font sizes via CSS. Remove 'hidden' to re-enable. */}}
             <!-- Font Size Selector -->
             <select title="Font Size"
-                class="fontSizeSelector border border-border rounded-sm px-2 py-1 text-sm cursor-pointer">
+                class="fontSizeSelector hidden border border-border rounded-sm px-2 py-1 text-sm cursor-pointer">
                 <option value="8px">8</option>
                 <option value="9px">9</option>
                 <option value="10px">10</option>

--- a/web/html/question_paper.html
+++ b/web/html/question_paper.html
@@ -5,7 +5,7 @@
 <title>{{ getName .TestPtr "en" }}</title>
 {{ template "pdf_mathjax_head" . }}
 </head>
-<body class="font-sans text-[14px] m-5 mt-0">
+<body class="font-sans text-[14px] m-5 mt-0" style="font-family: Arial, 'Liberation Sans', sans-serif; font-size: 14px;">
 
 {{ template "pdf_test_header" . }}
 {{ template "pdf_test_meta" . }}

--- a/web/html/question_paper_with_answers.html
+++ b/web/html/question_paper_with_answers.html
@@ -5,7 +5,7 @@
 <title>{{ getName .TestPtr "en" }}</title>
 {{ template "pdf_mathjax_head" . }}
 </head>
-<body class="font-sans text-[14px] m-5 mt-0">
+<body class="font-sans text-[14px] m-5 mt-0" style="font-family: Arial, 'Liberation Sans', sans-serif; font-size: 14px;">
 {{ template "pdf_test_header" . }}
 {{ template "pdf_test_meta" . }}
 

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -75,7 +75,7 @@ window.MathJax = {
 {{ end }}
 
 {{ define "pdf_section_header" }}
-<div class="text-center font-semibold text-lg bg-gray-100 border-t-2 border-t-gray-500 border-b border-b-gray-300 py-1 mb-4">
+<div class="text-center font-semibold text-lg bg-gray-100 border-t-2 border-t-gray-500 border-b border-b-gray-300 py-1 mb-4" style="break-after: avoid;">
     {{ capitalize .SubjectName }} - {{ getSectionName .SectionType .SectionName }}
 </div>
 {{ end }}

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -3,6 +3,13 @@
 window.MathJax = {
   startup: {
     pageReady: () => {
+      // Force display-style fractions in inline math so numerator/denominator
+      // render at the same size as single-line equations, not shrunk by TeX's textstyle rules.
+      MathJax.startup.document.inputJax[0].preFilters.add(({math}) => {
+        if (!math.display) {
+          math.math = '\\displaystyle{' + math.math + '}';
+        }
+      });
       return MathJax.startup.defaultPageReady().then(() => {
         document.getElementById('mathjax-done').textContent = 'true';
       });
@@ -83,7 +90,7 @@ window.MathJax = {
         </div>
     </div>
     {{ end }}
-    <div class="flex items-start mb-2">
+    <div class="flex items-baseline mb-2">
         <div class="w-6 font-semibold">Q{{ .Counter }}.</div>
         <div class="flex-1 pl-5">{{ .Problem.MetaData.Question }}</div>
     </div>


### PR DESCRIPTION
## Summary

This PR merges the latest changes from `main` into `release`.

### Included PRs

- [#162 — Fix: Enforce consistent Arial font & neutralise DB inline styles in PDFs](https://github.com/avantifellows/nex-gen-cms/pull/162)
- [#163 — Fix: Keep PDF section title on same page as first question](https://github.com/avantifellows/nex-gen-cms/pull/163)

## Changes

- Enforces consistent Arial font across all PDF output and strips inline styles from DB content that were overriding the PDF stylesheet.
- Fixes layout so that a section title is never orphaned on a page without its first question.

## Test plan

- [x] Generate a PDF with multiple sections and verify section titles stay with their first question.
- [x] Verify fonts render consistently as Arial throughout the PDF.
- [x] Spot-check existing PDF flows for regressions.