### PR TITLE
🐛 Fix test duration showing 0 on edit screen for JEE Advanced tests

### DIFF
--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -393,17 +393,17 @@
 
             {{ $duration := "" }}
 
-            <!-- if config is available, fix duration based on test rule config -->
-            {{ if .TestRule }}
+            <!-- if test rule config has a duration set, use it -->
+            {{ if and .TestRule .TestRule.Config.Duration }}
                 {{ $duration = .TestRule.Config.Duration }}
-            <!-- else for edit test case get it from test itself -->
+            <!-- else (no rule, or rule has no duration e.g. JEE Advanced) get it from the test itself -->
             {{ else }}
                 {{ $duration = .TestPtr.TypeParams.Duration }}
             {{ end }}
 
             <label class="text-sm font-medium">Duration (mins):</label>
             <input id="duration" type="number" class="w-1/4 border rounded-sm p-2" placeholder="60"
-                value="{{ $duration }}" 
+                value="{{ $duration }}"
                 {{ if and .TestRule .TestRule.Config.Duration }}readonly{{ end }}
                 onchange="sessionStorage.setItem('selectedDuration', this.value);">
             <label class="text-sm font-medium">Total Marks:</label>


### PR DESCRIPTION
## 🐞 Bug
On the edit test screen, duration showed `0` for JEE Advanced curriculum tests, even though the test list screen correctly showed the saved value (e.g. 60 mins).

## 🔍 Root cause
The duration field pre-filled from the matched test rule's config whenever *any* rule matched the test — but JEE Advanced's test rule only carries instructions, not a duration. So the input rendered `0` instead of falling back to the test's own saved duration.

## ✅ Fix
Only use the test rule's duration when it's actually set; otherwise fall back to the test's own `TypeParams.Duration` — matching what the list screen already displays.

## 🧪 Testing
- Verified the fallback correctly resolves to blank for new tests, the saved value for edit, and the copied value for copy mode.