### PR TITLE
🌐 Install regional PDF fonts, fix bilingual PDF colors/MCQ layout, problem-page language toggle, and PDF math rendering

### DIFF
--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -1031,7 +1031,9 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 		return
 	}
 	// output.css sets html/body to the app warm beige; question papers need a white page.
-	pdfPageStyle := `<style>html,body{background:#fff!important;background-color:#fff!important;min-height:auto!important}mjx-num{padding-bottom:0.1em!important}mjx-den{padding-top:0.1em!important}</style>`
+	// print-color-adjust:exact stops Chrome's print-economy mode from normalizing distinct
+	// dark colors (e.g. --color-ink vs text-gray-800) to the same fallback gray in the PDF.
+	pdfPageStyle := `<style>*{-webkit-print-color-adjust:exact!important;print-color-adjust:exact!important;color-adjust:exact!important}html,body{background:#fff!important;background-color:#fff!important;min-height:auto!important}mjx-num{padding-bottom:0.1em!important}mjx-den{padding-top:0.1em!important}</style>`
 	htmlContent = strings.Replace(htmlContent, "</head>", "<style>"+string(cssBytes)+"</style>"+pdfPageStyle+"</head>", 1)
 
 	headerHTML := fmt.Sprintf(`

--- a/terraform/user-data.sh
+++ b/terraform/user-data.sh
@@ -23,7 +23,12 @@ dnf update -y
 dnf install -y git nginx golang certbot python3-certbot-nginx firewalld
 
 log "Installing system fonts required for PDF generation (MathJax, Chromium)"
-sudo dnf install -y \
+# google-noto-sans-fonts only covers Latin/Greek/Cyrillic, so without the per-script Noto packages
+# below, Chrome has no glyphs for Hindi/Gujarati/Tamil and prints boxes ("tofu") instead of text.
+# --allowerasing: AL2023's split google-noto-sans-* packages have a known cross-package version
+# conflict on google-noto-fonts-common (amazonlinux/amazon-linux-2023#982); let dnf resolve it
+# instead of aborting the whole boot script.
+sudo dnf install -y --allowerasing \
   fontconfig \
   dejavu-sans-fonts \
   dejavu-serif-fonts \
@@ -31,7 +36,10 @@ sudo dnf install -y \
   liberation-fonts \
   google-noto-sans-fonts \
   google-noto-serif-fonts \
-  google-noto-sans-math-fonts
+  google-noto-sans-math-fonts \
+  google-noto-sans-devanagari-fonts \
+  google-noto-sans-gujarati-fonts \
+  google-noto-sans-tamil-fonts
 
 log "Rebuilding font cache"
 # fontconfig is now installed explicitly above; earlier AMI baselines apparently shipped it

--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -44,7 +44,7 @@
         {{ end }}
         <h2 class="section-title{{ if and (eq .ProblemPtr.Subtype "comprehension") .ProblemPtr.Paragraph }} mt-6{{ end }}">Statement / Text</h2>
         {{ range .ProblemPtr.LangVersions }}
-        <p class="lang-panel mt-2 text-ink" data-lang="{{ .LangCode }}" {{ if ne .LangCode "en" }}style="display:none"{{ end }}>{{ .MetaData.Question }}</p>
+        <div class="lang-panel mt-2 text-ink" data-lang="{{ .LangCode }}" {{ if ne .LangCode "en" }}style="display:none"{{ end }}>{{ .MetaData.Question }}</div>
         {{ end }}
         {{ if .ProblemPtr.Concepts }}
         <h2 class="section-title mt-6">Concepts</h2>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -116,11 +116,19 @@ window.MathJax = {
             {{ $gridClass = "grid-cols-4" }}
         {{ end }}
 
-        <div class="grid gap-x-4 gap-y-1 {{ $gridClass }}">
+        <div class="grid gap-x-4 gap-y-2 {{ $gridClass }}">
             {{ range $index, $option := $enLV.MetaData.Options }}
-            <div class="flex items-baseline">
+            <div class="flex items-start">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap"><span class="!text-ink [&_*]:!text-ink">{{- $option -}}</span>{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-800 [&_*]:!text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1">
+                    <div class="whitespace-pre-wrap !text-ink [&_*]:!text-ink">{{ $option }}</div>
+                    {{- if and $.RegionalLangCode $regLV -}}
+                    {{- $regOptions := $regLV.MetaData.Options -}}
+                    {{- if lt $index (len $regOptions) }}
+                    <div class="whitespace-pre-wrap mt-1 !text-gray-800 [&_*]:!text-gray-800">{{ index $regOptions $index }}</div>
+                    {{- end -}}
+                    {{- end }}
+                </div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -97,7 +97,7 @@ window.MathJax = {
         <div class="flex-1 pl-5">
             <div>{{ $enLV.MetaData.Question }}</div>
             {{ if and .RegionalLangCode $regLV }}
-            <div class="mt-1 !text-gray-500 [&_*]:!text-gray-500">{{ $regLV.MetaData.Question }}</div>
+            <div class="mt-1 !text-gray-800 [&_*]:!text-gray-800">{{ $regLV.MetaData.Question }}</div>
             {{ end }}
         </div>
     </div>
@@ -120,7 +120,7 @@ window.MathJax = {
             {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-500 [&_*]:!text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-800 [&_*]:!text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -95,7 +95,7 @@ window.MathJax = {
     <div class="flex items-baseline mb-2">
         <div class="w-6 font-semibold">Q{{ .Counter }}.</div>
         <div class="flex-1 pl-5">
-            <div>{{ $enLV.MetaData.Question }}</div>
+            <div class="!text-ink [&_*]:!text-ink">{{ $enLV.MetaData.Question }}</div>
             {{ if and .RegionalLangCode $regLV }}
             <div class="mt-1 !text-gray-800 [&_*]:!text-gray-800">{{ $regLV.MetaData.Question }}</div>
             {{ end }}
@@ -120,7 +120,7 @@ window.MathJax = {
             {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-800 [&_*]:!text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1 whitespace-pre-wrap"><span class="!text-ink [&_*]:!text-ink">{{- $option -}}</span>{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-800 [&_*]:!text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -90,7 +90,7 @@ window.MathJax = {
         <div class="flex-1 pl-5">
             <div>{{ $enLV.MetaData.Question }}</div>
             {{ if and .RegionalLangCode $regLV }}
-            <div class="mt-1 text-gray-800">{{ $regLV.MetaData.Question }}</div>
+            <div class="mt-1 !text-gray-500">{{ $regLV.MetaData.Question }}</div>
             {{ end }}
         </div>
     </div>
@@ -113,7 +113,7 @@ window.MathJax = {
             {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -97,7 +97,7 @@ window.MathJax = {
         <div class="flex-1 pl-5">
             <div>{{ $enLV.MetaData.Question }}</div>
             {{ if and .RegionalLangCode $regLV }}
-            <div class="mt-1 !text-gray-500">{{ $regLV.MetaData.Question }}</div>
+            <div class="mt-1 !text-gray-500 [&_*]:!text-gray-500">{{ $regLV.MetaData.Question }}</div>
             {{ end }}
         </div>
     </div>
@@ -120,7 +120,7 @@ window.MathJax = {
             {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-500 [&_*]:!text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -7,7 +7,9 @@ window.MathJax = {
       // render at the same size as single-line equations, not shrunk by TeX's textstyle rules.
       MathJax.startup.document.inputJax[0].preFilters.add(({math}) => {
         if (!math.display) {
-          math.math = '\\displaystyle{' + math.math + '}';
+          // Closing brace goes on its own line so a stray unescaped '%' in the
+          // source (which starts a TeX comment through end-of-line) can't eat it.
+          math.math = '\\displaystyle{' + math.math + '\n}';
         }
       });
       return MathJax.startup.defaultPageReady().then(() => {


### PR DESCRIPTION
## 🐞 Problems
- `google-noto-sans-fonts` only covers Latin/Greek/Cyrillic, so Chrome on EC2 had no Devanagari/Gujarati/Tamil glyphs and printed boxes instead of text in bilingual PDFs.
- Regional PDF text was meant to render lighter than English, but ended up darker instead — and rich-text-authored content could carry inline colors that overrode our styling entirely, on both the English and regional sides.
- Side-by-side MCQ options in the PDF got cramped once bilingual content made them too wide.
- On the (web) problem page, both language panels sometimes rendered simultaneously instead of toggling, because a stray `<p>` wrapping block-level content got silently closed by the browser, orphaning the display logic.
- An unescaped `%` inside inline math (e.g. `\(75%\)`) starts a TeX comment through end-of-line, which swallowed the closing brace our `\displaystyle` wrapper appends — leaving the group unclosed, so PDFs showed the raw broken LaTeX source in red/yellow error styling instead of the rendered math.

## ✅ Changes
- 🔤 Install new per-script Noto fonts (Hindi, Gujarati, Tamil) via `--allowerasing` to work around AL2023's package conflicts — these scripts had no font coverage before.
- 🎨 Force English PDF text to `!text-ink` and regional text to `!text-gray-800`, applied onto nested descendants (`[&_*]:`) so inline rich-text colors can't override it; also force `print-color-adjust:exact` so Chrome's print-economy mode doesn't collapse distinct shades to the same gray.
- 📐 Stack bilingual PDF MCQ options vertically instead of side-by-side, matching the layout already used for the question stem.
- 🛠️ Fix the malformed `<p>`-wrapped question markup on the problem page so language panels toggle correctly instead of both showing at once.
-  🧮 Put the `\displaystyle{...}` wrapper's closing brace on its own line so a stray `%` in the math source only comments out the (empty) rest of its line, not the brace.

## 🧪 Testing
- [x] Verified Hindi/Gujarati/Tamil glyphs render correctly in generated PDFs.
- [x] Verified English text renders darker than regional text in PDFs, and that inline-colored rich-text content doesn't break either.
- [x] Verified MCQ options render legibly stacked for bilingual PDFs.
- [x] Verified only one language panel displays at a time on the problem page.
- [x] Verified inline math containing a raw `%` (e.g. `\(75%\)`) renders correctly in PDFs instead of showing broken LaTeX source.