### PR TITLE
🏷️ Add new program codes to test creation form

### DIFF
--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -226,7 +226,7 @@
                 <option value="" selected disabled hidden>Select Program</option>
                 {{ end }}
             
-                {{range $opt := (slice "JN" "HP" "MH" "GJ" "TN" "PN" "UK" "OR" "DL" "X")}}
+                {{range $opt := (slice "AF" "DL" "GJ" "GN" "HP" "JN" "MH" "MS" "ON" "OR" "PN" "TN" "UK" "X" "Y" "Z")}}
                 <option {{if eq $program $opt}}selected{{end}}>{{$opt}}</option>
                 {{end}}
             </select>


### PR DESCRIPTION
## Summary
- Updates the program dropdown in the test creation form to include newly onboarded program codes alongside existing ones, and sorts the list alphabetically.
- New codes:
  - `AF` — Avanti Fellows standard tests (hiring, selection, teacher evaluation)
  - `ON` — Online programs
  - `GN` — General test, for unregistered programs / random requests
  - `MS` — Programs covering multiple states, not limited to a single state
  - `Y` — Grade 9th (X is used for 10th)
  - `Z` — Grade 8th or below

## Test plan
- [x] Open the Add Test form and confirm the Program dropdown lists all codes: AF, DL, GJ, GN, HP, JN, MH, MS, ON, OR, PN, TN, UK, X, Y, Z
- [x] Confirm selecting a program still pre-selects correctly when editing an existing test