### PR TITLE
🧹 Drop dead curriculum/grade/topic IDs from test & problem fetches

### DIFF
--- a/internal/dto/problem_dto.go
+++ b/internal/dto/problem_dto.go
@@ -8,8 +8,3 @@ type ProblemData struct {
 	TopicPtr   *models.Topic
 	ChapterPtr *models.Chapter
 }
-
-type CopyProblemModalData struct {
-	ProblemID          string
-	SourceCurriculumID string
-}

--- a/internal/handlers/problem_handler.go
+++ b/internal/handlers/problem_handler.go
@@ -23,7 +23,7 @@ import (
 const problemsKey = "problems"
 
 const problemsEndPoint = "problems"
-const problemEndPoint = "resource/problem/%d/%s"
+const problemEndPoint = "resource/problem/%d"
 const searchProblemsEndPoint = "problems/search"
 const testsContainingProblemsEndPoint = "resources/tests-containing-problems"
 const batchProblemsEndPoint = "resources/problems/batch"
@@ -102,7 +102,7 @@ func (h *ProblemsHandler) GetProblem(responseWriter http.ResponseWriter, request
 func (h *ProblemsHandler) getProblem(urlValues url.Values) (*models.Problem, int, error) {
 	problemIdStr := urlValues.Get("id")
 	problemId := utils.StringToInt(problemIdStr)
-	endPointWithId := fmt.Sprintf(problemEndPoint, problemId, urlValues.Get(QUERY_PARAM_CURRICULUM_ID))
+	endPointWithId := fmt.Sprintf(problemEndPoint, problemId)
 
 	// In problemEndPoint problem id is already included in path segment, hence passing blank as first argument
 	selectedProblemPtr, err := h.problemsService.GetObject("",
@@ -164,7 +164,7 @@ func (h *ProblemsHandler) GetTopicProblems(responseWriter http.ResponseWriter, r
 		return
 	}
 
-	queryParams := fmt.Sprintf("?"+QUERY_PARAM_CURRICULUM_ID+"=%s&topic_id=%d", urlValues.Get(CURRICULUM_DROPDOWN_NAME), topicId)
+	queryParams := fmt.Sprintf("?topic_id=%d", topicId)
 	if urlValues.Has(includeParagraphSiblingsParam) {
 		queryParams += "&" + includeParagraphSiblingsParam + "=" + urlValues.Get(includeParagraphSiblingsParam)
 	}
@@ -508,31 +508,19 @@ func (h *ProblemsHandler) LoadMoveProblems(responseWriter http.ResponseWriter, r
 
 func (h *ProblemsHandler) LoadCopyProblemDialog(responseWriter http.ResponseWriter, request *http.Request) {
 	problemIdStr := request.URL.Query().Get("id")
-	sourceCurriculumIdStr := request.URL.Query().Get(QUERY_PARAM_CURRICULUM_ID)
-	if problemIdStr == "" || sourceCurriculumIdStr == "" {
-		http.Error(responseWriter, "Missing problem ID or curriculum ID", http.StatusBadRequest)
+	if problemIdStr == "" {
+		http.Error(responseWriter, "Missing problem ID", http.StatusBadRequest)
 		return
 	}
 
-	data := dto.CopyProblemModalData{
-		ProblemID:          problemIdStr,
-		SourceCurriculumID: sourceCurriculumIdStr,
-	}
-	views.ExecuteTemplate(copyProblemModalTemplate, responseWriter, data, nil)
+	views.ExecuteTemplate(copyProblemModalTemplate, responseWriter, problemIdStr, nil)
 }
 
 func (h *ProblemsHandler) CopyProblem(responseWriter http.ResponseWriter, request *http.Request) {
 	urlValues := request.URL.Query()
 
-	sourceCurriculumIdStr := urlValues.Get("source_curriculum_id")
-	if sourceCurriculumIdStr == "" {
-		http.Error(responseWriter, "Missing source curriculum ID", http.StatusBadRequest)
-		return
-	}
-
 	problemQuery := url.Values{}
 	problemQuery.Set("id", urlValues.Get("id"))
-	problemQuery.Set(QUERY_PARAM_CURRICULUM_ID, sourceCurriculumIdStr)
 
 	selectedProblemPtr, code, err := h.getProblem(problemQuery)
 	if err != nil {

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -61,7 +61,7 @@ const questionPaperWithAnswersTemplate = "question_paper_with_answers.html"
 const answerSolutionSheetTemplate = "answer_sheet.html"
 const pdfSharedTemplate = "test_pdf_shared.html"
 
-const testProblemsEndPoint = "resource/test/%d/problems?" + QUERY_PARAM_CURRICULUM_ID + "=%s"
+const testProblemsEndPoint = "resource/test/%d/problems"
 const testRulesEndPoint = "test-rule"
 
 const testsKey = "tests"
@@ -436,14 +436,6 @@ func (h *TestsHandler) getTest(responseWriter http.ResponseWriter, request *http
 		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching test: %v", err)
 	}
 
-	curriculumId, err := utils.StringToIntType[int16](urlVals.Get(QUERY_PARAM_CURRICULUM_ID))
-	if err == nil {
-		gradeId, err := utils.StringToIntType[int8](urlVals.Get("grade_id"))
-		if err == nil {
-			selectedTestPtr.SetCurriculumGrade(curriculumId, gradeId)
-		}
-	}
-
 	// Fill subject names in test
 	h.fillSubjectNames(responseWriter, selectedTestPtr)
 
@@ -476,8 +468,7 @@ func (h *TestsHandler) fillSubjectNames(responseWriter http.ResponseWriter, test
 
 func (h *TestsHandler) GetDownloadModal(responseWriter http.ResponseWriter, request *http.Request) {
 	urlVals := request.URL.Query()
-	baseURL := fmt.Sprintf("/download-pdf?id=%s&curriculum_id=%s&grade_id=%s&type=%s",
-		urlVals.Get("id"), urlVals.Get(QUERY_PARAM_CURRICULUM_ID), urlVals.Get("grade_id"), urlVals.Get("type"))
+	baseURL := fmt.Sprintf("/download-pdf?id=%s&type=%s", urlVals.Get("id"), urlVals.Get("type"))
 	h.renderLangModal(responseWriter, request, baseURL, "Download PDF", "Download", "download")
 }
 
@@ -546,7 +537,7 @@ func (h *TestsHandler) getTestProblems(responseWriter http.ResponseWriter, reque
 	testIdStr := urlVals.Get("id")
 	testId := utils.StringToInt(testIdStr)
 
-	endPointWithId := fmt.Sprintf(testProblemsEndPoint, testId, urlVals.Get(QUERY_PARAM_CURRICULUM_ID))
+	endPointWithId := fmt.Sprintf(testProblemsEndPoint, testId)
 	problems, err := h.problemsService.GetList(endPointWithId, problemsKey, false, true)
 
 	if err != nil {
@@ -671,7 +662,7 @@ func (h *TestsHandler) AddQuestionToTest(responseWriter http.ResponseWriter, req
 	problemIdStr := request.FormValue("id")
 	problemId := utils.StringToInt(problemIdStr)
 
-	endPointWithId := fmt.Sprintf(problemEndPoint, problemId, request.FormValue("curriculum-id"))
+	endPointWithId := fmt.Sprintf(problemEndPoint, problemId)
 
 	// In problemEndPoint problem id is already included in path segment, hence passing blank as first argument
 	problemPtr, err := h.problemsService.GetObject("",

--- a/internal/handlers/test_service_api.go
+++ b/internal/handlers/test_service_api.go
@@ -45,7 +45,7 @@ func (h *TestsHandler) GetTestsJSON(responseWriter http.ResponseWriter, request 
 // GetAssembledTestJSON returns a single test with all its problems inlined — the input
 // contract for quiz-backend ingest. It reuses the same resolution the PDF/detail views use
 // (getTest + getTestProblems), so the assembled shape stays in lockstep with what the CMS
-// renders. Query params: id (test id), curriculum_id, grade_id.
+// renders. Query params: id (test id).
 func (h *TestsHandler) GetAssembledTestJSON(responseWriter http.ResponseWriter, request *http.Request) {
 	if request.URL.Query().Get("id") == "" {
 		http.Error(responseWriter, "id is required", http.StatusBadRequest)

--- a/internal/models/test.go
+++ b/internal/models/test.go
@@ -112,29 +112,6 @@ func (test *Test) GetNameByLang(langCode string) string {
 	return ""
 }
 
-func (test *Test) SetCurriculumGrade(curriculumID int16, gradeID int8) {
-	newPair := CurriculumGrade{
-		CurriculumID: curriculumID,
-		GradeID:      gradeID,
-	}
-
-	// If nil or empty, initialize with the new pair
-	if len(test.CurriculumGrades) == 0 {
-		test.CurriculumGrades = []CurriculumGrade{newPair}
-		return
-	}
-
-	// Check if the pair already exists
-	for _, cg := range test.CurriculumGrades {
-		if cg.CurriculumID == curriculumID && cg.GradeID == gradeID {
-			return // Already exists, do nothing
-		}
-	}
-
-	// Append if not found
-	test.CurriculumGrades = append(test.CurriculumGrades, newPair)
-}
-
 func (t *Test) DisplaySubtype() string {
 	switch t.Subtype {
 	case "chapter_test":

--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -987,10 +987,9 @@
                 
                 } else {
                     if (isEditPage && sessionStorage.getItem(REFRESH_PROBLEM_ON_BACK_KEY)) {
-                        const curriculumId = document.getElementById("curriculum-dropdown").value;
                         sessionStorage.setItem(
                             REFRESH_PROBLEM_URL_KEY,
-                            `/problem?id=${problemId}&curriculum_id=${curriculumId}`
+                            `/problem?id=${problemId}`
                         );
                         sessionStorage.removeItem(REFRESH_PROBLEM_ON_BACK_KEY);
                     }

--- a/web/html/add_test_search_row.html
+++ b/web/html/add_test_search_row.html
@@ -1,6 +1,6 @@
 {{range .Tests}}
 <div id="search-row-{{.ID}}" class="p-2 hover:bg-bg-card-alt cursor-pointer" hx-target="#searched-test-results"
-    hx-get="/api/test/subjectwise-problems?id={{.ID}}&curriculum_id={{(index .CurriculumGrades 0).CurriculumID}}&grade_id={{(index .CurriculumGrades 0).GradeID}}"
+    hx-get="/api/test/subjectwise-problems?id={{.ID}}"
     hx-indicator="#searched-test-loader, #searched-test-results" hx-trigger="click" hx-ext="addSelectedIds"
     hx-on::before-request="selectSuggestion(this.id, '{{.Code}} — {{ (index .Name 0).Resource }}')">
     {{.Code}} — {{ (index .Name 0).Resource }}

--- a/web/html/copy_problem_modal.html
+++ b/web/html/copy_problem_modal.html
@@ -9,8 +9,7 @@
 
         <form id="copy-problem-form" class="space-y-6" hx-disabled-elt="#copy-problem-btn">
 
-            <input type="hidden" name="id" value="{{.ProblemID}}">
-            <input type="hidden" name="source_curriculum_id" value="{{.SourceCurriculumID}}">
+            <input type="hidden" name="id" value="{{.}}">
 
             <div class="grid grid-cols-3 gap-4">
 

--- a/web/html/dest_problem_row.html
+++ b/web/html/dest_problem_row.html
@@ -5,8 +5,8 @@
     data-skill-ids="{{joinInt16 .SkillIDs ","}}" data-difficulty="{{$difficulty}}" data-chapter-id="{{.ChapterID}}" data-mathjax="true"
     class="cursor-move">
     <td class="p-2">{{if $.SrNo}}{{$.SrNo}}{{end}}</td>
-    <td class="p-2 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" 
-        hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body" hx-push-url="true">
+    <td class="p-2 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}"
+        hx-get="/problem?id={{.ID}}" hx-target="body" hx-push-url="true">
         {{ .Code }}</a></td>
     <td class="p-2 text-center">
         <select class="border border-border rounded-sm px-2 py-1 text-sm bg-bg-card"

--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -14,7 +14,7 @@
         {{ end }}
         <div class="flex space-x-4 ml-auto pr-4">
             <button class="action-button"
-                hx-get="/problems/edit-problem?id={{.ProblemPtr.ID}}&curriculum_id={{.ProblemPtr.CurriculumID}}&topic_id={{.ProblemPtr.TopicID}}"
+                hx-get="/problems/edit-problem?id={{.ProblemPtr.ID}}"
                 hx-on::before-request="sessionStorage.setItem(REFRESH_PROBLEM_ON_BACK_KEY, '1')"
                 hx-target="body" hx-push-url="true" title="Edit problem">
                 <i class="fa-solid fa-pen"></i>

--- a/web/html/search_problem_row.html
+++ b/web/html/search_problem_row.html
@@ -2,19 +2,19 @@
 <tr class="border-b">
     <!-- hx-params="none" is added to prevent extra query parameters (curriculum-dropdown
          and subject-dropdown) going from its parent topic_problems.html file's problemTableBody -->
-    <td class="p-2 text-center whitespace-nowrap text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
-            hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-params="none" hx-target="body"
+    <td class="p-2 text-center whitespace-nowrap text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}"
+            hx-get="/problem?id={{.ID}}" hx-params="none" hx-target="body"
             hx-push-url="true">{{.Code}}
         </a></td>
     <td class="p-2 overflow-hidden text-ellipsis">{{(.GetLangVersion "en").MetaData.Question}}</td>
     <td class="p-2 text-center space-x-4 whitespace-nowrap">
         <button class="action-button"
-            hx-get="/problems/edit-problem?id={{.ID}}&curriculum_id={{.CurriculumID}}&topic_id={{.TopicID}}"
+            hx-get="/problems/edit-problem?id={{.ID}}"
             hx-params="none" hx-target="body" hx-push-url="true">
             <i class="fa-solid fa-pen"></i>
         </button>
         <button class="action-button"
-            hx-get="/topic/copy-problem-dialog?id={{.ID}}&curriculum_id={{.CurriculumID}}"
+            hx-get="/topic/copy-problem-dialog?id={{.ID}}"
             hx-params="none" hx-target="body" hx-swap="beforeend" hx-push-url="true" title="Copy Problem">
             <i class="fa-solid fa-copy"></i>
         </button>

--- a/web/html/src_problem_row.html
+++ b/web/html/src_problem_row.html
@@ -1,13 +1,13 @@
 {{ define "src_problem_row" }}
 {{ range . }}
 <tr class="border-b">
-    <td class="p-2 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" 
-        hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body" hx-push-url="true">{{.Code}}
+    <td class="p-2 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}"
+        hx-get="/problem?id={{.ID}}" hx-target="body" hx-push-url="true">{{.Code}}
     </a></td>
     <td class="p-2">{{(.GetLangVersion "en").MetaData.Question}}</td>
     <td class="p-2 text-center"><button class="px-2 bg-success text-white rounded-sm" data-id="{{.ID}}"
             data-subject="{{.Subject.ID}}" data-subtype="{{.Subtype}}" data-difficulty="{{.DifficultyLevel}}"
-            data-curriculum="{{.CurriculumID}}" data-subject-parent="{{if .Subject.ParentID}}{{.Subject.ParentID}}{{end}}" 
+            data-subject-parent="{{if .Subject.ParentID}}{{.Subject.ParentID}}{{end}}"
             hx-on:click="addQuestionToTest(this)">+</button>
     </td>
 </tr>
@@ -61,7 +61,6 @@
                 swap: "delete",
                 values: {
                     "id": dataset.id,
-                    "curriculum-id": dataset.curriculum,
                     "subject-exists": subjectProblemRows.length > 0,
                     "subtype-exists": subtypeProblemRows.length > 0,
                     "insert-after-id": insertAfterId,

--- a/web/html/test.html
+++ b/web/html/test.html
@@ -34,7 +34,7 @@
                     <th class="w-auto">Text</th>
                 </tr>
             </thead>
-            <tbody hx-get="/api/test/problems?id={{$.TestPtr.ID}}&curriculum_id={{(index $.TestPtr.CurriculumGrades 0).CurriculumID}}&subject_id={{$subject.SubjectID}}"
+            <tbody hx-get="/api/test/problems?id={{$.TestPtr.ID}}&subject_id={{$subject.SubjectID}}"
                 hx-trigger="load" data-mathjax="true" hx-on::after-swap="onSubjectLoaded()">
                 <!-- Rows will be dynamically inserted here -->
             </tbody>

--- a/web/html/test_problem_row.html
+++ b/web/html/test_problem_row.html
@@ -2,8 +2,8 @@
 <tr class="border-b hover:bg-bg-card-alt text-center">
     <!-- add is a custom function registered in test_handler.go -->
     <td class="w-16 py-2 px-4">{{ add $index 1 }}</td>
-    <td class="w-32 px-4 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
-            hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body"
+    <td class="w-32 px-4 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}"
+            hx-get="/problem?id={{.ID}}" hx-target="body"
             hx-push-url="true">{{.Code}}</a>
     </td>
     <td class="w-auto px-4 text-left">

--- a/web/html/test_row.html
+++ b/web/html/test_row.html
@@ -1,7 +1,4 @@
 {{ range . }}
-{{ $curriculumGrade := (index .CurriculumGrades 0) }}
-{{ $curriculumId := $curriculumGrade.CurriculumID }}
-{{ $gradeId := $curriculumGrade.GradeID }}
 <tr class="border-b border-border/40 hover:bg-bg-hover transition-colors">
     <td class="py-4 px-6">{{.Code}}</td>
     <td class="px-6 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/test?id={{.ID}}"
@@ -14,32 +11,32 @@
     <td class="text-center space-x-4 whitespace-nowrap">
         <!-- target is kept body instead of #content, because using #content as target will not work when
          directly edit url is entered in browser -->
-        <button class="action-button" hx-get="/tests/edit-test?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}"
+        <button class="action-button" hx-get="/tests/edit-test?id={{.ID}}"
             hx-target="body" hx-push-url="true">
             <i class="fa-solid fa-pen"></i>
         </button>
         <a class="action-button cursor-pointer" title="Download Questions PDF"
-            hx-get="/tests/download-modal?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions"
+            hx-get="/tests/download-modal?id={{.ID}}&type=questions"
             hx-target="#download-modal-container" hx-swap="innerHTML">
             <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q</span>
         </a>
         <a class="action-button cursor-pointer" title="Download Answers PDF"
-            hx-get="/tests/download-modal?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=answers"
+            hx-get="/tests/download-modal?id={{.ID}}&type=answers"
             hx-target="#download-modal-container" hx-swap="innerHTML">
             <i class="fa-solid fa-download"></i><span class="text-xs ml-1">A</span>
         </a>
         <a class="action-button cursor-pointer" title="Download Questions with Answers PDF"
-            hx-get="/tests/download-modal?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions_with_answers"
+            hx-get="/tests/download-modal?id={{.ID}}&type=questions_with_answers"
             hx-target="#download-modal-container" hx-swap="innerHTML">
             <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q+A</span>
         </a>
             
         <a class="action-button cursor-pointer" title="Copy Link"
-            hx-get="/tests/copy-link-modal?id={{.ID}}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}"
+            hx-get="/tests/copy-link-modal?id={{.ID}}"
             hx-target="#download-modal-container" hx-swap="innerHTML">
             <i class="fa-solid fa-link"></i>
         </a>
-        <button class="action-button" hx-get="/tests/copy-test?id={{.ID}}&curriculum_id={{$curriculumId}}"
+        <button class="action-button" hx-get="/tests/copy-test?id={{.ID}}"
             hx-target="body" title="Copy Test" hx-push-url="true">
             <i class="fa-solid fa-copy"></i>
         </button>

--- a/web/html/test_search_row.html
+++ b/web/html/test_search_row.html
@@ -43,31 +43,31 @@
                 <td class="text-center space-x-4 whitespace-nowrap" rowspan="{{ $total }}">
                     <!-- target is kept body instead of #content, because using #content as target will not work when
                     directly edit url is entered in browser -->
-                    <button class="action-button" hx-get="/tests/edit-test?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}"
+                    <button class="action-button" hx-get="/tests/edit-test?id={{ $test.ID }}"
                         hx-target="body" hx-push-url="true">
                         <i class="fa-solid fa-pen"></i>
                     </button>
                     <a class="action-button cursor-pointer" title="Download Questions PDF"
-                        hx-get="/tests/download-modal?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions"
+                        hx-get="/tests/download-modal?id={{ $test.ID }}&type=questions"
                         hx-target="#download-modal-container" hx-swap="innerHTML">
                         <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q</span>
                     </a>
                     <a class="action-button cursor-pointer" title="Download Answers PDF"
-                        hx-get="/tests/download-modal?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=answers"
+                        hx-get="/tests/download-modal?id={{ $test.ID }}&type=answers"
                         hx-target="#download-modal-container" hx-swap="innerHTML">
                         <i class="fa-solid fa-download"></i><span class="text-xs ml-1">A</span>
                     </a>
                     <a class="action-button cursor-pointer" title="Download Questions with Answers PDF"
-                        hx-get="/tests/download-modal?id={{ $test.ID }}&curriculum_id={{$curriculumId}}&grade_id={{$gradeId}}&type=questions_with_answers"
+                        hx-get="/tests/download-modal?id={{ $test.ID }}&type=questions_with_answers"
                         hx-target="#download-modal-container" hx-swap="innerHTML">
                         <i class="fa-solid fa-download"></i><span class="text-xs ml-1">Q+A</span>
                     </a>
                     <a class="action-button cursor-pointer" title="Copy Link"
-                        hx-get="/tests/copy-link-modal?id={{ $test.ID }}&curriculum_id={{ $curriculumId }}&grade_id={{ $gradeId }}"
+                        hx-get="/tests/copy-link-modal?id={{ $test.ID }}"
                         hx-target="#download-modal-container" hx-swap="innerHTML">
                         <i class="fa-solid fa-link"></i>
                     </a>
-                    <button class="action-button" hx-get="/tests/copy-test?id={{ $test.ID }}&curriculum_id={{$curriculumId}}"
+                    <button class="action-button" hx-get="/tests/copy-test?id={{ $test.ID }}"
                         hx-target="body" title="Copy Test" hx-push-url="true">
                         <i class="fa-solid fa-copy"></i>
                     </button>

--- a/web/html/topic_problem_row.html
+++ b/web/html/topic_problem_row.html
@@ -6,19 +6,18 @@
 
     <!-- hx-params="none" is added to prevent extra query parameters (curriculum-dropdown
          and subject-dropdown) going from its parent topic_problems.html file's problemTableBody -->
-    <td class="p-2 text-center whitespace-nowrap text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
-            hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-params="none" hx-target="body"
+    <td class="p-2 text-center whitespace-nowrap text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}"
+            hx-get="/problem?id={{.ID}}" hx-params="none" hx-target="body"
             hx-push-url="true">{{.Code}}
         </a></td>
     <td class="p-2 overflow-hidden text-ellipsis">{{(.GetLangVersion "en").MetaData.Question}}</td>
     <td class="p-2 text-center space-x-4 whitespace-nowrap">
-        <button class="action-button"
-            hx-get="/problems/edit-problem?id={{.ID}}&curriculum_id={{.CurriculumID}}&topic_id={{.TopicID}}"
+        <button class="action-button" hx-get="/problems/edit-problem?id={{.ID}}"
             hx-params="none" hx-target="body" hx-push-url="true">
             <i class="fa-solid fa-pen"></i>
         </button>
         <button class="action-button"
-            hx-get="/topic/copy-problem-dialog?id={{.ID}}&curriculum_id={{.CurriculumID}}"
+            hx-get="/topic/copy-problem-dialog?id={{.ID}}"
             hx-params="none" hx-target="body" hx-swap="beforeend" hx-push-url="true" title="Copy Problem">
             <i class="fa-solid fa-copy"></i>
         </button>


### PR DESCRIPTION
## 🎯 Why
The db-service endpoints for fetching a problem and a test's problems no longer require `curriculum_id`. That one API change left a long tail of query params, hidden form fields, and JS wiring across the CMS that were still being built and forwarded for no reason — some were simple pass-throughs, but a couple were subtler:
- `getTest()`'s `SetCurriculumGrade` fallback was either a silent no-op (when the caller sent the same curriculum/grade the test already had) or a way for a caller to inject an **unvalidated** curriculum/grade pair into the `GetAssembledTestJSON` service contract used by `af_lms`/`quiz-creator`.
- `topic_id` on `/problems/edit-problem` was never actually read by its handler — dead since the day it was added.
- `source_curriculum_id` on the copy-problem flow *was* genuinely used (forwarded into `getProblem()`'s request to fetch the correct curriculum-scoped problem) — it only went dead as a consequence of dropping `curriculum_id` from that request in this same change.

## 🔧 What changed
- 🗑️ Removed `curriculum_id` from the `getProblem()` and `getTestProblems()` request paths to db-service (`problemEndPoint`, `testProblemsEndPoint`).
- 🧵 Traced and stripped the now-redundant `curriculum_id`/`grade_id`/`topic_id` params from every downstream caller: `/problem`, `/problems/edit-problem`, `/topic/copy-problem-dialog`, `/topic/copy-problem`, `/tests/edit-test`, `/tests/download-modal`, `/tests/copy-link-modal`, `/tests/copy-test`, `/api/test/subjectwise-problems`, `/api/test/problems`.
- ✂️ Deleted `Test.SetCurriculumGrade` and its call site — no remaining consumers, and it could let external callers fabricate curriculum/grade data in the JSON test-assembly API.
- 🧽 Removed `CopyProblemModalData` (down to a single field, so passing the string directly matches the existing `LoadMoveProblems` pattern) and the associated `source_curriculum_id` plumbing end-to-end (handler, DTO, template, callers).
- 📝 Updated `GetAssembledTestJSON`'s doc comment to reflect it only takes `id` now.

## ✅ Test plan
- [x] Manually verify: view a test, edit a test, download a test PDF, copy a test/link, add/edit/copy a problem, subjectwise problem search in add/edit-test