### PR TITLE
🌐 Add per-language test instructions + 2 issue fixes: Pdf option alignment & prevent re-download on back

### DIFF
--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -946,6 +946,56 @@ func currentInstructionsMap(test *models.Test, rule *models.TestRule) map[string
 	return m
 }
 
+// ResolvedTestInstructions is the English + regional instructions text to render in a
+// test's PDF, for a given RegionalLangCode (empty if no regional language was requested).
+type ResolvedTestInstructions struct {
+	English  template.HTML
+	Regional template.HTML
+}
+
+// resolveTestInstructions decides which instructions a test's PDF should show. If the test
+// has any instructions of its own (legacy or per-language), it owns its instructions outright
+// — resolved purely from the test, with no cascade, so a language missing from the test's own
+// data renders blank rather than silently picking up the rule's default. Only when the test
+// has no instructions at all does it cascade to the matching SubjectRule (for single-subject
+// tests) and then the TestRule's own default, for every language.
+func resolveTestInstructions(test *models.Test, rule *models.TestRule, regionalLangCode string) ResolvedTestInstructions {
+	if test == nil {
+		return ResolvedTestInstructions{}
+	}
+
+	hasOwnInstructions := test.TypeParams.Instructions != "" || len(test.TypeParams.InstructionLangVersions) > 0
+	if hasOwnInstructions {
+		return ResolvedTestInstructions{
+			English:  models.ResolveInstructions(test.TypeParams.Instructions, test.TypeParams.InstructionLangVersions, "en"),
+			Regional: models.ResolveInstructions(test.TypeParams.Instructions, test.TypeParams.InstructionLangVersions, regionalLangCode),
+		}
+	}
+	if rule == nil {
+		return ResolvedTestInstructions{}
+	}
+
+	if rule.Config.SingleSubject && len(test.TypeParams.Subjects) > 0 {
+		subjectId := test.TypeParams.Subjects[0].SubjectID
+		for _, subjectRule := range rule.Config.Subjects {
+			if subjectRule.SubjectID != subjectId {
+				continue
+			}
+			if subjectRule.Instructions != "" || len(subjectRule.InstructionLangVersions) > 0 {
+				return ResolvedTestInstructions{
+					English:  models.ResolveInstructions(subjectRule.Instructions, subjectRule.InstructionLangVersions, "en"),
+					Regional: models.ResolveInstructions(subjectRule.Instructions, subjectRule.InstructionLangVersions, regionalLangCode),
+				}
+			}
+		}
+	}
+
+	return ResolvedTestInstructions{
+		English:  models.ResolveInstructions(rule.Config.Instructions, rule.Config.InstructionLangVersions, "en"),
+		Regional: models.ResolveInstructions(rule.Config.Instructions, rule.Config.InstructionLangVersions, regionalLangCode),
+	}
+}
+
 func (h *TestsHandler) AddTestModal(responseWriter http.ResponseWriter, request *http.Request) {
 	var data dto.AddTestDialogData
 
@@ -1030,17 +1080,18 @@ func (h *TestsHandler) DownloadPdf(responseWriter http.ResponseWriter, request *
 	tmplPath := filepath.Join(constants.GetHtmlFolderPath(), pdfTemplate)
 	sharedTmplPath := filepath.Join(constants.GetHtmlFolderPath(), pdfSharedTemplate)
 	tmpl, err := template.New(pdfTemplate).Funcs(template.FuncMap{
-		"getName":        getTestName,
-		"add":            utils.Add,
-		"labels":         optionLabels,
-		"dict":           utils.Dict,
-		"capitalize":     utils.Capitalize,
-		"getSectionName": views.GetSectionName,
-		"stringToInt":    utils.StringToInt,
-		"trim":           strings.TrimSpace,
-		"isEmptyHTML":    utils.IsEmptyHTML,
-		"getChapterName": getProblemChapterName,
-		"langName":       utils.LangName,
+		"getName":                 getTestName,
+		"add":                     utils.Add,
+		"labels":                  optionLabels,
+		"dict":                    utils.Dict,
+		"capitalize":              utils.Capitalize,
+		"getSectionName":          views.GetSectionName,
+		"stringToInt":             utils.StringToInt,
+		"trim":                    strings.TrimSpace,
+		"isEmptyHTML":             utils.IsEmptyHTML,
+		"getChapterName":          getProblemChapterName,
+		"langName":                utils.LangName,
+		"resolveTestInstructions": resolveTestInstructions,
 	}).ParseFiles(sharedTmplPath, tmplPath)
 	if err != nil {
 		http.Error(responseWriter, "Template parsing error: "+err.Error(), http.StatusInternalServerError)

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -501,7 +501,7 @@ func (h *TestsHandler) renderLangModal(responseWriter http.ResponseWriter, reque
 	}
 	if len(regionalLangs) == 0 {
 		if action == "download" {
-			fmt.Fprintf(responseWriter, `<script>window.open('%s', '_blank');</script>`, baseURL)
+			fmt.Fprintf(responseWriter, `<script>window.open('%s', '_blank');document.getElementById('download-modal-container').innerHTML='';</script>`, baseURL)
 		} else {
 			fmt.Fprintf(responseWriter, `<script>copyToClipboard(window.location.origin+'%s');document.getElementById('download-modal-container').innerHTML='';</script>`, baseURL)
 		}

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -598,6 +598,8 @@ func (h *TestsHandler) AddTest(responseWriter http.ResponseWriter, request *http
 		"toJson":                   utils.ToJson,
 		"getParentId":              getParentSubjectId,
 		"currentYear":              utils.GetCurrentYearLast2Digits,
+		"defaultInstructionsMap":   defaultInstructionsMap,
+		"currentInstructionsMap":   currentInstructionsMap,
 	}, baseTemplate, addTestTemplate, problemTypeOptionsTemplate, testTypeOptionsTemplate, testChipEditorTemplate,
 		addTestDestSubjectRowTemplate, addTestDestSubtypeRowTemplate, addTestDestProblemRowTemplate, chipBoxCellTemplate,
 		testInstructionsModalTemplate, editorTemplate)
@@ -810,6 +812,8 @@ func (h *TestsHandler) EditTest(responseWriter http.ResponseWriter, request *htt
 		"toJson":                   utils.ToJson,
 		"getParentId":              getParentSubjectId,
 		"currentYear":              utils.GetCurrentYearLast2Digits,
+		"defaultInstructionsMap":   defaultInstructionsMap,
+		"currentInstructionsMap":   currentInstructionsMap,
 	}, baseTemplate, addTestTemplate, problemTypeOptionsTemplate, testTypeOptionsTemplate, testChipEditorTemplate,
 		addTestDestSubjectRowTemplate, addTestDestSubtypeRowTemplate, addTestDestProblemRowTemplate, chipBoxCellTemplate,
 		testInstructionsModalTemplate, editorTemplate)
@@ -905,6 +909,41 @@ func (h *TestsHandler) ArchiveTest(responseWriter http.ResponseWriter, request *
 
 func getTestName(t models.Test, lang string) string {
 	return t.GetNameByLang(lang)
+}
+
+// defaultInstructionsMap returns the test rule's instructions per language code, omitting
+// languages with no content. Used to prefill the instructions modal and to detect whether
+// a test has customized instructions away from the rule's default.
+func defaultInstructionsMap(rule *models.TestRule) map[string]string {
+	m := map[string]string{}
+	if rule == nil {
+		return m
+	}
+	for _, code := range utils.LangCodes() {
+		if v := models.ResolveInstructions(rule.Config.Instructions, rule.Config.InstructionLangVersions, code); v != "" {
+			m[code] = string(v)
+		}
+	}
+	return m
+}
+
+// currentInstructionsMap returns the test's own instructions per language, falling back to
+// the test rule's default for any language the test hasn't overridden yet.
+func currentInstructionsMap(test *models.Test, rule *models.TestRule) map[string]string {
+	m := map[string]string{}
+	for _, code := range utils.LangCodes() {
+		v := ""
+		if test != nil {
+			v = string(models.ResolveInstructions(test.TypeParams.Instructions, test.TypeParams.InstructionLangVersions, code))
+		}
+		if v == "" && rule != nil {
+			v = string(models.ResolveInstructions(rule.Config.Instructions, rule.Config.InstructionLangVersions, code))
+		}
+		if v != "" {
+			m[code] = v
+		}
+	}
+	return m
 }
 
 func (h *TestsHandler) AddTestModal(responseWriter http.ResponseWriter, request *http.Request) {
@@ -1252,6 +1291,8 @@ func (h *TestsHandler) CopyTest(responseWriter http.ResponseWriter, request *htt
 		"toJson":                   utils.ToJson,
 		"getParentId":              getParentSubjectId,
 		"currentYear":              utils.GetCurrentYearLast2Digits,
+		"defaultInstructionsMap":   defaultInstructionsMap,
+		"currentInstructionsMap":   currentInstructionsMap,
 	}, baseTemplate, addTestTemplate, problemTypeOptionsTemplate, testTypeOptionsTemplate, testChipEditorTemplate,
 		addTestDestSubjectRowTemplate, addTestDestSubtypeRowTemplate, addTestDestProblemRowTemplate, chipBoxCellTemplate,
 		testInstructionsModalTemplate, editorTemplate)

--- a/internal/models/test.go
+++ b/internal/models/test.go
@@ -37,6 +37,38 @@ type ResTypeParams struct {
 	ChapterID    *int16        `json:"chapter_id,omitempty"`
 	Subjects     []ResSubject  `json:"subjects,omitempty"`
 	Instructions template.HTML `json:"instructions,omitempty"`
+	// InstructionLangVersions is the source of truth going forward, and includes an "en"
+	// entry alongside any regional ones. Instructions above is kept in sync for now so
+	// older consumers still work; once everything reads from the array it can be dropped.
+	InstructionLangVersions []InstructionLangVersion `json:"instruction_lang_versions,omitempty"`
+}
+
+// InstructionLangVersion holds one language's instructions text, including English.
+type InstructionLangVersion struct {
+	LangCode     string        `json:"lang_code"`
+	Instructions template.HTML `json:"instructions"`
+}
+
+// FindInstructionLangVersion returns the version matching langCode, or nil if absent.
+func FindInstructionLangVersion(versions []InstructionLangVersion, langCode string) *InstructionLangVersion {
+	for i := range versions {
+		if versions[i].LangCode == langCode {
+			return &versions[i]
+		}
+	}
+	return nil
+}
+
+// ResolveInstructions looks up langCode in versions; if not found, falls back to the
+// legacy singular field for "en" only (covers rows not yet migrated to the array).
+func ResolveInstructions(legacy template.HTML, versions []InstructionLangVersion, langCode string) template.HTML {
+	if v := FindInstructionLangVersion(versions, langCode); v != nil {
+		return v.Instructions
+	}
+	if langCode == "en" {
+		return legacy
+	}
+	return ""
 }
 
 type ResSubject struct {

--- a/internal/models/test_rule.go
+++ b/internal/models/test_rule.go
@@ -9,17 +9,19 @@ type TestRule struct {
 }
 
 type Config struct {
-	Subjects      []SubjectRule `json:"subjects"`
-	Duration      int16         `json:"duration"`
-	MarkingScheme MarkingScheme `json:"marking_scheme"`
-	Instructions  template.HTML `json:"instructions"`
-	SingleSubject bool          `json:"single_subject,omitempty"`
+	Subjects                []SubjectRule            `json:"subjects"`
+	Duration                int16                    `json:"duration"`
+	MarkingScheme           MarkingScheme            `json:"marking_scheme"`
+	Instructions            template.HTML            `json:"instructions"`
+	InstructionLangVersions []InstructionLangVersion `json:"instruction_lang_versions,omitempty"`
+	SingleSubject           bool                     `json:"single_subject,omitempty"`
 }
 
 type SubjectRule struct {
-	SubjectID    int8          `json:"subject_id"`
-	Rules        RuleDetails   `json:"rules"`
-	Instructions template.HTML `json:"instructions,omitempty"`
+	SubjectID               int8                     `json:"subject_id"`
+	Rules                   RuleDetails              `json:"rules"`
+	Instructions            template.HTML            `json:"instructions,omitempty"`
+	InstructionLangVersions []InstructionLangVersion `json:"instruction_lang_versions,omitempty"`
 }
 
 type RuleDetails struct {

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -319,12 +319,7 @@
         initProblemTagsSection(mainTagsRoot);
 
         // --- Language tabs ---
-        const SUPPORTED_LANGUAGES = [
-            { code: 'en', label: 'English' },
-            { code: 'hi', label: 'Hindi' },
-            { code: 'gu', label: 'Gujarati' },
-            { code: 'ta', label: 'Tamil' },
-        ];
+        const SUPPORTED_LANGUAGES = window.SUPPORTED_LANGUAGES;
         let activeLang = 'en';
         const enabledLangs = new Set(['en'
             {{ if $prefill }}

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -190,14 +190,6 @@
             hx-on::before-request='if (event.target === this) createTest(event, {{$id}}, {{$subtype}}, {{$curriculumGrades}}, {{index .TestPtr.ExamIDs 0}})'
         {{ end }}>
 
-        {{ $defaultInstructions := "" }}
-        {{ if and .TestRule .TestRule.Config.Instructions }}
-            {{ $defaultInstructions = printf "%s" .TestRule.Config.Instructions }}
-        {{ end }}
-        {{ $existingInstructions := "" }}
-        {{ if .TestPtr.TypeParams.Instructions }}
-            {{ $existingInstructions = printf "%s" .TestPtr.TypeParams.Instructions }}
-        {{ end }}
         <div class="flex items-center justify-between">
             <label class="font-semibold">Select Test Code</label>
             <button type="button" id="test-instructions-link"
@@ -262,10 +254,10 @@
                 {{end}}
             </select>
         </div>
-        <input type="hidden" id="test-instructions"
-            value='{{ if $existingInstructions }}{{ $existingInstructions }}{{ else }}{{ $defaultInstructions }}{{ end }}'>
-        <input type="hidden" id="test-instructions-default-from-rule"
-            value='{{ $defaultInstructions }}'>
+        <input type="hidden" id="test-instructions-current-store"
+            value='{{ currentInstructionsMap .TestPtr .TestRule | toJson }}'>
+        <input type="hidden" id="test-instructions-default-store"
+            value='{{ defaultInstructionsMap .TestRule | toJson }}'>
         {{ template "test_instructions_modal" }}
 
         <div class="flex items-center gap-2">
@@ -473,8 +465,9 @@
                     if (firstSubjectRow) {
                         const subjectId = parseInt(firstSubjectRow.id.replace("subject-", ""), 10);
                         const subjectRule = testRule.config.subjects.find(s => s.subject_id === subjectId);
-                        if (subjectRule?.instructions) {
-                            applySubjectInstructions(subjectRule.instructions);
+                        const subjectInstructionsMap = buildInstructionsLangMap(subjectRule);
+                        if (Object.keys(subjectInstructionsMap).length > 0) {
+                            applySubjectInstructions(subjectInstructionsMap);
                         }
                     }
                 }
@@ -1073,7 +1066,8 @@
         }
         // Only persist instructions when they differ from the test-rule default (omit to let the rule apply; avoids redundant storage).
         if (shouldIncludeTestInstructionsInPayload()) {
-            typeParams.instructions = getCurrentInstructions();
+            typeParams.instruction_lang_versions = Object.entries(getCurrentInstructionsMap())
+                .map(([lang_code, instructions]) => ({ lang_code, instructions }));
         }
 
         return {
@@ -1094,21 +1088,38 @@
         };
     }
 
-    function applySubjectInstructions(instructionsHtml) {
-        const currentInstructions = getCurrentInstructions().trim();
-        const defaultFromRule = (document.getElementById('test-instructions-default-from-rule')?.value || "").trim();
+    // Builds a {lang_code: instructions} map from a test-rule object that carries the legacy
+    // "instructions" field and/or the "instruction_lang_versions" array (works for both the
+    // rule-level config and a single subject rule).
+    function buildInstructionsLangMap(obj) {
+        const map = {};
+        if (obj?.instructions) {
+            map['en'] = obj.instructions;
+        }
+        obj?.instruction_lang_versions?.forEach(v => {
+            if (v?.lang_code) {
+                map[v.lang_code] = v.instructions || '';
+            }
+        });
+        return map;
+    }
 
-        // Only update if the user hasn't manually overridden the instructions
-        if (currentInstructions === defaultFromRule) {
-            document.getElementById('test-instructions').value = instructionsHtml;
-            document.getElementById('test-instructions-default-from-rule').value = instructionsHtml;
+    function sortedMapJson(map) {
+        const sorted = {};
+        Object.keys(map).sort().forEach(k => { sorted[k] = map[k]; });
+        return JSON.stringify(sorted);
+    }
+
+    function applySubjectInstructions(instructionsMap) {
+        // Only update if the user hasn't manually overridden the instructions in any language
+        if (sortedMapJson(getCurrentInstructionsMap()) === sortedMapJson(getDefaultInstructionsMap())) {
+            setCurrentInstructionsMap(instructionsMap);
+            setDefaultInstructionsMap(instructionsMap);
         }
     }
 
     function shouldIncludeTestInstructionsInPayload() {
-        const current = (getCurrentInstructions() || "").trim();
-        const defaultFromRule = (document.getElementById('test-instructions-default-from-rule')?.value || "").trim();
-        return current !== defaultFromRule;
+        return sortedMapJson(getCurrentInstructionsMap()) !== sortedMapJson(getDefaultInstructionsMap());
     }
 
     function buildAllSubjectsJson() {

--- a/web/html/src_problem_row.html
+++ b/web/html/src_problem_row.html
@@ -49,8 +49,8 @@
             // For single-subject tests, apply per-subject instructions when a new subject row is created
             const subjectRule = testRule?.config?.subjects?.find(s => s.subject_id === subjectId);
             const newSubjectInstructions = (testRule?.config?.single_subject && subjectProblemRows.length === 0)
-                ? (subjectRule?.instructions ?? "")
-                : "";
+                ? buildInstructionsLangMap(subjectRule)
+                : {};
 
             // Hook a one-time global listener that just closes over this specific button's data
             const handler = createAfterRequestHandler(difficulty, insertAfterId, questionsTableBody, resolve, newSubjectInstructions);
@@ -100,7 +100,7 @@
                 initSortableForSections();
                 updateSubjectArrowStates();
 
-                if (newSubjectInstructions && typeof applySubjectInstructions === "function") {
+                if (Object.keys(newSubjectInstructions).length > 0 && typeof applySubjectInstructions === "function") {
                     applySubjectInstructions(newSubjectInstructions);
                 }
             }

--- a/web/html/test_instructions_modal.html
+++ b/web/html/test_instructions_modal.html
@@ -11,8 +11,23 @@
             </button>
         </div>
 
+        <div class="mb-1">
+            <div class="nav nav-tabs" id="instructionsLangTabs"></div>
+        </div>
+
         <div id="test-instructions-editor-wrapper" class="flex-1 overflow-y-auto">
-            {{ template "editor" }}
+            <div class="lang-content" data-lang="en">
+                {{ template "editor" }}
+            </div>
+            <div class="lang-content hidden" data-lang="hi">
+                {{ template "editor" }}
+            </div>
+            <div class="lang-content hidden" data-lang="gu">
+                {{ template "editor" }}
+            </div>
+            <div class="lang-content hidden" data-lang="ta">
+                {{ template "editor" }}
+            </div>
         </div>
 
         <div class="mt-4 flex justify-end gap-3">
@@ -30,48 +45,173 @@
 <script src="/web/static/js/editor.js"></script>
 <script>
     (function () {
+        const SUPPORTED_LANGUAGES = window.SUPPORTED_LANGUAGES;
+
         const wrapper = document.getElementById("test-instructions-editor-wrapper");
-        if (window.initializeRichTextEditors && wrapper) {
-            window.initializeRichTextEditors(wrapper);
+        const langTabsEl = document.getElementById("instructionsLangTabs");
+
+        let activeLang = 'en';
+        const enabledLangs = new Set(['en']);
+        const initializedLangs = new Set();
+
+        function getInstructionsEditor(langCode) {
+            return wrapper?.querySelector(`.lang-content[data-lang="${langCode}"] .editor`);
         }
-    })();
 
-    function getCurrentInstructions() {
-        const hiddenInput = document.getElementById("test-instructions");
-        return hiddenInput?.value || "";
-    }
-
-    function getInstructionsEditor() {
-        const wrapper = document.getElementById("test-instructions-editor-wrapper");
-        return wrapper?.querySelector(".editor");
-    }
-
-    function openInstructionsModal() {
-        const modal = document.getElementById("test-instructions-modal");
-        const editor = getInstructionsEditor();
-        const initialInstructions = getCurrentInstructions() || "";
-
-        if (editor) {
-            editor.innerHTML = initialInstructions;
-            if (typeof renderMath === "function") {
-                renderMath(editor);
+        function initLangEditor(langCode) {
+            if (initializedLangs.has(langCode) || !window.initializeRichTextEditors) {
+                return;
             }
-            editor.focus();
+            const container = wrapper.querySelector(`.lang-content[data-lang="${langCode}"]`);
+            if (container) {
+                window.initializeRichTextEditors(container);
+                initializedLangs.add(langCode);
+            }
         }
 
-        modal.classList.remove("hidden");
-    }
+        function switchLangEditors(langCode) {
+            wrapper.querySelectorAll('.lang-content').forEach(el => {
+                el.classList.toggle('hidden', el.dataset.lang !== langCode);
+            });
+            initLangEditor(langCode);
+        }
 
-    function closeInstructionsModal() {
-        const modal = document.getElementById("test-instructions-modal");
-        modal.classList.add("hidden");
-    }
+        function renderLangTabs() {
+            langTabsEl.innerHTML = '';
+            SUPPORTED_LANGUAGES.forEach(({ code, label }) => {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'nav-link' + (code === activeLang ? ' active' : '');
+                btn.dataset.lang = code;
+                btn.addEventListener('click', () => {
+                    if (code === activeLang) return;
+                    if (code !== 'en' && !enabledLangs.has(code)) {
+                        enabledLangs.add(code);
+                    }
+                    activeLang = code;
+                    switchLangEditors(code);
+                    renderLangTabs();
+                });
 
-    function saveInstructionsModal() {
-        const hiddenInput = document.getElementById("test-instructions");
-        const editor = getInstructionsEditor();
-        hiddenInput.value = editor ? getEditorHtml(editor) : "";
-        closeInstructionsModal();
-    }
+                if (code === 'en') {
+                    btn.textContent = label + ' *';
+                } else {
+                    const isEnabled = enabledLangs.has(code);
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.checked = isEnabled;
+                    checkbox.title = `Include ${label}`;
+                    checkbox.style.marginRight = '6px';
+                    checkbox.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        if (checkbox.checked) {
+                            enabledLangs.add(code);
+                            activeLang = code;
+                            switchLangEditors(code);
+                        } else {
+                            enabledLangs.delete(code);
+                            if (activeLang === code) {
+                                activeLang = 'en';
+                                switchLangEditors('en');
+                            }
+                        }
+                        renderLangTabs();
+                    });
+                    btn.appendChild(checkbox);
+                    btn.appendChild(document.createTextNode(label));
+
+                    if (!isEnabled) {
+                        btn.style.opacity = '0.5';
+                    }
+                }
+
+                langTabsEl.appendChild(btn);
+            });
+        }
+
+        initLangEditor('en');
+        renderLangTabs();
+
+        // --- Backing stores (hidden inputs rendered by add_test.html hold the source of truth) ---
+
+        function readMapStore(elementId) {
+            const el = document.getElementById(elementId);
+            try {
+                return JSON.parse(el?.value || "{}") || {};
+            } catch (e) {
+                return {};
+            }
+        }
+
+        function writeMapStore(elementId, map) {
+            const el = document.getElementById(elementId);
+            if (el) {
+                el.value = JSON.stringify(map);
+            }
+        }
+
+        window.getCurrentInstructionsMap = function () {
+            return readMapStore("test-instructions-current-store");
+        };
+
+        window.setCurrentInstructionsMap = function (map) {
+            writeMapStore("test-instructions-current-store", map);
+        };
+
+        window.getDefaultInstructionsMap = function () {
+            return readMapStore("test-instructions-default-store");
+        };
+
+        window.setDefaultInstructionsMap = function (map) {
+            writeMapStore("test-instructions-default-store", map);
+        };
+
+        // --- Modal lifecycle ---
+
+        window.openInstructionsModal = function () {
+            const modal = document.getElementById("test-instructions-modal");
+            const current = getCurrentInstructionsMap();
+
+            enabledLangs.clear();
+            enabledLangs.add('en');
+            SUPPORTED_LANGUAGES.forEach(({ code }) => {
+                if (code !== 'en' && (current[code] || "").trim()) {
+                    enabledLangs.add(code);
+                }
+            });
+            activeLang = 'en';
+
+            SUPPORTED_LANGUAGES.forEach(({ code }) => {
+                const editor = getInstructionsEditor(code);
+                if (editor) {
+                    editor.innerHTML = current[code] || "";
+                    if (typeof renderMath === "function") {
+                        renderMath(editor);
+                    }
+                }
+            });
+
+            switchLangEditors('en');
+            renderLangTabs();
+            modal.classList.remove("hidden");
+            getInstructionsEditor('en')?.focus();
+        };
+
+        window.closeInstructionsModal = function () {
+            document.getElementById("test-instructions-modal").classList.add("hidden");
+        };
+
+        window.saveInstructionsModal = function () {
+            const updated = {};
+            SUPPORTED_LANGUAGES.forEach(({ code }) => {
+                if (!enabledLangs.has(code)) return;
+                const editor = getInstructionsEditor(code);
+                updated[code] = editor ? getEditorHtml(editor) : "";
+            });
+
+            setCurrentInstructionsMap(updated);
+            closeInstructionsModal();
+        };
+    })();
 </script>
 {{ end }}

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -48,10 +48,10 @@ window.MathJax = {
 {{ if $instructions.English }}
 <div class="border border-black p-4 mb-5">
     <h3 class="text-base font-semibold mb-2">Instructions:</h3>
-    {{ $instructions.English }}
+    <div class="!text-ink [&_*]:!text-ink">{{ $instructions.English }}</div>
     {{ if $instructions.Regional }}
     <hr class="my-3 border-black">
-    {{ $instructions.Regional }}
+    <div class="!text-gray-800 [&_*]:!text-gray-800">{{ $instructions.Regional }}</div>
     {{ end }}
 </div>
 {{ end }}

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -111,7 +111,7 @@ window.MathJax = {
 
         <div class="grid gap-x-4 gap-y-2 {{ $gridClass }}">
             {{ range $index, $option := $enLV.MetaData.Options }}
-            <div class="flex items-start">
+            <div class="flex items-baseline">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
                 <div class="flex-1">
                     <div class="whitespace-pre-wrap !text-ink [&_*]:!text-ink">{{ $option }}</div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -35,24 +35,15 @@ window.MathJax = {
 {{ end }}
 
 {{ define "pdf_test_meta" }}
-{{ $instructions := .TestPtr.TypeParams.Instructions }}
-{{ if and (not $instructions) .TestRule }}
-    {{ if and .TestRule.Config.SingleSubject .TestPtr.TypeParams.Subjects }}
-        {{ $subjectId := (index .TestPtr.TypeParams.Subjects 0).SubjectID }}
-        {{ range .TestRule.Config.Subjects }}
-            {{ if eq .SubjectID $subjectId }}
-                {{ $instructions = .Instructions }}
-            {{ end }}
-        {{ end }}
-    {{ end }}
-    {{ if not $instructions }}
-        {{ $instructions = .TestRule.Config.Instructions }}
-    {{ end }}
-{{ end }}
-{{ if $instructions }}
+{{ $instructions := resolveTestInstructions .TestPtr .TestRule .RegionalLangCode }}
+{{ if $instructions.English }}
 <div class="border border-black p-4 mb-5">
     <h3 class="text-base font-semibold mb-2">Instructions:</h3>
-    {{ $instructions }}
+    {{ $instructions.English }}
+    {{ if $instructions.Regional }}
+    <hr class="my-3 border-black">
+    {{ $instructions.Regional }}
+    {{ end }}
 </div>
 {{ end }}
 

--- a/web/static/js/constants.js
+++ b/web/static/js/constants.js
@@ -1,3 +1,11 @@
 window.CHAPTERS_LOADED_KEY = "chaptersLoaded";
 window.TESTS_LOADED_KEY = "testsLoaded";
 window.TESTS_VIEW_LOADED_KEY = "testsViewLoaded";
+
+// Languages with a per-language editor tab on the problem and test-instructions forms.
+window.SUPPORTED_LANGUAGES = [
+    { code: 'en', label: 'English' },
+    { code: 'hi', label: 'Hindi' },
+    { code: 'gu', label: 'Gujarati' },
+    { code: 'ta', label: 'Tamil' },
+];


### PR DESCRIPTION
## Summary
- ✍️ Add per-language editors for test instructions (English mandatory, regional languages toggleable) in the add/edit/copy test flows
- 📄 Render regional-language instructions in generated PDFs, cascading test → subject rule → rule default, with legacy English-only fallback for un-migrated tests
- 🎨 Match regional instructions font color to the regional problem text styling in PDFs
- Bonus fixes: 
  -  🐛 Clear the download-modal container after triggering a PDF download, so HTMX no longer re-fires a stale download script when navigating back to the test list
  -  🎯 Center-align MCQ option labels with the option's first line in PDFs (handles taller first lines, e.g. equations)

## Test plan
- [x] Add a new test, fill in English + at least one regional language instruction, save, and confirm both persist on reopen
- [x] Edit an existing (pre-feature) test with only legacy English instructions and confirm it still loads/saves correctly
- [x] Copy a test and confirm per-language instructions carry over
- [ ] Generate a "questions" and a "questions with answers" PDF for a test with regional instructions and confirm regional text renders with correct styling
- [x] From the test list, download a PDF, click into a test, then navigate back — confirm the PDF does not re-download
- [x] Generate a PDF for an MCQ with a multi-line option whose first line contains an equation, and confirm the option label sits level with that first line instead of above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)