### PR TITLE
Fix topic list truncation by hardcoding limit=5000

### DIFF
--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -93,7 +93,7 @@ func getChapterName(ch models.Chapter, lang string) string {
 }
 
 func (h *ChaptersHandler) getTopics(responseWriter http.ResponseWriter, chapterPtrs []*models.Chapter) {
-	topics, err := h.topicsService.GetList(handlerutils.TopicsEndPoint, handlerutils.TopicsKey, false, false)
+	topics, err := h.topicsService.GetList(handlerutils.TopicsEndPoint+"?limit=5000", handlerutils.TopicsKey, false, false)
 	if err != nil {
 		http.Error(responseWriter, fmt.Sprintf("Error fetching topics: %v", err), http.StatusInternalServerError)
 	} else {


### PR DESCRIPTION
## 🐛 Problem
db-service caps list responses at 1000 items by default, causing topics to be silently truncated when fetched all at once.

## 🔧 Fix
Hardcode `limit=5000` on the topic list API call in `getTopics`.

## 📝 Note
This is a temporary workaround. The long-term fix will fetch topic counts per chapter, eliminating the need to load all topics in a single call.