### PR TITLE
🌐 Multilingual problem support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -153,6 +153,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.HandleFunc("/test", testsHandler.GetTest)
 	muxHandler.HandleFunc("/api/test/problems", testsHandler.GetTestProblems)
 	muxHandler.HandleFunc("/tests/download-modal", testsHandler.GetDownloadModal)
+	muxHandler.HandleFunc("/tests/copy-link-modal", testsHandler.GetCopyLinkModal)
 	muxHandler.HandleFunc("/api/test/subjectwise-problems", testsHandler.GetSubjectwiseTestProblems)
 	muxHandler.HandleFunc("/tests/add-test", editor(testsHandler.AddTest))
 	muxHandler.HandleFunc("/add-question-to-test", editor(testsHandler.AddQuestionToTest))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -152,6 +152,7 @@ func setup(configLoader ConfigLoader, muxHandler MuxHandler, appComponentPtr *di
 	muxHandler.HandleFunc("/api/search-tests", testsHandler.GetSearchTests)
 	muxHandler.HandleFunc("/test", testsHandler.GetTest)
 	muxHandler.HandleFunc("/api/test/problems", testsHandler.GetTestProblems)
+	muxHandler.HandleFunc("/tests/download-modal", testsHandler.GetDownloadModal)
 	muxHandler.HandleFunc("/api/test/subjectwise-problems", testsHandler.GetSubjectwiseTestProblems)
 	muxHandler.HandleFunc("/tests/add-test", editor(testsHandler.AddTest))
 	muxHandler.HandleFunc("/add-question-to-test", editor(testsHandler.AddQuestionToTest))

--- a/internal/dto/paper_dto.go
+++ b/internal/dto/paper_dto.go
@@ -9,7 +9,10 @@ type PaperData struct {
 	RegionalLangCode string
 }
 
-type DownloadModalData struct {
-	RegionalLangs   map[string]bool
-	BaseDownloadURL string
+type LangModalData struct {
+	RegionalLangs map[string]bool
+	BaseURL       string
+	Title         string
+	ConfirmLabel  string
+	Action        string // "download" | "copy"
 }

--- a/internal/dto/paper_dto.go
+++ b/internal/dto/paper_dto.go
@@ -3,7 +3,13 @@ package dto
 import "github.com/avantifellows/nex-gen-cms/internal/models"
 
 type PaperData struct {
-	TestPtr     *models.Test
-	ProblemsMap map[int]*models.Problem
-	TestRule    *models.TestRule
+	TestPtr          *models.Test
+	ProblemsMap      map[int]*models.Problem
+	TestRule         *models.TestRule
+	RegionalLangCode string
+}
+
+type DownloadModalData struct {
+	RegionalLangs   map[string]bool
+	BaseDownloadURL string
 }

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -23,7 +23,7 @@ import (
 const problemsKey = "problems"
 
 const problemsEndPoint = "problems"
-const problemEndPoint = "resource/problem/%d/en/%s"
+const problemEndPoint = "resource/problem/%d/%s"
 const searchProblemsEndPoint = "problems/search"
 const testsContainingProblemsEndPoint = "resources/tests-containing-problems"
 const batchProblemsEndPoint = "resources/problems/batch"
@@ -164,7 +164,7 @@ func (h *ProblemsHandler) GetTopicProblems(responseWriter http.ResponseWriter, r
 		return
 	}
 
-	queryParams := fmt.Sprintf("?"+QUERY_PARAM_CURRICULUM_ID+"=%s&topic_id=%d&lang_code=en", urlValues.Get(CURRICULUM_DROPDOWN_NAME), topicId)
+	queryParams := fmt.Sprintf("?"+QUERY_PARAM_CURRICULUM_ID+"=%s&topic_id=%d", urlValues.Get(CURRICULUM_DROPDOWN_NAME), topicId)
 	if urlValues.Has(includeParagraphSiblingsParam) {
 		queryParams += "&" + includeParagraphSiblingsParam + "=" + urlValues.Get(includeParagraphSiblingsParam)
 	}
@@ -415,7 +415,7 @@ func (h *ProblemsHandler) GetSearchProblems(responseWriter http.ResponseWriter, 
 
 	limit := utils.StringToIntOrDefault(urlVals.Get("limit"), 10, 1)  // min = 1
 	offset := utils.StringToIntOrDefault(urlVals.Get("offset"), 0, 0) // min = 0
-	queryParams := "?lang_code=en&search=" + url.QueryEscape(search) + "&limit=" + strconv.Itoa(limit) + "&offset=" + strconv.Itoa(offset)
+	queryParams := "?search=" + url.QueryEscape(search) + "&limit=" + strconv.Itoa(limit) + "&offset=" + strconv.Itoa(offset)
 
 	subjectId := utils.StringToInt(urlVals.Get("problems-subject-dropdown"))
 	if subjectId != 0 {

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -95,6 +95,7 @@ func (h *ProblemsHandler) GetProblem(responseWriter http.ResponseWriter, request
 		"stringToInt": utils.StringToInt,
 		"seq":         utils.Seq,
 		"getName":     getConceptName,
+		"langName":    utils.LangName,
 	}, baseTemplate, problemTemplate)
 }
 

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -61,7 +61,7 @@ const questionPaperWithAnswersTemplate = "question_paper_with_answers.html"
 const answerSolutionSheetTemplate = "answer_sheet.html"
 const pdfSharedTemplate = "test_pdf_shared.html"
 
-const testProblemsEndPoint = "resource/test/%d/problems?lang_code=en&" + QUERY_PARAM_CURRICULUM_ID + "=%s"
+const testProblemsEndPoint = "resource/test/%d/problems?" + QUERY_PARAM_CURRICULUM_ID + "=%s"
 const testRulesEndPoint = "test-rule"
 
 const testsKey = "tests"

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -480,6 +480,13 @@ func (h *TestsHandler) GetDownloadModal(responseWriter http.ResponseWriter, requ
 			}
 		}
 	}
+	if len(regionalLangs) == 0 {
+		urlVals := request.URL.Query()
+		downloadURL := fmt.Sprintf("/download-pdf?id=%s&curriculum_id=%s&grade_id=%s&type=%s",
+			urlVals.Get("id"), urlVals.Get(QUERY_PARAM_CURRICULUM_ID), urlVals.Get("grade_id"), urlVals.Get("type"))
+		fmt.Fprintf(responseWriter, `<script>window.open('%s', '_blank');</script>`, downloadURL)
+		return
+	}
 	views.ExecuteTemplate(testDownloadModalTemplate, responseWriter, regionalLangs, template.FuncMap{
 		"langName": utils.LangName,
 	})

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -996,17 +996,19 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 		"trim":           strings.TrimSpace,
 		"isEmptyHTML":    utils.IsEmptyHTML,
 		"getChapterName": getProblemChapterName,
+		"langName":       utils.LangName,
 	}).ParseFiles(sharedTmplPath, tmplPath)
 	if err != nil {
 		http.Error(responseWriter, "Template parsing error: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+	regionalLangCode := urlVals.Get("lang_code")
 	data := dto.PaperData{
 		TestPtr:          selectedTestPtr,
 		ProblemsMap:      problemsMap,
 		TestRule:         testRule,
-		RegionalLangCode: urlVals.Get("lang_code"),
+		RegionalLangCode: regionalLangCode,
 	}
 
 	// Render HTML to buffer
@@ -1078,8 +1080,11 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 
 	// Send as response
 	responseWriter.Header().Set("Content-Type", "application/pdf")
-	responseWriter.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s - %s.pdf"`,
-		selectedTestPtr.GetNameByLang("en"), pdfSuffix))
+	filename := fmt.Sprintf(`"%s - %s.pdf"`, selectedTestPtr.GetNameByLang("en"), pdfSuffix)
+	if regionalLangCode != "" {
+		filename = fmt.Sprintf(`"%s - %s - %s.pdf"`, selectedTestPtr.GetNameByLang("en"), pdfSuffix, utils.LangName(regionalLangCode))
+	}
+	responseWriter.Header().Set("Content-Disposition", "attachment; filename="+filename)
 	_, _ = responseWriter.Write(pdfData)
 }
 

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -480,14 +480,17 @@ func (h *TestsHandler) GetDownloadModal(responseWriter http.ResponseWriter, requ
 			}
 		}
 	}
+	urlVals := request.URL.Query()
+	baseURL := fmt.Sprintf("/download-pdf?id=%s&curriculum_id=%s&grade_id=%s&type=%s",
+		urlVals.Get("id"), urlVals.Get(QUERY_PARAM_CURRICULUM_ID), urlVals.Get("grade_id"), urlVals.Get("type"))
 	if len(regionalLangs) == 0 {
-		urlVals := request.URL.Query()
-		downloadURL := fmt.Sprintf("/download-pdf?id=%s&curriculum_id=%s&grade_id=%s&type=%s",
-			urlVals.Get("id"), urlVals.Get(QUERY_PARAM_CURRICULUM_ID), urlVals.Get("grade_id"), urlVals.Get("type"))
-		fmt.Fprintf(responseWriter, `<script>window.open('%s', '_blank');</script>`, downloadURL)
+		fmt.Fprintf(responseWriter, `<script>window.open('%s', '_blank');</script>`, baseURL)
 		return
 	}
-	views.ExecuteTemplate(testDownloadModalTemplate, responseWriter, regionalLangs, template.FuncMap{
+	views.ExecuteTemplate(testDownloadModalTemplate, responseWriter, dto.DownloadModalData{
+		RegionalLangs:   regionalLangs,
+		BaseDownloadURL: baseURL,
+	}, template.FuncMap{
 		"langName": utils.LangName,
 	})
 }
@@ -951,7 +954,8 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 		problemsMap[p.ID] = p
 	}
 
-	pdfType := request.URL.Query().Get("type") // "questions", "questions_with_answers", or "answers"
+	urlVals := request.URL.Query()
+	pdfType := urlVals.Get("type") // "questions", "questions_with_answers", or "answers"
 
 	pdfTemplate, headerTxt, pdfSuffix, testRule := h.resolvePdfParams(selectedTestPtr, pdfType)
 
@@ -981,9 +985,10 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 	}
 
 	data := dto.PaperData{
-		TestPtr:     selectedTestPtr,
-		ProblemsMap: problemsMap,
-		TestRule:    testRule,
+		TestPtr:          selectedTestPtr,
+		ProblemsMap:      problemsMap,
+		TestRule:         testRule,
+		RegionalLangCode: urlVals.Get("lang_code"),
 	}
 
 	// Render HTML to buffer

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -364,6 +364,13 @@ func (h *TestsHandler) GetTest(responseWriter http.ResponseWriter, request *http
 		return
 	}
 
