### PR TITLE
Prod release: Multilingual PDF/problem-page fixes, JEE Advanced duration fix

### DIFF
--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -1031,7 +1031,9 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 		return
 	}
 	// output.css sets html/body to the app warm beige; question papers need a white page.
-	pdfPageStyle := `<style>html,body{background:#fff!important;background-color:#fff!important;min-height:auto!important}mjx-num{padding-bottom:0.1em!important}mjx-den{padding-top:0.1em!important}</style>`
+	// print-color-adjust:exact stops Chrome's print-economy mode from normalizing distinct
+	// dark colors (e.g. --color-ink vs text-gray-800) to the same fallback gray in the PDF.
+	pdfPageStyle := `<style>*{-webkit-print-color-adjust:exact!important;print-color-adjust:exact!important;color-adjust:exact!important}html,body{background:#fff!important;background-color:#fff!important;min-height:auto!important}mjx-num{padding-bottom:0.1em!important}mjx-den{padding-top:0.1em!important}</style>`
 	htmlContent = strings.Replace(htmlContent, "</head>", "<style>"+string(cssBytes)+"</style>"+pdfPageStyle+"</head>", 1)
 
 	headerHTML := fmt.Sprintf(`

--- a/terraform/user-data.sh
+++ b/terraform/user-data.sh
@@ -23,7 +23,12 @@ dnf update -y
 dnf install -y git nginx golang certbot python3-certbot-nginx firewalld
 
 log "Installing system fonts required for PDF generation (MathJax, Chromium)"
-sudo dnf install -y \
+# google-noto-sans-fonts only covers Latin/Greek/Cyrillic, so without the per-script Noto packages
+# below, Chrome has no glyphs for Hindi/Gujarati/Tamil and prints boxes ("tofu") instead of text.
+# --allowerasing: AL2023's split google-noto-sans-* packages have a known cross-package version
+# conflict on google-noto-fonts-common (amazonlinux/amazon-linux-2023#982); let dnf resolve it
+# instead of aborting the whole boot script.
+sudo dnf install -y --allowerasing \
   fontconfig \
   dejavu-sans-fonts \
   dejavu-serif-fonts \
@@ -31,7 +36,10 @@ sudo dnf install -y \
   liberation-fonts \
   google-noto-sans-fonts \
   google-noto-serif-fonts \
-  google-noto-sans-math-fonts
+  google-noto-sans-math-fonts \
+  google-noto-sans-devanagari-fonts \
+  google-noto-sans-gujarati-fonts \
+  google-noto-sans-tamil-fonts
 
 log "Rebuilding font cache"
 # fontconfig is now installed explicitly above; earlier AMI baselines apparently shipped it

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -393,17 +393,17 @@
 
             {{ $duration := "" }}
 
-            <!-- if config is available, fix duration based on test rule config -->
-            {{ if .TestRule }}
+            <!-- if test rule config has a duration set, use it -->
+            {{ if and .TestRule .TestRule.Config.Duration }}
                 {{ $duration = .TestRule.Config.Duration }}
-            <!-- else for edit test case get it from test itself -->
+            <!-- else (no rule, or rule has no duration e.g. JEE Advanced) get it from the test itself -->
             {{ else }}
                 {{ $duration = .TestPtr.TypeParams.Duration }}
             {{ end }}
 
             <label class="text-sm font-medium">Duration (mins):</label>
             <input id="duration" type="number" class="w-1/4 border rounded-sm p-2" placeholder="60"
-                value="{{ $duration }}" 
+                value="{{ $duration }}"
                 {{ if and .TestRule .TestRule.Config.Duration }}readonly{{ end }}
                 onchange="sessionStorage.setItem('selectedDuration', this.value);">
             <label class="text-sm font-medium">Total Marks:</label>

--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -44,7 +44,7 @@
         {{ end }}
         <h2 class="section-title{{ if and (eq .ProblemPtr.Subtype "comprehension") .ProblemPtr.Paragraph }} mt-6{{ end }}">Statement / Text</h2>
         {{ range .ProblemPtr.LangVersions }}
-        <p class="lang-panel mt-2 text-ink" data-lang="{{ .LangCode }}" {{ if ne .LangCode "en" }}style="display:none"{{ end }}>{{ .MetaData.Question }}</p>
+        <div class="lang-panel mt-2 text-ink" data-lang="{{ .LangCode }}" {{ if ne .LangCode "en" }}style="display:none"{{ end }}>{{ .MetaData.Question }}</div>
         {{ end }}
         {{ if .ProblemPtr.Concepts }}
         <h2 class="section-title mt-6">Concepts</h2>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -116,11 +116,19 @@ window.MathJax = {
             {{ $gridClass = "grid-cols-4" }}
         {{ end }}
 
-        <div class="grid gap-x-4 gap-y-1 {{ $gridClass }}">
+        <div class="grid gap-x-4 gap-y-2 {{ $gridClass }}">
             {{ range $index, $option := $enLV.MetaData.Options }}
-            <div class="flex items-baseline">
+            <div class="flex items-start">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap"><span class="!text-ink [&_*]:!text-ink">{{- $option -}}</span>{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-800 [&_*]:!text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1">
+                    <div class="whitespace-pre-wrap !text-ink [&_*]:!text-ink">{{ $option }}</div>
+                    {{- if and $.RegionalLangCode $regLV -}}
+                    {{- $regOptions := $regLV.MetaData.Options -}}
+                    {{- if lt $index (len $regOptions) }}
+                    <div class="whitespace-pre-wrap mt-1 !text-gray-800 [&_*]:!text-gray-800">{{ index $regOptions $index }}</div>
+                    {{- end -}}
+                    {{- end }}
+                </div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -97,7 +97,7 @@ window.MathJax = {
         <div class="flex-1 pl-5">
             <div>{{ $enLV.MetaData.Question }}</div>
             {{ if and .RegionalLangCode $regLV }}
-            <div class="mt-1 !text-gray-500 [&_*]:!text-gray-500">{{ $regLV.MetaData.Question }}</div>
+            <div class="mt-1 !text-gray-800 [&_*]:!text-gray-800">{{ $regLV.MetaData.Question }}</div>
             {{ end }}
         </div>
     </div>
@@ -120,7 +120,7 @@ window.MathJax = {
             {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-500 [&_*]:!text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-800 [&_*]:!text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -95,7 +95,7 @@ window.MathJax = {
     <div class="flex items-baseline mb-2">
         <div class="w-6 font-semibold">Q{{ .Counter }}.</div>
         <div class="flex-1 pl-5">
-            <div>{{ $enLV.MetaData.Question }}</div>
+            <div class="!text-ink [&_*]:!text-ink">{{ $enLV.MetaData.Question }}</div>
             {{ if and .RegionalLangCode $regLV }}
             <div class="mt-1 !text-gray-800 [&_*]:!text-gray-800">{{ $regLV.MetaData.Question }}</div>
             {{ end }}
@@ -120,7 +120,7 @@ window.MathJax = {
             {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-800 [&_*]:!text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1 whitespace-pre-wrap"><span class="!text-ink [&_*]:!text-ink">{{- $option -}}</span>{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-800 [&_*]:!text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -90,7 +90,7 @@ window.MathJax = {
         <div class="flex-1 pl-5">
             <div>{{ $enLV.MetaData.Question }}</div>
             {{ if and .RegionalLangCode $regLV }}
-            <div class="mt-1 text-gray-800">{{ $regLV.MetaData.Question }}</div>
+            <div class="mt-1 !text-gray-500">{{ $regLV.MetaData.Question }}</div>
             {{ end }}
         </div>
     </div>
@@ -113,7 +113,7 @@ window.MathJax = {
             {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="text-gray-800 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -97,7 +97,7 @@ window.MathJax = {
         <div class="flex-1 pl-5">
             <div>{{ $enLV.MetaData.Question }}</div>
             {{ if and .RegionalLangCode $regLV }}
-            <div class="mt-1 !text-gray-500">{{ $regLV.MetaData.Question }}</div>
+            <div class="mt-1 !text-gray-500 [&_*]:!text-gray-500">{{ $regLV.MetaData.Question }}</div>
             {{ end }}
         </div>
     </div>
@@ -120,7 +120,7 @@ window.MathJax = {
             {{ range $index, $option := $enLV.MetaData.Options }}
             <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
-                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
+                <div class="flex-1 whitespace-pre-wrap">{{- $option -}}{{- if and $.RegionalLangCode $regLV -}}{{- $regOptions := $regLV.MetaData.Options -}}{{- if lt $index (len $regOptions) -}}<span class="!text-gray-500 [&_*]:!text-gray-500 ml-2">{{ index $regOptions $index }}</span>{{- end -}}{{- end -}}</div>
             </div>
             {{ end }}
         </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -7,7 +7,9 @@ window.MathJax = {
       // render at the same size as single-line equations, not shrunk by TeX's textstyle rules.
       MathJax.startup.document.inputJax[0].preFilters.add(({math}) => {
         if (!math.display) {
-          math.math = '\\displaystyle{' + math.math + '}';
+          // Closing brace goes on its own line so a stray unescaped '%' in the
+          // source (which starts a TeX comment through end-of-line) can't eat it.
+          math.math = '\\displaystyle{' + math.math + '\n}';
         }
       });
       return MathJax.startup.defaultPageReady().then(() => {


### PR DESCRIPTION
Merges the following PRs from `main` into `release`:
- #174 — 🐛 Fix test duration showing 0 on edit screen for JEE Advanced tests
- #171 — 🌐 Install regional PDF fonts, fix bilingual PDF colors/MCQ layout, problem-page language toggle, and PDF math rendering