+	// curriculum_id/grade_id are no longer passed in the /test URL, so the test's own
+	// curriculum-grade association is the only source; a test without one can't be rendered
+	if len(selectedTestPtr.CurriculumGrades) == 0 {
+		http.Error(responseWriter, "test has no curriculum/grade association", http.StatusUnprocessableEntity)
+		return
+	}
+
 	data := dto.TestData{
 		HomeData: dto.HomeData{
 			CurriculumID: selectedTestPtr.CurriculumGrades[0].CurriculumID,
@@ -475,9 +482,7 @@ func (h *TestsHandler) GetDownloadModal(responseWriter http.ResponseWriter, requ
 }
 
 func (h *TestsHandler) GetCopyLinkModal(responseWriter http.ResponseWriter, request *http.Request) {
-	urlVals := request.URL.Query()
-	baseURL := fmt.Sprintf("/test?id=%s&curriculum_id=%s&grade_id=%s",
-		urlVals.Get("id"), urlVals.Get(QUERY_PARAM_CURRICULUM_ID), urlVals.Get("grade_id"))
+	baseURL := fmt.Sprintf("/test?id=%s", request.URL.Query().Get("id"))
 	h.renderLangModal(responseWriter, request, baseURL, "Copy Link", "Copy", "copy")
 }
 

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -40,7 +40,7 @@ const testSearchRowTemplate = "test_search_row.html"
 const addTestSearchRowTemplate = "add_test_search_row.html"
 const testTemplate = "test.html"
 const testProblemRowTemplate = "test_problem_row.html"
-const testDownloadModalTemplate = "test_download_modal.html"
+const testLangModalTemplate = "test_lang_modal.html"
 const addTestTemplate = "add_test.html"
 const testTypeOptionsTemplate = "test_type_options.html"
 const testChipEditorTemplate = "test_chip_editor.html"
@@ -468,6 +468,20 @@ func (h *TestsHandler) fillSubjectNames(responseWriter http.ResponseWriter, test
 }
 
 func (h *TestsHandler) GetDownloadModal(responseWriter http.ResponseWriter, request *http.Request) {
+	urlVals := request.URL.Query()
+	baseURL := fmt.Sprintf("/download-pdf?id=%s&curriculum_id=%s&grade_id=%s&type=%s",
+		urlVals.Get("id"), urlVals.Get(QUERY_PARAM_CURRICULUM_ID), urlVals.Get("grade_id"), urlVals.Get("type"))
+	h.renderLangModal(responseWriter, request, baseURL, "Download PDF", "Download", "download")
+}
+
+func (h *TestsHandler) GetCopyLinkModal(responseWriter http.ResponseWriter, request *http.Request) {
+	urlVals := request.URL.Query()
+	baseURL := fmt.Sprintf("/test?id=%s&curriculum_id=%s&grade_id=%s",
+		urlVals.Get("id"), urlVals.Get(QUERY_PARAM_CURRICULUM_ID), urlVals.Get("grade_id"))
+	h.renderLangModal(responseWriter, request, baseURL, "Copy Link", "Copy", "copy")
+}
+
+func (h *TestsHandler) renderLangModal(responseWriter http.ResponseWriter, request *http.Request, baseURL, title, confirmLabel, action string) {
 	problems := h.getTestProblems(responseWriter, request)
 	if problems == nil {
 		return
@@ -480,16 +494,20 @@ func (h *TestsHandler) GetDownloadModal(responseWriter http.ResponseWriter, requ
 			}
 		}
 	}
-	urlVals := request.URL.Query()
-	baseURL := fmt.Sprintf("/download-pdf?id=%s&curriculum_id=%s&grade_id=%s&type=%s",
-		urlVals.Get("id"), urlVals.Get(QUERY_PARAM_CURRICULUM_ID), urlVals.Get("grade_id"), urlVals.Get("type"))
 	if len(regionalLangs) == 0 {
-		fmt.Fprintf(responseWriter, `<script>window.open('%s', '_blank');</script>`, baseURL)
+		if action == "download" {
+			fmt.Fprintf(responseWriter, `<script>window.open('%s', '_blank');</script>`, baseURL)
+		} else {
+			fmt.Fprintf(responseWriter, `<script>copyToClipboard(window.location.origin+'%s');document.getElementById('download-modal-container').innerHTML='';</script>`, baseURL)
+		}
 		return
 	}
-	views.ExecuteTemplate(testDownloadModalTemplate, responseWriter, dto.DownloadModalData{
-		RegionalLangs:   regionalLangs,
-		BaseDownloadURL: baseURL,
+	views.ExecuteTemplate(testLangModalTemplate, responseWriter, dto.LangModalData{
+		RegionalLangs: regionalLangs,
+		BaseURL:       baseURL,
+		Title:         title,
+		ConfirmLabel:  confirmLabel,
+		Action:        action,
 	}, template.FuncMap{
 		"langName": utils.LangName,
 	})

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -371,7 +371,10 @@ func (h *TestsHandler) GetTest(responseWriter http.ResponseWriter, request *http
 		TestPtr: selectedTestPtr,
 	}
 
-	views.ExecuteTemplates(responseWriter, data, nil, baseTemplate, testTemplate)
+	views.ExecuteTemplates(responseWriter, data, template.FuncMap{
+		"langName":  utils.LangName,
+		"langCodes": utils.LangCodes,
+	}, baseTemplate, testTemplate)
 }
 
 func (h *TestsHandler) GetSubjectwiseTestProblems(responseWriter http.ResponseWriter, request *http.Request) {

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -40,6 +40,7 @@ const testSearchRowTemplate = "test_search_row.html"
 const addTestSearchRowTemplate = "add_test_search_row.html"
 const testTemplate = "test.html"
 const testProblemRowTemplate = "test_problem_row.html"
+const testDownloadModalTemplate = "test_download_modal.html"
 const addTestTemplate = "add_test.html"
 const testTypeOptionsTemplate = "test_type_options.html"
 const testChipEditorTemplate = "test_chip_editor.html"
@@ -464,6 +465,24 @@ func (h *TestsHandler) fillSubjectNames(responseWriter http.ResponseWriter, test
 			testPtr.TypeParams.Subjects[i].Name = subjectIdToNameMap[testSubject.SubjectID]
 		}
 	}
+}
+
+func (h *TestsHandler) GetDownloadModal(responseWriter http.ResponseWriter, request *http.Request) {
+	problems := h.getTestProblems(responseWriter, request)
+	if problems == nil {
+		return
+	}
+	regionalLangs := map[string]bool{}
+	for _, p := range *problems {
+		for _, lv := range p.LangVersions {
+			if lv.LangCode != "en" {
+				regionalLangs[lv.LangCode] = true
+			}
+		}
+	}
+	views.ExecuteTemplate(testDownloadModalTemplate, responseWriter, regionalLangs, template.FuncMap{
+		"langName": utils.LangName,
+	})
 }
 
 func (h *TestsHandler) GetTestProblems(responseWriter http.ResponseWriter, request *http.Request) {

--- a/internal/models/problem.go
+++ b/internal/models/problem.go
@@ -10,6 +10,7 @@ type Problem struct {
 	Paragraph       *ProblemParagraph `json:"paragraph,omitempty"`
 	TypeParams      ProbTypeParams    `json:"type_params"`
 	MetaData        ProbMetaData      `json:"meta_data"`
+	LangVersions    []LangVersion     `json:"lang_versions"`
 	SkillIDs        []int16           `json:"skill_ids"`
 	Skills          []Skill
 	CurriculumID    int16 `json:"curriculum_id"` // used with only get call
@@ -24,6 +25,11 @@ type Problem struct {
 	TagIDs          []int         `json:"tag_ids"`
 	TagNames        []string
 	StatusID        int8 `json:"cms_status_id"`
+}
+
+type LangVersion struct {
+	LangCode string       `json:"lang_code"`
+	MetaData ProbMetaData `json:"meta_data"`
 }
 
 type ProbTypeParams struct {

--- a/internal/models/problem.go
+++ b/internal/models/problem.go
@@ -53,6 +53,15 @@ type ProblemParagraph struct {
 	Body template.HTML `json:"body"`
 }
 
+func (p *Problem) GetLangVersion(langCode string) *LangVersion {
+	for i := range p.LangVersions {
+		if p.LangVersions[i].LangCode == langCode {
+			return &p.LangVersions[i]
+		}
+	}
+	return nil
+}
+
 func (p Problem) DisplayDifficulty() int8 {
 	switch p.DifficultyLevel {
 	case "hard":

--- a/utils/lang_util.go
+++ b/utils/lang_util.go
@@ -1,0 +1,15 @@
+package utils
+
+var langNames = map[string]string{
+	"en": "English",
+	"hi": "Hindi",
+	"gu": "Gujarati",
+	"ta": "Tamil",
+}
+
+func LangName(code string) string {
+	if name, ok := langNames[code]; ok {
+		return name
+	}
+	return code
+}

--- a/utils/lang_util.go
+++ b/utils/lang_util.go
@@ -1,5 +1,10 @@
 package utils
 
+import (
+	"maps"
+	"slices"
+)
+
 var langNames = map[string]string{
 	"en": "English",
 	"hi": "Hindi",
@@ -12,4 +17,8 @@ func LangName(code string) string {
 		return name
 	}
 	return code
+}
+
+func LangCodes() []string {
+	return slices.Collect(maps.Keys(langNames))
 }

--- a/utils/lang_util.go
+++ b/utils/lang_util.go
@@ -1,9 +1,9 @@
 package utils
 
-import (
-	"maps"
-	"slices"
-)
+// langCodes is the source of truth for both the supported language codes
+// and the order they should be displayed in — map iteration order in Go is
+// randomized, so it can't be relied on for a stable UI order.
+var langCodes = []string{"en", "hi", "gu", "ta"}
 
 var langNames = map[string]string{
 	"en": "English",
@@ -20,5 +20,5 @@ func LangName(code string) string {
 }
 
 func LangCodes() []string {
-	return slices.Collect(maps.Keys(langNames))
+	return langCodes
 }

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -355,6 +355,9 @@
                 btn.dataset.lang = code;
                 btn.addEventListener('click', () => {
                     if (code === activeLang) return;
+                    if (code !== 'en' && !enabledLangs.has(code)) {
+                        enabledLangs.add(code);
+                    }
                     activeLang = code;
                     switchLangEditors(code);
                     renderLangTabs();
@@ -373,6 +376,8 @@
                         e.stopPropagation();
                         if (checkbox.checked) {
                             enabledLangs.add(code);
+                            activeLang = code;
+                            switchLangEditors(code);
                         } else {
                             enabledLangs.delete(code);
                             // Switch back to English if this tab was active
@@ -387,9 +392,7 @@
                     btn.appendChild(document.createTextNode(label));
 
                     if (!isEnabled) {
-                        btn.style.pointerEvents = 'none';
                         btn.style.opacity = '0.5';
-                        checkbox.style.pointerEvents = 'auto';
                     }
                 }
 

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -85,6 +85,11 @@
         </div>
     </div>
 
+    <!-- Language Tabs -->
+    <div class="mb-1">
+        <div class="nav nav-tabs" id="langTabs"></div>
+    </div>
+
     <!-- Question editor -->
     <div id="questionDiv" class="mb-6">
         <p class="form-label mb-2">Text</p>
@@ -290,6 +295,37 @@
 
         const mainTagsRoot = document.querySelector('#main-problem-tags .problem-tags-section');
         initProblemTagsSection(mainTagsRoot);
+
+        // --- Language tabs ---
+        const SUPPORTED_LANGUAGES = [
+            { code: 'en', label: 'English' },
+            { code: 'hi', label: 'Hindi' },
+            { code: 'gu', label: 'Gujarati' },
+            { code: 'ta', label: 'Tamil' },
+        ];
+        let activeLang = 'en';
+
+        const langTabsEl = document.getElementById('langTabs');
+
+        function renderLangTabs() {
+            langTabsEl.innerHTML = '';
+            SUPPORTED_LANGUAGES.forEach(({ code, label }) => {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'nav-link' + (code === activeLang ? ' active' : '');
+                btn.dataset.lang = code;
+                btn.textContent = label + (code === 'en' ? ' *' : '');
+                btn.addEventListener('click', () => {
+                    if (code === activeLang) return;
+                    activeLang = code;
+                    renderLangTabs();
+                });
+                langTabsEl.appendChild(btn);
+            });
+        }
+
+        renderLangTabs();
+        // --- End language tabs ---
 
         let skillsOptionsHtml = '';
         let topicsOptionsHtml = '';

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -2,6 +2,16 @@
 {{ $isCopy := and .TopicPtr .ProblemPtr }}
 {{ $isEdit := and .ProblemPtr (not $isCopy) }}
 {{ $prefill := or $isEdit $isCopy }}
+{{ $enLang := false }}
+{{ $hiLang := false }}
+{{ $guLang := false }}
+{{ $taLang := false }}
+{{ if $prefill }}
+    {{ $enLang = .ProblemPtr.GetLangVersion "en" }}
+    {{ $hiLang = .ProblemPtr.GetLangVersion "hi" }}
+    {{ $guLang = .ProblemPtr.GetLangVersion "gu" }}
+    {{ $taLang = .ProblemPtr.GetLangVersion "ta" }}
+{{ end }}
 <form class="card card-pad w-full" onsubmit="createProblem(event,
         {{if .TopicPtr}}
         <!-- add or copy problem -->
@@ -94,15 +104,17 @@
     <div id="questionDiv" class="mb-6">
         <p class="form-label mb-2">Text</p>
         <div class="lang-content" data-lang="en">
-            {{ if $prefill }}
-            {{ template "editor" .ProblemPtr.MetaData.Question }}
-            {{ else }}
-            {{ template "editor" }}
-            {{ end }}
+            {{ if $prefill }}{{ with $enLang }}{{ template "editor" .MetaData.Question }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}
         </div>
-        <div class="lang-content hidden" data-lang="hi">{{ template "editor" }}</div>
-        <div class="lang-content hidden" data-lang="gu">{{ template "editor" }}</div>
-        <div class="lang-content hidden" data-lang="ta">{{ template "editor" }}</div>
+        <div class="lang-content hidden" data-lang="hi">
+            {{ if $prefill }}{{ with $hiLang }}{{ template "editor" .MetaData.Question }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}
+        </div>
+        <div class="lang-content hidden" data-lang="gu">
+            {{ if $prefill }}{{ with $guLang }}{{ template "editor" .MetaData.Question }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}
+        </div>
+        <div class="lang-content hidden" data-lang="ta">
+            {{ if $prefill }}{{ with $taLang }}{{ template "editor" .MetaData.Question }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}
+        </div>
     </div>
 
     <!-- Options -->
@@ -133,15 +145,17 @@
     <div class="mb-6" id="solutionDiv">
         <p class="form-label mb-2">Solution</p>
         <div class="lang-content" data-lang="en">
-            {{ if and $prefill (gt (len .ProblemPtr.MetaData.Solutions) 0) }}
-            {{ template "editor" (index .ProblemPtr.MetaData.Solutions 0).Value }}
-            {{ else }}
-            {{ template "editor" }}
-            {{ end }}
+            {{ if $prefill }}{{ with $enLang }}{{ with .MetaData.Solutions }}{{ template "editor" (index . 0).Value }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}
         </div>
-        <div class="lang-content hidden" data-lang="hi">{{ template "editor" }}</div>
-        <div class="lang-content hidden" data-lang="gu">{{ template "editor" }}</div>
-        <div class="lang-content hidden" data-lang="ta">{{ template "editor" }}</div>
+        <div class="lang-content hidden" data-lang="hi">
+            {{ if $prefill }}{{ with $hiLang }}{{ with .MetaData.Solutions }}{{ template "editor" (index . 0).Value }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}
+        </div>
+        <div class="lang-content hidden" data-lang="gu">
+            {{ if $prefill }}{{ with $guLang }}{{ with .MetaData.Solutions }}{{ template "editor" (index . 0).Value }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}
+        </div>
+        <div class="lang-content hidden" data-lang="ta">
+            {{ if $prefill }}{{ with $taLang }}{{ with .MetaData.Solutions }}{{ template "editor" (index . 0).Value }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}{{ else }}{{ template "editor" }}{{ end }}
+        </div>
     </div>
 
     <!-- Tags -->
@@ -272,9 +286,7 @@
 
 <template id="tmplAnsNumeric">
     {{ $meta := (dict "Answers" nil) }}
-    {{ if $prefill }}
-        {{ $meta = .ProblemPtr.MetaData }}
-    {{ end }}
+    {{ if $prefill }}{{ with $enLang }}{{ $meta = .MetaData }}{{ end }}{{ end }}
 
     {{ template "problem_answer_numerical" $meta }}
 </template>
@@ -314,7 +326,13 @@
             { code: 'ta', label: 'Tamil' },
         ];
         let activeLang = 'en';
-        const enabledLangs = new Set(['en']);
+        const enabledLangs = new Set(['en'
+            {{ if $prefill }}
+                {{ range .ProblemPtr.LangVersions }}
+                    {{ if ne .LangCode "en" }}, '{{ .LangCode }}'{{ end }}
+                {{ end }}
+            {{ end }}
+        ]);
 
         const langTabsEl = document.getElementById('langTabs');
         const initializedLangs = new Set(['en']); // en is initialized by bootRichTextEditors
@@ -416,22 +434,14 @@
         // keep 4 tabs so that while editing such problem if type is changed to mcq
         // then 4 option tabs will be visible by default
         let tabs = new Array(
-            {{ if and $prefill (gt (len .ProblemPtr.MetaData.Options) 0) }}
-                {{ len .ProblemPtr.MetaData.Options }}
-            {{ else }}
-                4
-            {{ end }}
+            {{ if $prefill }}{{ with $enLang }}{{ if gt (len .MetaData.Options) 0 }}{{ len .MetaData.Options }}{{ else }}4{{ end }}{{ else }}4{{ end }}{{ else }}4{{ end }}
         ).fill(null);
 
         let activeIndex = 0;
 
         const answerLabels = new Set([
             {{ if and $prefill (or (eq .ProblemPtr.Subtype "mcq_single_answer") (eq .ProblemPtr.Subtype "matrix_match") (eq .ProblemPtr.Subtype "mcq_multiple_answer")) }}
-                {{ range .ProblemPtr.MetaData.Answers }}
-                    {{ if . }}
-                        '{{ printf "%c" (add 64 (stringToInt .)) }}',
-                    {{ end }}
-                {{ end }}
+                {{ with $enLang }}{{ range .MetaData.Answers }}{{ if . }}'{{ printf "%c" (add 64 (stringToInt .)) }}',{{ end }}{{ end }}{{ end }}
             {{ end }}
         ]); // <=== tracks checked answer labels
 
@@ -631,12 +641,7 @@
 
             } else {
                 // Integer type fallback (simple input)
-                let answer = 
-                    {{ if $prefill }}
-                        '{{ index .ProblemPtr.MetaData.Answers 0 }}'
-                    {{ else }}
-                        ''
-                    {{ end }}; 
+                let answer = {{ if $prefill }}{{ with $enLang }}{{ if gt (len .MetaData.Answers) 0 }}'{{ index .MetaData.Answers 0 }}'{{ else }}''{{ end }}{{ else }}''{{ end }}{{ else }}''{{ end }};
 
                 // if problem type is changed from numerical to integer for edit problem case, 
                 // where answer already contains decimal point
@@ -733,16 +738,23 @@
         SUPPORTED_LANGUAGES.forEach(({ code }) => {
             tabContentByLang[code] = code === 'en'
                 ? [
-                    {{ if $prefill }}
-                        {{ range .ProblemPtr.MetaData.Options }}
-                            { html: `{{ . }}`, preview: `{{ . }}` },
-                        {{ end }}
+                    {{ if $prefill }}{{ with $enLang }}
+                        {{ range .MetaData.Options }}{ html: `{{ . }}`, preview: `{{ . }}` },{{ end }}
                     {{ else }}
+                        ...Array.from({ length: 4 }, () => ({ html: '', preview: '' }))
+                    {{ end }}{{ else }}
                         ...Array.from({ length: 4 }, () => ({ html: '', preview: '' }))
                     {{ end }}
                   ]
                 : Array.from({ length: tabs.length }, () => ({ html: '', preview: '' }));
         });
+        {{ if $prefill }}
+        {{ range .ProblemPtr.LangVersions }}{{ if ne .LangCode "en" }}
+        tabContentByLang['{{ .LangCode }}'] = [
+            {{ range .MetaData.Options }}{ html: `{{ . }}`, preview: `{{ . }}` },{{ end }}
+        ].concat(Array.from({ length: Math.max(0, tabs.length - {{ len .MetaData.Options }}) }, () => ({ html: '', preview: '' })));
+        {{ end }}{{ end }}
+        {{ end }}
         let tabContent = tabContentByLang['en'];
 
         // Initial rendering of options & answers for mcq & matrix match only

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -314,6 +314,7 @@
             { code: 'ta', label: 'Tamil' },
         ];
         let activeLang = 'en';
+        const enabledLangs = new Set(['en']);
 
         const langTabsEl = document.getElementById('langTabs');
         const initializedLangs = new Set(['en']); // en is initialized by bootRichTextEditors
@@ -352,13 +353,30 @@
                 btn.type = 'button';
                 btn.className = 'nav-link' + (code === activeLang ? ' active' : '');
                 btn.dataset.lang = code;
-                btn.textContent = label + (code === 'en' ? ' *' : '');
                 btn.addEventListener('click', () => {
                     if (code === activeLang) return;
                     activeLang = code;
                     switchLangEditors(code);
                     renderLangTabs();
                 });
+
+                if (code === 'en') {
+                    btn.textContent = label + ' *';
+                } else {
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.checked = enabledLangs.has(code);
+                    checkbox.title = `Include ${label}`;
+                    checkbox.style.marginRight = '6px';
+                    checkbox.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        if (checkbox.checked) enabledLangs.add(code);
+                        else enabledLangs.delete(code);
+                    });
+                    btn.appendChild(checkbox);
+                    btn.appendChild(document.createTextNode(label));
+                }
+
                 langTabsEl.appendChild(btn);
             });
         }
@@ -817,7 +835,7 @@
             saveCurrentContent(); // Save current tab before adding new
 
             tabs.push(null);
-            tabContent.push({ html: '', preview: '' });
+            Object.values(tabContentByLang).forEach(arr => arr.push({ html: '', preview: '' }));
             activeIndex = tabs.length - 1;
 
             renderTabs();
@@ -832,7 +850,7 @@
             }
 
             tabs.splice(index, 1);
-            tabContent.splice(index, 1);
+            Object.values(tabContentByLang).forEach(arr => arr.splice(index, 1));
 
             const removedLabel = getLabel(index); // label like 'A', 'B'
             // Also remove this label from answerLabels set
@@ -1150,14 +1168,14 @@
         }
 
         // Returns lang_versions for the main (non-comprehension) problem.
-        // Skips non-English languages whose question editor is empty.
+        // Only includes languages the user has enabled via the language tab checkboxes.
         function getLangVersionsForMain(subtype) {
             const isMCQ = subtype === 'mcq_single_answer' || subtype === 'matrix_match' || subtype === 'mcq_multiple_answer';
             const versions = [];
             SUPPORTED_LANGUAGES.forEach(({ code }) => {
+                if (!enabledLangs.has(code)) return;
                 const questionEl = document.querySelector(`#questionDiv .lang-content[data-lang="${code}"] .editor`);
                 const question = questionEl ? getEditorHtml(questionEl) : '';
-                if (code !== 'en' && !question.trim()) return;
                 const solutionEl = document.querySelector(`#solutionDiv .lang-content[data-lang="${code}"] .editor`);
                 const solution = solutionEl ? getEditorHtml(solutionEl) : '';
                 const options = isMCQ ? tabContentByLang[code].map(item => item.html) : null;

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -93,11 +93,16 @@
     <!-- Question editor -->
     <div id="questionDiv" class="mb-6">
         <p class="form-label mb-2">Text</p>
-        {{ if $prefill }}
-        {{ template "editor" .ProblemPtr.MetaData.Question }}
-        {{ else }}
-        {{ template "editor" }}
-        {{ end }}
+        <div class="lang-content" data-lang="en">
+            {{ if $prefill }}
+            {{ template "editor" .ProblemPtr.MetaData.Question }}
+            {{ else }}
+            {{ template "editor" }}
+            {{ end }}
+        </div>
+        <div class="lang-content hidden" data-lang="hi">{{ template "editor" }}</div>
+        <div class="lang-content hidden" data-lang="gu">{{ template "editor" }}</div>
+        <div class="lang-content hidden" data-lang="ta">{{ template "editor" }}</div>
     </div>
 
     <!-- Options -->
@@ -127,11 +132,16 @@
     <!-- Solution -->
     <div class="mb-6" id="solutionDiv">
         <p class="form-label mb-2">Solution</p>
-        {{ if and $prefill (gt (len .ProblemPtr.MetaData.Solutions) 0) }}
-        {{ template "editor" (index .ProblemPtr.MetaData.Solutions 0).Value }}
-        {{ else }}
-        {{ template "editor" }}
-        {{ end }}
+        <div class="lang-content" data-lang="en">
+            {{ if and $prefill (gt (len .ProblemPtr.MetaData.Solutions) 0) }}
+            {{ template "editor" (index .ProblemPtr.MetaData.Solutions 0).Value }}
+            {{ else }}
+            {{ template "editor" }}
+            {{ end }}
+        </div>
+        <div class="lang-content hidden" data-lang="hi">{{ template "editor" }}</div>
+        <div class="lang-content hidden" data-lang="gu">{{ template "editor" }}</div>
+        <div class="lang-content hidden" data-lang="ta">{{ template "editor" }}</div>
     </div>
 
     <!-- Tags -->
@@ -306,6 +316,34 @@
         let activeLang = 'en';
 
         const langTabsEl = document.getElementById('langTabs');
+        const initializedLangs = new Set(['en']); // en is initialized by bootRichTextEditors
+
+        function switchLangEditors(langCode) {
+            // Save MCQ options for the current language before switching
+            saveCurrentContent();
+            tabContent = tabContentByLang[langCode];
+
+            // Show/hide question and solution editors
+            ['questionDiv', 'solutionDiv'].forEach(divId => {
+                const div = document.getElementById(divId);
+                if (!div) return;
+                div.querySelectorAll('.lang-content').forEach(el => {
+                    el.classList.toggle('hidden', el.dataset.lang !== langCode);
+                });
+            });
+
+            // Lazily initialize question/solution editors on first switch to this language
+            if (!initializedLangs.has(langCode) && window.initializeRichTextEditors) {
+                ['questionDiv', 'solutionDiv'].forEach(divId => {
+                    const container = document.querySelector(`#${divId} .lang-content[data-lang="${langCode}"]`);
+                    if (container) window.initializeRichTextEditors(container);
+                });
+                initializedLangs.add(langCode);
+            }
+
+            // Reload the active MCQ tab's content for the new language
+            loadActiveContent();
+        }
 
         function renderLangTabs() {
             langTabsEl.innerHTML = '';
@@ -318,6 +356,7 @@
                 btn.addEventListener('click', () => {
                     if (code === activeLang) return;
                     activeLang = code;
+                    switchLangEditors(code);
                     renderLangTabs();
                 });
                 langTabsEl.appendChild(btn);
@@ -652,17 +691,22 @@
         const editor = optionsDiv.querySelector('.editor');
         const preview = optionsDiv.querySelector('.output');
 
-        // Initial setup
-        const tabContent = [
-            {{ if $prefill }}
-                {{ range .ProblemPtr.MetaData.Options }}
-                    { html: `{{ . }}`, preview: `{{ . }}` },
-                {{ end }}
-            {{ else }}
-                // Default empty tabs
-                ...Array.from({ length: 4 }, () => ({ html: '', preview: '' }))
-            {{ end }}
-        ];
+        // Per-language MCQ option content
+        const tabContentByLang = {};
+        SUPPORTED_LANGUAGES.forEach(({ code }) => {
+            tabContentByLang[code] = code === 'en'
+                ? [
+                    {{ if $prefill }}
+                        {{ range .ProblemPtr.MetaData.Options }}
+                            { html: `{{ . }}`, preview: `{{ . }}` },
+                        {{ end }}
+                    {{ else }}
+                        ...Array.from({ length: 4 }, () => ({ html: '', preview: '' }))
+                    {{ end }}
+                  ]
+                : Array.from({ length: tabs.length }, () => ({ html: '', preview: '' }));
+        });
+        let tabContent = tabContentByLang['en'];
 
         // Initial rendering of options & answers for mcq & matrix match only
         function bootMcqTabsIfNeeded() {

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -1142,13 +1142,28 @@
                 topicId,
                 chapterId,
                 difficulty,
-                question,
-                options: null,
+                langVersions: [{ lang_code: 'en', question, options: null, solution }],
                 answers,
-                solution,
                 conceptIds: selectedConceptIds,
                 tags,
             });
+        }
+
+        // Returns lang_versions for the main (non-comprehension) problem.
+        // Skips non-English languages whose question editor is empty.
+        function getLangVersionsForMain(subtype) {
+            const isMCQ = subtype === 'mcq_single_answer' || subtype === 'matrix_match' || subtype === 'mcq_multiple_answer';
+            const versions = [];
+            SUPPORTED_LANGUAGES.forEach(({ code }) => {
+                const questionEl = document.querySelector(`#questionDiv .lang-content[data-lang="${code}"] .editor`);
+                const question = questionEl ? getEditorHtml(questionEl) : '';
+                if (code !== 'en' && !question.trim()) return;
+                const solutionEl = document.querySelector(`#solutionDiv .lang-content[data-lang="${code}"] .editor`);
+                const solution = solutionEl ? getEditorHtml(solutionEl) : '';
+                const options = isMCQ ? tabContentByLang[code].map(item => item.html) : null;
+                versions.push({ lang_code: code, question, options, solution });
+            });
+            return versions;
         }
 
         function buildProblemPayload({
@@ -1160,15 +1175,12 @@
             topicId,
             chapterId,
             difficulty,
-            question,
-            options,
+            langVersions,
             answers,
-            solution,
             conceptIds,
             tags
         }) {
             return {
-                lang_code: "en",
                 type: "problem",
                 subtype: subtype,
                 skill_ids: skillIds,
@@ -1185,17 +1197,15 @@
                 topic_id: topicId,
                 chapter_id: chapterId,
                 difficulty_level: difficulty,
-                meta_data: {
-                    text: question,
-                    options: options,
-                    answer: answers,
-                    solutions: [
-                        {
-                            type: "text",
-                            value: solution
-                        }
-                    ]
-                },
+                lang_versions: langVersions.map(({ lang_code, question, options, solution }) => ({
+                    lang_code,
+                    meta_data: {
+                        text: question,
+                        options: options,
+                        answer: answers,
+                        solutions: [{ type: "text", value: solution }]
+                    }
+                })),
                 concept_ids: conceptIds,
                 tags: tags
             };
@@ -1213,12 +1223,8 @@
 
             const difficulty = document.querySelector('input[name="difficulty"]:checked').value;
 
-            const question = getEditorHtml(document.getElementById('questionDiv').querySelector('.editor'));
-
-            let options = null;
             let answers = [];
             if (subtype === 'mcq_single_answer' || subtype === 'matrix_match' || subtype === 'mcq_multiple_answer') {
-                options = tabContent.map(item => item.html);
                 // Convert the labels to their number indexes (+1), sort in ascending order and then convert to strings
                 answers = Array.from(answerLabels)
                     .map(label => labelPool.indexOf(label) + 1)
@@ -1241,7 +1247,8 @@
                 // integer_type
                 answers = [document.getElementById("answerInput").value];
             }
-            const solution = getEditorHtml(document.getElementById('solutionDiv').querySelector('.editor'));
+
+            const langVersions = getLangVersionsForMain(subtype);
 
             const conceptsDropdown = document.getElementById("concepts-dropdown");
             const selectedConceptIds = Array.from(conceptsDropdown.selectedOptions).map(opt => parseInt(opt.value, 10));
@@ -1255,10 +1262,8 @@
                 topicId,
                 chapterId,
                 difficulty,
-                question,
-                options,
+                langVersions,
                 answers,
-                solution,
                 conceptIds: selectedConceptIds,
                 tags: getTagsForSection(mainTagsRoot),
             });

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -363,18 +363,34 @@
                 if (code === 'en') {
                     btn.textContent = label + ' *';
                 } else {
+                    const isEnabled = enabledLangs.has(code);
                     const checkbox = document.createElement('input');
                     checkbox.type = 'checkbox';
-                    checkbox.checked = enabledLangs.has(code);
+                    checkbox.checked = isEnabled;
                     checkbox.title = `Include ${label}`;
                     checkbox.style.marginRight = '6px';
                     checkbox.addEventListener('click', (e) => {
                         e.stopPropagation();
-                        if (checkbox.checked) enabledLangs.add(code);
-                        else enabledLangs.delete(code);
+                        if (checkbox.checked) {
+                            enabledLangs.add(code);
+                        } else {
+                            enabledLangs.delete(code);
+                            // Switch back to English if this tab was active
+                            if (activeLang === code) {
+                                activeLang = 'en';
+                                switchLangEditors('en');
+                            }
+                        }
+                        renderLangTabs();
                     });
                     btn.appendChild(checkbox);
                     btn.appendChild(document.createTextNode(label));
+
+                    if (!isEnabled) {
+                        btn.style.pointerEvents = 'none';
+                        btn.style.opacity = '0.5';
+                        checkbox.style.pointerEvents = 'auto';
+                    }
                 }
 
                 langTabsEl.appendChild(btn);
@@ -911,6 +927,7 @@
                 toggleButton(saveBtn, false, 'Save')
                 return false;
             }
+
             
             const subtype = document.getElementById('problem-type-dropdown').value;
             const isComprehensionCreate = !isEditPage && subtype === 'comprehension';
@@ -1068,18 +1085,17 @@
             }
 
             if (subtype === 'mcq_single_answer' || subtype === 'matrix_match' || subtype === 'mcq_multiple_answer') {
-                if (typeof tabContent !== 'undefined' && Array.isArray(tabContent)) {
-                    for (let i = 0; i < tabContent.length; i++) {
-                        const optionLabel = String.fromCharCode(65 + i); // A, B, C...
-                        const optionText = tabContent[i]?.html?.trim();
-                        if (!optionText) {
-                            alert(`Option ${optionLabel} is empty. Please fill it out before submitting.`);
-                            return false;
-                        }
-                    }
-                } else {
+                if (typeof tabContentByLang === 'undefined' || !Array.isArray(tabContentByLang['en'])) {
                     alert('Options are not available.');
                     return false;
+                }
+                const enOptions = tabContentByLang['en'];
+                for (let i = 0; i < enOptions.length; i++) {
+                    const optionLabel = String.fromCharCode(65 + i); // A, B, C...
+                    if (!enOptions[i]?.html?.trim()) {
+                        alert(`Option ${optionLabel} is empty. Please fill it out before submitting.`);
+                        return false;
+                    }
                 }
 
                 if (answerLabels.size === 0) {

--- a/web/html/answer_sheet.html
+++ b/web/html/answer_sheet.html
@@ -29,7 +29,7 @@
                         <tr>
                             <td class="answer-pdf-table-row">{{ $Counter }}.</td>
                             <td class="answer-pdf-table-row">
-                                {{ template "pdf_answer_value" (dict "Subtype" $p.Subtype "Answers" $p.MetaData.Answers) }}
+                                {{ template "pdf_answer_value" (dict "Subtype" $p.Subtype "Answers" ($p.GetLangVersion "en").MetaData.Answers) }}
                             </td>
                             <td class="answer-pdf-table-row">{{ capitalize $p.DifficultyLevel }}</td>
                             <td class="answer-pdf-table-row">{{ getChapterName $p "en" }}</td>
@@ -50,10 +50,11 @@
                 {{ range $prob := $section.Compulsory.Problems }}
                     {{ $p := index $.ProblemsMap $prob.ID }}
                     {{ $Counter = add $Counter 1 }}
-                    {{ if and (gt (len $p.MetaData.Solutions) 0) (not (isEmptyHTML (printf "%s" (index $p.MetaData.Solutions 0).Value))) }}
+                    {{ $enLang := $p.GetLangVersion "en" }}
+                    {{ if and (gt (len $enLang.MetaData.Solutions) 0) (not (isEmptyHTML (printf "%s" (index $enLang.MetaData.Solutions 0).Value))) }}
                         <div class="mb-4 flex">
                             <span class="font-semibold">Q{{ $Counter }}.</span>
-                            <div class="ml-5 flex-1 solution-content">{{ (index $p.MetaData.Solutions 0).Value }}</div>
+                            <div class="ml-5 flex-1 solution-content">{{ (index $enLang.MetaData.Solutions 0).Value }}</div>
                         </div>
                     {{ end }}
                 {{ end }}

--- a/web/html/answer_sheet.html
+++ b/web/html/answer_sheet.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>{{ getName .TestPtr "en" }}</title>
+<title>{{ getName .TestPtr "en" }}{{ if .RegionalLangCode }} - {{ langName .RegionalLangCode }}{{ end }}</title>
 {{ template "pdf_mathjax_head" . }}
 </head>
 <body class="font-sans text-[14px] m-5 mt-0">

--- a/web/html/chapter_tests.html
+++ b/web/html/chapter_tests.html
@@ -1,3 +1,4 @@
+<div id="download-modal-container"></div>
 <div>
     <div class="card overflow-x-auto">
         <table class="app-table">

--- a/web/html/dest_problem_row.html
+++ b/web/html/dest_problem_row.html
@@ -16,7 +16,7 @@
             <option value="hard"   {{if eq $difficulty "hard"}}selected{{end}}>3</option>        
         </select>        
     </td>
-    <td class="p-2">{{ .MetaData.Question }}</td>
+    <td class="p-2">{{ (.GetLangVersion "en").MetaData.Question }}</td>
     <!-- if we pass . instead of empty dictionary, then it will throw error - "can't evaluate field PosMarks 
      in type *models.Problem" -->
     {{ template "chip_box_cells" (dict "PosMarks" $.PosMarks "NegMarks" $.NegMarks "ReadOnlyMarks" $.ReadOnlyMarks) }}

--- a/web/html/home.html
+++ b/web/html/home.html
@@ -42,6 +42,21 @@
     <script src="/web/static/js/table-sort.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
     <script>
+        function copyToClipboard(text) {
+            if (navigator.clipboard && document.hasFocus()) {
+                navigator.clipboard.writeText(text).then(() => showToast('Link copied!', 'success'));
+                return;
+            }
+            const el = document.createElement('textarea');
+            el.value = text;
+            el.style.cssText = 'position:fixed;opacity:0';
+            document.body.appendChild(el);
+            el.select();
+            document.execCommand('copy');
+            document.body.removeChild(el);
+            showToast('Link copied!', 'success');
+        }
+
         function afterDropdownReq(dropdown, selectedValue) {
             if (dropdown.id === 'grade-dropdown') {
                 const opt = document.createElement('option');

--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -37,7 +37,7 @@
         {{ end }}
         <h2 class="section-title{{ if and (eq .ProblemPtr.Subtype "comprehension") .ProblemPtr.Paragraph }} mt-6{{ end }}">Statement / Text</h2>
         <p class="mt-2 text-ink">
-            {{.ProblemPtr.MetaData.Question}}
+            {{ (.ProblemPtr.GetLangVersion "en").MetaData.Question }}
         </p>
         {{ if .ProblemPtr.Concepts }}
         <h2 class="section-title mt-6">Concepts</h2>
@@ -53,10 +53,11 @@
                 {{- if $index }}, {{ end -}}{{ $skill.Name }}
             {{- end -}}
         </p>
-        {{ if .ProblemPtr.MetaData.Options }}
+        {{ $enLang := .ProblemPtr.GetLangVersion "en" }}
+        {{ if $enLang.MetaData.Options }}
         <h2 class="section-title mt-6">Options</h2>
         <div class="mt-2 rounded-lg border border-border overflow-hidden">
-            {{ range $index, $option := .ProblemPtr.MetaData.Options }}
+            {{ range $index, $option := $enLang.MetaData.Options }}
             <div class="flex items-center border-b border-border/40 p-4 last:border-b-0 bg-bg-card">
                 <span class="mr-6 font-mono font-bold text-accent w-6">
                     {{ printf "%c" (add 65 $index) }}    <!-- Convert ASCII to letter -->
@@ -69,26 +70,26 @@
         <h2 class="section-title mt-6">Answer</h2>
         <p class="mt-2 text-ink font-mono">
             {{ if or (eq .ProblemPtr.Subtype "mcq_single_answer") (eq .ProblemPtr.Subtype "matrix_match") }}
-                {{ range .ProblemPtr.MetaData.Answers }}
+                {{ range $enLang.MetaData.Answers }}
                     {{ printf "%c" (add 64 (stringToInt .)) }}
                 {{ end }}
             {{ else if eq .ProblemPtr.Subtype "mcq_multiple_answer" }}
-                {{ range $i, $ans := .ProblemPtr.MetaData.Answers }}
+                {{ range $i, $ans := $enLang.MetaData.Answers }}
                     {{- if $i }}, {{ end }}
                     {{ printf "%c" (add 64 (stringToInt $ans)) -}}
                 {{ end }}
-            {{ else if and (or (eq .ProblemPtr.Subtype "numerical_answer") (eq .ProblemPtr.Subtype "comprehension")) (eq (len .ProblemPtr.MetaData.Answers) 2) }}
-                [{{ index .ProblemPtr.MetaData.Answers 0 }} to {{ index .ProblemPtr.MetaData.Answers 1 }}]
+            {{ else if and (or (eq .ProblemPtr.Subtype "numerical_answer") (eq .ProblemPtr.Subtype "comprehension")) (eq (len $enLang.MetaData.Answers) 2) }}
+                [{{ index $enLang.MetaData.Answers 0 }} to {{ index $enLang.MetaData.Answers 1 }}]
             {{ else }}
-                {{ range .ProblemPtr.MetaData.Answers }}
+                {{ range $enLang.MetaData.Answers }}
                     {{ . }}
                 {{ end }}
             {{ end }}
         </p>
         <h2 class="section-title mt-6">Solution</h2>
         <div class="mt-2 text-ink solution-content">
-            {{ if gt (len .ProblemPtr.MetaData.Solutions) 0 }}
-                {{ (index .ProblemPtr.MetaData.Solutions 0).Value }}
+            {{ if gt (len $enLang.MetaData.Solutions) 0 }}
+                {{ (index $enLang.MetaData.Solutions 0).Value }}
             {{ else }}
                 <span class="text-ink-muted italic">No solution available.</span>
             {{ end }}

--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -5,6 +5,13 @@
             <i class="fa-solid fa-chevron-left"></i> Back
         </button>
         <h3 class="ml-4 text-lg font-bold uppercase tracking-wide text-ink font-mono">{{.ProblemPtr.Code}}</h3>
+        {{ if gt (len .ProblemPtr.LangVersions) 1 }}
+        <select id="lang-select" class="ml-4 border border-border rounded px-2 py-1 text-sm bg-bg-card" onchange="switchLang(this.value)">
+            {{ range .ProblemPtr.LangVersions }}
+            <option value="{{ .LangCode }}">{{ langName .LangCode }}</option>
+            {{ end }}
+        </select>
+        {{ end }}
         <div class="flex space-x-4 ml-auto pr-4">
             <button class="action-button"
                 hx-get="/problems/edit-problem?id={{.ProblemPtr.ID}}&curriculum_id={{.ProblemPtr.CurriculumID}}&topic_id={{.ProblemPtr.TopicID}}"
@@ -36,9 +43,9 @@
         </p>
         {{ end }}
         <h2 class="section-title{{ if and (eq .ProblemPtr.Subtype "comprehension") .ProblemPtr.Paragraph }} mt-6{{ end }}">Statement / Text</h2>
-        <p class="mt-2 text-ink">
-            {{ (.ProblemPtr.GetLangVersion "en").MetaData.Question }}
-        </p>
+        {{ range .ProblemPtr.LangVersions }}
+        <p class="lang-panel mt-2 text-ink" data-lang="{{ .LangCode }}" {{ if ne .LangCode "en" }}style="display:none"{{ end }}>{{ .MetaData.Question }}</p>
+        {{ end }}
         {{ if .ProblemPtr.Concepts }}
         <h2 class="section-title mt-6">Concepts</h2>
         <p class="mt-2 text-ink">
@@ -53,20 +60,22 @@
                 {{- if $index }}, {{ end -}}{{ $skill.Name }}
             {{- end -}}
         </p>
-        {{ $enLang := .ProblemPtr.GetLangVersion "en" }}
-        {{ if $enLang.MetaData.Options }}
-        <h2 class="section-title mt-6">Options</h2>
-        <div class="mt-2 rounded-lg border border-border overflow-hidden">
-            {{ range $index, $option := $enLang.MetaData.Options }}
-            <div class="flex items-center border-b border-border/40 p-4 last:border-b-0 bg-bg-card">
-                <span class="mr-6 font-mono font-bold text-accent w-6">
-                    {{ printf "%c" (add 65 $index) }}    <!-- Convert ASCII to letter -->
-                </span>
-                <p class="text-ink">{{ $option }}</p>
+        {{ range .ProblemPtr.LangVersions }}
+        {{ if .MetaData.Options }}
+        <div class="lang-panel" data-lang="{{ .LangCode }}" {{ if ne .LangCode "en" }}style="display:none"{{ end }}>
+            <h2 class="section-title mt-6">Options</h2>
+            <div class="mt-2 rounded-lg border border-border overflow-hidden">
+                {{ range $index, $option := .MetaData.Options }}
+                <div class="flex items-center border-b border-border/40 p-4 last:border-b-0 bg-bg-card">
+                    <span class="mr-6 font-mono font-bold text-accent w-6">{{ printf "%c" (add 65 $index) }}</span>
+                    <p class="text-ink">{{ $option }}</p>
+                </div>
+                {{ end }}
             </div>
-            {{ end }}
         </div>
         {{ end }}
+        {{ end }}
+        {{ $enLang := .ProblemPtr.GetLangVersion "en" }}
         <h2 class="section-title mt-6">Answer</h2>
         <p class="mt-2 text-ink font-mono">
             {{ if or (eq .ProblemPtr.Subtype "mcq_single_answer") (eq .ProblemPtr.Subtype "matrix_match") }}
@@ -86,14 +95,18 @@
                 {{ end }}
             {{ end }}
         </p>
-        <h2 class="section-title mt-6">Solution</h2>
-        <div class="mt-2 text-ink solution-content">
-            {{ if gt (len $enLang.MetaData.Solutions) 0 }}
-                {{ (index $enLang.MetaData.Solutions 0).Value }}
-            {{ else }}
-                <span class="text-ink-muted italic">No solution available.</span>
-            {{ end }}
+        {{ range .ProblemPtr.LangVersions }}
+        <div class="lang-panel" data-lang="{{ .LangCode }}" {{ if ne .LangCode "en" }}style="display:none"{{ end }}>
+            <h2 class="section-title mt-6">Solution</h2>
+            <div class="mt-2 text-ink solution-content">
+                {{ if gt (len .MetaData.Solutions) 0 }}
+                    {{ (index .MetaData.Solutions 0).Value }}
+                {{ else }}
+                    <span class="text-ink-muted italic">No solution available.</span>
+                {{ end }}
+            </div>
         </div>
+        {{ end }}
         <h2 class="section-title mt-6">Difficulty</h2>
         <div class="mt-2 flex items-center text-brand-gold">
             {{ range $i := seq 1 3 }}
@@ -108,6 +121,12 @@
     </div>
 </div>
 <script>
+    function switchLang(langCode) {
+        document.querySelectorAll('.lang-panel').forEach(p => {
+            p.style.display = p.dataset.lang === langCode ? '' : 'none';
+        });
+    }
+
     document.querySelector(PROBLEM_DIV_SELECTOR).addEventListener(BACK_TO_PROBLEM_EVT, () => {
         sessionStorage.removeItem(REFRESH_PROBLEM_ON_BACK_KEY);
         const refreshUrl = sessionStorage.getItem(REFRESH_PROBLEM_URL_KEY);

--- a/web/html/question_paper.html
+++ b/web/html/question_paper.html
@@ -21,7 +21,7 @@
             {{ $p := index $.ProblemsMap $prob.ID }}
             {{ $Counter = add $Counter 1 }}
 
-            {{ template "pdf_question_options" (dict "Counter" $Counter "Problem" $p "OptionLayout" $prob.OptionLayout) }}
+            {{ template "pdf_question_options" (dict "Counter" $Counter "Problem" $p "OptionLayout" $prob.OptionLayout "RegionalLangCode" $.RegionalLangCode) }}
         {{ end }}
     {{ end }}
 {{ end }}

--- a/web/html/question_paper.html
+++ b/web/html/question_paper.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>{{ getName .TestPtr "en" }}</title>
+<title>{{ getName .TestPtr "en" }}{{ if .RegionalLangCode }} - {{ langName .RegionalLangCode }}{{ end }}</title>
 {{ template "pdf_mathjax_head" . }}
 </head>
 <body class="font-sans text-[14px] m-5 mt-0">

--- a/web/html/question_paper_with_answers.html
+++ b/web/html/question_paper_with_answers.html
@@ -21,7 +21,7 @@
             {{ $Counter = add $Counter 1 }}
 
             <div class="mb-6">
-                {{ template "pdf_question_options" (dict "Counter" $Counter "Problem" $p "OptionLayout" $prob.OptionLayout) }}
+                {{ template "pdf_question_options" (dict "Counter" $Counter "Problem" $p "OptionLayout" $prob.OptionLayout "RegionalLangCode" $.RegionalLangCode) }}
 
                 <!-- Answer aligned with question text start -->
                 <div class="flex items-start mt-3">

--- a/web/html/question_paper_with_answers.html
+++ b/web/html/question_paper_with_answers.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>{{ getName .TestPtr "en" }}</title>
+<title>{{ getName .TestPtr "en" }}{{ if .RegionalLangCode }} - {{ langName .RegionalLangCode }}{{ end }}</title>
 {{ template "pdf_mathjax_head" . }}
 </head>
 <body class="font-sans text-[14px] m-5 mt-0">

--- a/web/html/question_paper_with_answers.html
+++ b/web/html/question_paper_with_answers.html
@@ -30,16 +30,17 @@
                         <div class="border border-gray-300 rounded-sm p-2 bg-gray-50 text-sm">
                             <span class="font-semibold">Answer:</span>
                             <span class="ml-2">
-                                {{ template "pdf_answer_value" (dict "Subtype" $p.Subtype "Answers" $p.MetaData.Answers) }}
+                                {{ template "pdf_answer_value" (dict "Subtype" $p.Subtype "Answers" ($p.GetLangVersion "en").MetaData.Answers) }}
                             </span>
                         </div>
                         <div class="mt-2 border border-gray-200 rounded-sm p-2 bg-white text-sm">
                             <div><span class="font-semibold">Chapter:</span> <span class="ml-1">{{ getChapterName $p "en" }}</span></div>
                             <div><span class="font-semibold">Difficulty:</span> <span class="ml-1">{{ capitalize $p.DifficultyLevel }}</span></div>
-                            {{ if and (gt (len $p.MetaData.Solutions) 0) (not (isEmptyHTML (printf "%s" (index $p.MetaData.Solutions 0).Value))) }}
+                            {{ $enLang := $p.GetLangVersion "en" }}
+                            {{ if and (gt (len $enLang.MetaData.Solutions) 0) (not (isEmptyHTML (printf "%s" (index $enLang.MetaData.Solutions 0).Value))) }}
                             <div class="mt-1">
                                 <span class="font-semibold">Solution:</span>
-                                <div class="ml-1 solution-content">{{ (index $p.MetaData.Solutions 0).Value }}</div>
+                                <div class="ml-1 solution-content">{{ (index $enLang.MetaData.Solutions 0).Value }}</div>
                             </div>
                             {{ end }}
                         </div>

--- a/web/html/search_problem_row.html
+++ b/web/html/search_problem_row.html
@@ -6,7 +6,7 @@
             hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-params="none" hx-target="body"
             hx-push-url="true">{{.Code}}
         </a></td>
-    <td class="p-2 overflow-hidden text-ellipsis">{{.MetaData.Question}}</td>
+    <td class="p-2 overflow-hidden text-ellipsis">{{(.GetLangVersion "en").MetaData.Question}}</td>
     <td class="p-2 text-center space-x-4 whitespace-nowrap">
         <button class="action-button"
             hx-get="/problems/edit-problem?id={{.ID}}&curriculum_id={{.CurriculumID}}&topic_id={{.TopicID}}"

--- a/web/html/src_problem_row.html
+++ b/web/html/src_problem_row.html
@@ -4,7 +4,7 @@
     <td class="p-2 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" 
         hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body" hx-push-url="true">{{.Code}}
     </a></td>
-    <td class="p-2">{{.MetaData.Question}}</td>
+    <td class="p-2">{{(.GetLangVersion "en").MetaData.Question}}</td>
     <td class="p-2 text-center"><button class="px-2 bg-success text-white rounded-sm" data-id="{{.ID}}"
             data-subject="{{.Subject.ID}}" data-subtype="{{.Subtype}}" data-difficulty="{{.DifficultyLevel}}"
             data-curriculum="{{.CurriculumID}}" data-subject-parent="{{if .Subject.ParentID}}{{.Subject.ParentID}}{{end}}" 

--- a/web/html/test.html
+++ b/web/html/test.html
@@ -61,7 +61,17 @@
             select.querySelectorAll('option').forEach(opt => {
                 if (!codes.has(opt.value)) opt.remove();
             });
-            if (select.options.length > 1) select.style.display = '';
+            if (select.options.length > 1) {
+                select.style.display = '';
+                const urlLang = new URLSearchParams(window.location.search).get('lang_code');
+                if (urlLang && [...select.options].some(o => o.value === urlLang)) {
+                    select.value = urlLang;
+                    switchLang(urlLang);
+                } else {
+                    select.value = 'en';
+                    switchLang('en');
+                }
+            }
         };
     })();
 </script>

--- a/web/html/test.html
+++ b/web/html/test.html
@@ -5,6 +5,11 @@
             <i class="fa-solid fa-chevron-left"></i> Back
         </button>
         <h3 class="ml-4 text-lg font-bold uppercase tracking-wide text-ink">{{ (index .TestPtr.Name 0).Resource }}</h3>
+        <select id="lang-select" class="ml-4 border border-border rounded px-2 py-1 text-sm bg-bg-card" onchange="switchLang(this.value)" style="display:none">
+            {{ range langCodes }}
+            <option value="{{ . }}">{{ langName . }}</option>
+            {{ end }}
+        </select>
         <div class="ml-auto flex items-center gap-6 text-sm">
             <div>
                 <span class="form-label mb-0">Duration</span>
@@ -30,11 +35,34 @@
                 </tr>
             </thead>
             <tbody hx-get="/api/test/problems?id={{$.TestPtr.ID}}&curriculum_id={{(index $.TestPtr.CurriculumGrades 0).CurriculumID}}&subject_id={{$subject.SubjectID}}"
-                hx-trigger="load" data-mathjax="true">
+                hx-trigger="load" data-mathjax="true" hx-on::after-swap="onSubjectLoaded()">
                 <!-- Rows will be dynamically inserted here -->
             </tbody>
         </table>
     </div>
     {{ end }}
 </div>
+<script>
+    (function() {
+        let pendingSubjects = {{ len .TestPtr.TypeParams.Subjects }};
+
+        window.switchLang = function(langCode) {
+            document.querySelectorAll('.lang-panel').forEach(p => {
+                p.style.display = p.dataset.lang === langCode ? '' : 'none';
+            });
+        };
+
+        window.onSubjectLoaded = function() {
+            if (--pendingSubjects > 0) return;
+            const codes = new Set();
+            document.querySelectorAll('.lang-panel').forEach(p => codes.add(p.dataset.lang));
+
+            const select = document.getElementById('lang-select');
+            select.querySelectorAll('option').forEach(opt => {
+                if (!codes.has(opt.value)) opt.remove();
+            });
+            if (select.options.length > 1) select.style.display = '';
+        };
+    })();
+</script>
 {{ end }}

--- a/web/html/test_download_modal.html
+++ b/web/html/test_download_modal.html
@@ -1,5 +1,6 @@
 <div id="download-pdf-modal"
     class="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4"
+    data-base-url="{{ .BaseDownloadURL }}"
     onclick="if (event.target === this) closeDownloadModal()">
     <div class="card shadow-xl rounded-xl w-full max-w-sm p-6">
         <h2 class="page-title mb-6">Download PDF</h2>
@@ -8,12 +9,12 @@
                 <span class="form-label">Primary Language</span>
                 <span class="mt-1 inline-block px-3 py-1 rounded bg-bg-card-alt text-ink text-sm font-medium">English</span>
             </div>
-            {{ if . }}
+            {{ if .RegionalLangs }}
             <div>
                 <label for="regional-lang-select" class="form-label">Regional Language <span class="text-ink-muted font-normal">(optional)</span></label>
                 <select id="regional-lang-select" class="mt-1 w-full border border-border rounded px-2 py-1 text-sm bg-bg-card">
                     <option value="">None</option>
-                    {{ range $code, $_ := . }}
+                    {{ range $code, $_ := .RegionalLangs }}
                     <option value="{{ $code }}">{{ langName $code }}</option>
                     {{ end }}
                 </select>
@@ -31,6 +32,13 @@
         document.getElementById('download-modal-container').innerHTML = '';
     };
     window.confirmDownload = function() {
+        const modal = document.getElementById('download-pdf-modal');
+        let url = modal.dataset.baseUrl;
+        const langSelect = document.getElementById('regional-lang-select');
+        if (langSelect && langSelect.value) {
+            url += '&lang_code=' + encodeURIComponent(langSelect.value);
+        }
         closeDownloadModal();
+        window.open(url, '_blank');
     };
 </script>

--- a/web/html/test_download_modal.html
+++ b/web/html/test_download_modal.html
@@ -1,0 +1,37 @@
+<div id="download-pdf-modal"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4"
+    onclick="if (event.target === this) closeDownloadModal()">
+    <div class="card shadow-xl rounded-xl w-full max-w-sm p-6">
+        <h2 class="page-title mb-6">Download PDF</h2>
+        <div class="space-y-4">
+            <div>
+                <span class="form-label">Primary Language</span>
+                <span class="mt-1 inline-block px-3 py-1 rounded bg-bg-card-alt text-ink text-sm font-medium">English</span>
+            </div>
+            {{ if . }}
+            <div>
+                <label for="regional-lang-select" class="form-label">Regional Language <span class="text-ink-muted font-normal">(optional)</span></label>
+                <select id="regional-lang-select" class="mt-1 w-full border border-border rounded px-2 py-1 text-sm bg-bg-card">
+                    <option value="">None</option>
+                    {{ range $code, $_ := . }}
+                    <option value="{{ $code }}">{{ langName $code }}</option>
+                    {{ end }}
+                </select>
+            </div>
+            {{ end }}
+        </div>
+        <div class="mt-6 flex justify-end gap-3">
+            <button type="button" class="btn-secondary" onclick="closeDownloadModal()">Cancel</button>
+            <button type="button" class="btn-primary" onclick="confirmDownload()">Download</button>
+        </div>
+    </div>
+</div>
+<script>
+    window.closeDownloadModal = function() {
+        document.getElementById('download-modal-container').innerHTML = '';
+    };
+    window.confirmDownload = function() {
+        console.log('download confirmed');
+        closeDownloadModal();
+    };
+</script>

--- a/web/html/test_download_modal.html
+++ b/web/html/test_download_modal.html
@@ -31,7 +31,6 @@
         document.getElementById('download-modal-container').innerHTML = '';
     };
     window.confirmDownload = function() {
-        console.log('download confirmed');
         closeDownloadModal();
     };
 </script>

--- a/web/html/test_lang_modal.html
+++ b/web/html/test_lang_modal.html
@@ -1,9 +1,10 @@
-<div id="download-pdf-modal"
+<div id="lang-modal"
     class="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4"
-    data-base-url="{{ .BaseDownloadURL }}"
-    onclick="if (event.target === this) closeDownloadModal()">
+    data-base-url="{{ .BaseURL }}"
+    data-action="{{ .Action }}"
+    onclick="if (event.target === this) closeLangModal()">
     <div class="card shadow-xl rounded-xl w-full max-w-sm p-6">
-        <h2 class="page-title mb-6">Download PDF</h2>
+        <h2 class="page-title mb-6">{{ .Title }}</h2>
         <div class="space-y-4">
             <div>
                 <span class="form-label">Primary Language</span>
@@ -11,8 +12,8 @@
             </div>
             {{ if .RegionalLangs }}
             <div>
-                <label for="regional-lang-select" class="form-label">Regional Language <span class="text-ink-muted font-normal">(optional)</span></label>
-                <select id="regional-lang-select" class="mt-1 w-full border border-border rounded px-2 py-1 text-sm bg-bg-card">
+                <label for="lang-modal-select" class="form-label">Regional Language <span class="text-ink-muted font-normal">(optional)</span></label>
+                <select id="lang-modal-select" class="mt-1 w-full border border-border rounded px-2 py-1 text-sm bg-bg-card">
                     <option value="">None</option>
                     {{ range $code, $_ := .RegionalLangs }}
                     <option value="{{ $code }}">{{ langName $code }}</option>
@@ -22,23 +23,27 @@
             {{ end }}
         </div>
         <div class="mt-6 flex justify-end gap-3">
-            <button type="button" class="btn-secondary" onclick="closeDownloadModal()">Cancel</button>
-            <button type="button" class="btn-primary" onclick="confirmDownload()">Download</button>
+            <button type="button" class="btn-secondary" onclick="closeLangModal()">Cancel</button>
+            <button type="button" class="btn-primary" onclick="confirmLangModal()">{{ .ConfirmLabel }}</button>
         </div>
     </div>
 </div>
 <script>
-    window.closeDownloadModal = function() {
+    window.closeLangModal = function() {
         document.getElementById('download-modal-container').innerHTML = '';
     };
-    window.confirmDownload = function() {
-        const modal = document.getElementById('download-pdf-modal');
+    window.confirmLangModal = function() {
+        const modal = document.getElementById('lang-modal');
         let url = modal.dataset.baseUrl;
-        const langSelect = document.getElementById('regional-lang-select');
+        const langSelect = document.getElementById('lang-modal-select');
         if (langSelect && langSelect.value) {
             url += '&lang_code=' + encodeURIComponent(langSelect.value);
         }
-        closeDownloadModal();
-        window.open(url, '_blank');
+        closeLangModal();
+        if (modal.dataset.action === 'download') {
+            window.open(url, '_blank');
+        } else {
+            copyToClipboard(window.location.origin + url);
+        }
     };
 </script>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -74,6 +74,8 @@ window.MathJax = {
 {{ end }}
 
 {{ define "pdf_question_options" }}
+{{ $enLV := .Problem.GetLangVersion "en" }}
+{{ $regLV := .Problem.GetLangVersion .RegionalLangCode }}
 <div class="mb-6" style="break-inside: avoid;">
     {{ if and (eq .Problem.Subtype "comprehension") .Problem.Paragraph }}
     <div class="flex items-start mb-3 pl-11">
@@ -85,7 +87,12 @@ window.MathJax = {
     {{ end }}
     <div class="flex items-start mb-2">
         <div class="w-6 font-semibold">Q{{ .Counter }}.</div>
-        <div class="flex-1 pl-5">{{ (.Problem.GetLangVersion "en").MetaData.Question }}</div>
+        <div class="flex-1 pl-5">
+            <div>{{ $enLV.MetaData.Question }}</div>
+            {{ if and .RegionalLangCode $regLV }}
+            <div class="mt-1 text-gray-600">{{ $regLV.MetaData.Question }}</div>
+            {{ end }}
+        </div>
     </div>
 
     {{ if or (eq .Problem.Subtype "mcq_single_answer") (eq .Problem.Subtype "mcq_multiple_answer") (eq .Problem.Subtype "matrix_match") }}
@@ -103,10 +110,10 @@ window.MathJax = {
         {{ end }}
 
         <div class="grid gap-x-4 gap-y-1 {{ $gridClass }}">
-            {{ range $index, $option := (.Problem.GetLangVersion "en").MetaData.Options }}
+            {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{ $option }}</div>
+                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -85,7 +85,7 @@ window.MathJax = {
     {{ end }}
     <div class="flex items-start mb-2">
         <div class="w-6 font-semibold">Q{{ .Counter }}.</div>
-        <div class="flex-1 pl-5">{{ .Problem.MetaData.Question }}</div>
+        <div class="flex-1 pl-5">{{ (.Problem.GetLangVersion "en").MetaData.Question }}</div>
     </div>
 
     {{ if or (eq .Problem.Subtype "mcq_single_answer") (eq .Problem.Subtype "mcq_multiple_answer") (eq .Problem.Subtype "matrix_match") }}
@@ -103,7 +103,7 @@ window.MathJax = {
         {{ end }}
 
         <div class="grid gap-x-4 gap-y-1 {{ $gridClass }}">
-            {{ range $index, $option := .Problem.MetaData.Options }}
+            {{ range $index, $option := (.Problem.GetLangVersion "en").MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
                 <div class="flex-1 whitespace-pre-wrap">{{ $option }}</div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -29,7 +29,7 @@ window.MathJax = {
 {{ define "pdf_test_header" }}
 <div id="mathjax-done" style="display:none"></div>
 <div class="flex flex-wrap justify-between mb-3 w-full gap-y-1">
-    <h2 class="text-lg font-bold">{{ getName .TestPtr "en" }}</h2>
+    <h2 class="text-lg font-bold">{{ getName .TestPtr "en" }}{{ if .RegionalLangCode }} - {{ langName .RegionalLangCode }}{{ end }}</h2>
     <h2 class="text-lg font-bold shrink-0">Test Code: {{ .TestPtr.Code }}</h2>
 </div>
 {{ end }}
@@ -90,7 +90,7 @@ window.MathJax = {
         <div class="flex-1 pl-5">
             <div>{{ $enLV.MetaData.Question }}</div>
             {{ if and .RegionalLangCode $regLV }}
-            <div class="mt-1 text-gray-600">{{ $regLV.MetaData.Question }}</div>
+            <div class="mt-1 text-gray-800">{{ $regLV.MetaData.Question }}</div>
             {{ end }}
         </div>
     </div>
@@ -113,7 +113,7 @@ window.MathJax = {
             {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_problem_row.html
+++ b/web/html/test_problem_row.html
@@ -6,6 +6,6 @@
             hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body"
             hx-push-url="true">{{.Code}}</a>
     </td>
-    <td class="w-auto px-4 text-left">{{.MetaData.Question}}</td>
+    <td class="w-auto px-4 text-left">{{(.GetLangVersion "en").MetaData.Question}}</td>
 </tr>
 {{ end }}

--- a/web/html/test_problem_row.html
+++ b/web/html/test_problem_row.html
@@ -6,6 +6,10 @@
             hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body"
             hx-push-url="true">{{.Code}}</a>
     </td>
-    <td class="w-auto px-4 text-left">{{(.GetLangVersion "en").MetaData.Question}}</td>
+    <td class="w-auto px-4 text-left">
+        {{ range .LangVersions }}
+        <span class="lang-panel" data-lang="{{ .LangCode }}" {{ if ne .LangCode "en" }}style="display:none"{{ end }}>{{ .MetaData.Question }}</span>
+        {{ end }}
+    </td>
 </tr>
 {{ end }}

--- a/web/html/test_row.html
+++ b/web/html/test_row.html
@@ -11,7 +11,7 @@
     <td class="text-center">{{.TypeParams.Marks}}</td>
     <td class="text-center">{{.TypeParams.Duration}}</td>
     <td></td>
-    <td class="text-center space-x-4">
+    <td class="text-center space-x-4 whitespace-nowrap">
         <!-- target is kept body instead of #content, because using #content as target will not work when
          directly edit url is entered in browser -->
         <button class="action-button" hx-get="/tests/edit-test?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}"

--- a/web/html/test_row.html
+++ b/web/html/test_row.html
@@ -34,7 +34,12 @@
             <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q+A</span>
         </a>
             
-        <button class="action-button" hx-get="/tests/copy-test?id={{.ID}}&curriculum_id={{$curriculumId}}" 
+        <a class="action-button cursor-pointer" title="Copy Link"
+            hx-get="/tests/copy-link-modal?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}"
+            hx-target="#download-modal-container" hx-swap="innerHTML">
+            <i class="fa-solid fa-link"></i>
+        </a>
+        <button class="action-button" hx-get="/tests/copy-test?id={{.ID}}&curriculum_id={{$curriculumId}}"
             hx-target="body" title="Copy Test" hx-push-url="true">
             <i class="fa-solid fa-copy"></i>
         </button>

--- a/web/html/test_row.html
+++ b/web/html/test_row.html
@@ -4,8 +4,8 @@
 {{ $gradeId := $curriculumGrade.GradeID }}
 <tr class="border-b border-border/40 hover:bg-bg-hover transition-colors">
     <td class="py-4 px-6">{{.Code}}</td>
-    <td class="px-6 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/test?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}" 
-        hx-get="/test?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}" hx-target="body"
+    <td class="px-6 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/test?id={{.ID}}"
+        hx-get="/test?id={{.ID}}" hx-include="unset" hx-target="body"
         hx-push-url="true">{{ (index .Name 0).Resource }}</a></td>
     <td class="px-6 text-center text-accent hover:text-accent-hover hover:underline font-medium">{{.ProblemCount}}</td>
     <td class="text-center">{{.TypeParams.Marks}}</td>

--- a/web/html/test_row.html
+++ b/web/html/test_row.html
@@ -18,17 +18,20 @@
             hx-target="body" hx-push-url="true">
             <i class="fa-solid fa-pen"></i>
         </button>
-        <a href="/download-pdf?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions" 
-            target="_blank" class="action-button" title="Download Questions PDF">
-                <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q</span>
+        <a class="action-button cursor-pointer" title="Download Questions PDF"
+            hx-get="/tests/download-modal?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions"
+            hx-target="#download-modal-container" hx-swap="innerHTML">
+            <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q</span>
         </a>
-        <a href="/download-pdf?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=answers"  
-            target="_blank"class="action-button" title="Download Answers PDF">
-                <i class="fa-solid fa-download"></i><span class="text-xs ml-1">A</span>
+        <a class="action-button cursor-pointer" title="Download Answers PDF"
+            hx-get="/tests/download-modal?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=answers"
+            hx-target="#download-modal-container" hx-swap="innerHTML">
+            <i class="fa-solid fa-download"></i><span class="text-xs ml-1">A</span>
         </a>
-        <a href="/download-pdf?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions_with_answers" 
-            target="_blank" class="action-button" title="Download Questions with Answers PDF">
-                <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q+A</span>
+        <a class="action-button cursor-pointer" title="Download Questions with Answers PDF"
+            hx-get="/tests/download-modal?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions_with_answers"
+            hx-target="#download-modal-container" hx-swap="innerHTML">
+            <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q+A</span>
         </a>
             
         <button class="action-button" hx-get="/tests/copy-test?id={{.ID}}&curriculum_id={{$curriculumId}}" 

--- a/web/html/test_search_row.html
+++ b/web/html/test_search_row.html
@@ -23,8 +23,8 @@
                 <td class="py-4 px-6" rowspan="{{ $total }}">{{ $test.Code }}</td>
 
                 <td class="px-6 text-accent hover:text-accent-hover hover:underline font-medium" rowspan="{{ $total }}">
-                    <a href="/test?id={{ $test.ID }}&curriculum_id={{ $curriculumId }}&grade_id={{ $gradeId }}"
-                       hx-get="/test?id={{ $test.ID }}&curriculum_id={{ $curriculumId }}&grade_id={{ $gradeId }}"
+                    <a href="/test?id={{ $test.ID }}"
+                       hx-get="/test?id={{ $test.ID }}" hx-include="unset"
                        hx-target="body" hx-push-url="true">
                        {{ (index $test.Name 0).Resource }}
                     </a>

--- a/web/html/test_search_row.html
+++ b/web/html/test_search_row.html
@@ -62,7 +62,12 @@
                         hx-target="#download-modal-container" hx-swap="innerHTML">
                         <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q+A</span>
                     </a>
-                    <button class="action-button" hx-get="/tests/copy-test?id={{ $test.ID }}&curriculum_id={{$curriculumId}}" 
+                    <a class="action-button cursor-pointer" title="Copy Link"
+                        hx-get="/tests/copy-link-modal?id={{ $test.ID }}&curriculum_id={{ $curriculumId }}&grade_id={{ $gradeId }}"
+                        hx-target="#download-modal-container" hx-swap="innerHTML">
+                        <i class="fa-solid fa-link"></i>
+                    </a>
+                    <button class="action-button" hx-get="/tests/copy-test?id={{ $test.ID }}&curriculum_id={{$curriculumId}}"
                         hx-target="body" title="Copy Test" hx-push-url="true">
                         <i class="fa-solid fa-copy"></i>
                     </button>

--- a/web/html/test_search_row.html
+++ b/web/html/test_search_row.html
@@ -47,17 +47,20 @@
                         hx-target="body" hx-push-url="true">
                         <i class="fa-solid fa-pen"></i>
                     </button>
-                    <a href="/download-pdf?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions" 
-                        target="_blank" class="action-button" title="Download Questions PDF">
-                            <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q</span>
+                    <a class="action-button cursor-pointer" title="Download Questions PDF"
+                        hx-get="/tests/download-modal?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions"
+                        hx-target="#download-modal-container" hx-swap="innerHTML">
+                        <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q</span>
                     </a>
-                    <a href="/download-pdf?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=answers"  
-                        target="_blank"class="action-button" title="Download Answers PDF">
-                            <i class="fa-solid fa-download"></i><span class="text-xs ml-1">A</span>
+                    <a class="action-button cursor-pointer" title="Download Answers PDF"
+                        hx-get="/tests/download-modal?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=answers"
+                        hx-target="#download-modal-container" hx-swap="innerHTML">
+                        <i class="fa-solid fa-download"></i><span class="text-xs ml-1">A</span>
                     </a>
-                    <a href="/download-pdf?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions_with_answers" 
-                        target="_blank" class="action-button" title="Download Questions with Answers PDF">
-                            <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q+A</span>
+                    <a class="action-button cursor-pointer" title="Download Questions with Answers PDF"
+                        hx-get="/tests/download-modal?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions_with_answers"
+                        hx-target="#download-modal-container" hx-swap="innerHTML">
+                        <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q+A</span>
                     </a>
                     <button class="action-button" hx-get="/tests/copy-test?id={{ $test.ID }}&curriculum_id={{$curriculumId}}" 
                         hx-target="body" title="Copy Test" hx-push-url="true">

--- a/web/html/test_search_row.html
+++ b/web/html/test_search_row.html
@@ -40,7 +40,7 @@
                         {{ $test.Subtype }}
                     {{ end }}
                 </td>
-                <td class="text-center space-x-4" rowspan="{{ $total }}">
+                <td class="text-center space-x-4 whitespace-nowrap" rowspan="{{ $total }}">
                     <!-- target is kept body instead of #content, because using #content as target will not work when
                     directly edit url is entered in browser -->
                     <button class="action-button" hx-get="/tests/edit-test?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}"

--- a/web/html/tests.html
+++ b/web/html/tests.html
@@ -41,6 +41,8 @@
 
 </div>
 
+<div id="download-modal-container"></div>
+
 <script>
     (function () {
         htmx.defineExtension('tests-view-loader', {

--- a/web/html/topic_problem_row.html
+++ b/web/html/topic_problem_row.html
@@ -10,7 +10,7 @@
             hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-params="none" hx-target="body"
             hx-push-url="true">{{.Code}}
         </a></td>
-    <td class="p-2 overflow-hidden text-ellipsis">{{.MetaData.Question}}</td>
+    <td class="p-2 overflow-hidden text-ellipsis">{{(.GetLangVersion "en").MetaData.Question}}</td>
     <td class="p-2 text-center space-x-4 whitespace-nowrap">
         <button class="action-button"
             hx-get="/problems/edit-problem?id={{.ID}}&curriculum_id={{.CurriculumID}}&topic_id={{.TopicID}}"


### PR DESCRIPTION
## 🌐 Multilingual Problem Support

Adds end-to-end support for creating, editing, copying, and viewing problems in multiple languages (English, Hindi, Gujarati, Tamil).

## ✨ What's new

### Add / Edit / Copy problem form
- **Language tab bar** — English is mandatory; regional language tabs auto-check and activate when clicked, and uncheck when disabled via checkbox
- **Per-language editors** for question, solution, and MCQ options — each language gets its own rich-text editor
- **Validation applies to English only** — question and MCQ options for non-English languages are not validated on submit
- **Active tab switches back to English** automatically when an active tab non-English language is disabled
- **Edit & copy prefill** — all language versions (question, solution, options, answer) are restored correctly from `lang_versions`
- **Payload updated** to send `lang_versions` array to the API instead of flat `meta_data`

### Problem & test views
- **Language filter** on test view and problem view to switch displayed language
- **All problem related templates updated** to read question, options, and solutions from `lang_versions` instead of flat `meta_data`: `search_problem_row`, `topic_problem_row`, `test_problem_row`, `src_problem_row`, `dest_problem_row`, `test_pdf_shared`, `answer_sheet`, `question_paper_with_answers`, `problem`

### PDF download
- **Language selection dialog** on test list to pick regional language before downloading
- **Direct download in new tab** (no dialog) when no regional language problems are found in the test
- **Bilingual PDF layout** — regional language question is shown below the English question; each regional language option is shown side-by-side next to its corresponding English option
- **Regional language name appended to PDF title and filename** — bilingual downloads are named `<Test Name> - <Suffix> - <Language>.pdf` (e.g. `- Hindi`), and the same suffix appears in the PDF header, so it's clear which language the PDF contains

### Copy link
- **Copy link button** added to each test row (test list, test search & chapter tests) — on click, if the test has no regional language problems, the test URL is copied to clipboard immediately and a toast confirmation appears; if regional languages exist, a dialog opens to optionally append a `lang_code` to the URL before copying
- **Test URL simplified to `/test?id=<id>`** — dropped the redundant `curriculum_id`/`grade_id` query params (the single-test screen already derives both from the test's own curriculum-grade association) 
- Stopped the test-name link from inheriting stray `curriculum-dropdown`/`grade-dropdown`/`testtype-dropdown`/search params via HTMX's `hx-include` on the parent table, so clicking a test or copying its link now always yields one clean **small URL**

### UI fixes
- **Action buttons stay on one line** — the actions column in test rows (tests tab, chapter tests tab, and test search) no longer wraps

## 🔧 API changes

- Removed `lang_code` query param from `GET /api/problems`, `GET /api/problems/search`, and `GET /api/resource/test/{id}/problems` — problems are now returned with all available `lang_versions`
- Removed `lang_code` path segment from `GET /api/resource/problem/{id}/{curriculum_id}`
- Lang names centralised in utils

## 🧪 Test plan

- [x] Add a new problem with English only — verify save works and no regional lang data is sent
- [x] Add a new problem with Hindi enabled — verify both lang versions saved correctly
- [x] Click a language tab without checking its checkbox — verify it auto-checks and activates
- [x] Disable an active regional language tab — verify active tab switches back to English
- [x] Leave a regional language MCQ option empty — verify no validation error is raised
- [x] Edit a bilingual problem — verify all language editors are prefilled correctly
- [x] Copy a bilingual problem — verify copy also prefills all languages
- [x] Use language filter on test view and problem view — verify content switches correctly
- [x] Verify all problem row views (search, topic, test, src, dest) display correct language content
- [x] Download PDF for a test with regional lang problems — verify bilingual questions & options 
- [x] Download a bilingual PDF — verify filename and PDF header include the regional language name
- [x] Download PDF for an English-only test — verify direct download in new tab with no dialog and no language suffix in the filename
- [x] Copy a test link with regional lang — verify correct lang code in URL and toast appears
- [x] Download / copy link from the chapter Tests tab — verify modal opens without console errors
- [x] Verify all seven action buttons render on a single line in tests, chapter tests, and search results
- [x] Click a test from the tests list, chapter tests tab, and search results — verify the browser/pushed URL and the copied link show only `?id=<id>`, with no `curriculum_id`, `grade_id`, dropdown, or search params leaking in