### PR TITLE
🔗 Link associated test IDs to edit-test screen in the Problem Test Association dialog

### DIFF
--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -954,8 +954,9 @@
                 }
 
             }).then(readResponseOrThrow).then(() => {
-                  // go back to remove add/edit test screen
-                  goBackAfterDelay(0);
+                  // go back to remove add/edit test screen; shows a toast only if there's
+                  // no previous screen to go back to (e.g. edit-test opened in a new tab)
+                  goBackAfterDelay(0, mode === "edit" ? "Test updated successfully" : undefined);
                   if (mode === "new") {
                       // remove add test dialog
                       goBackAfterDelay(0);

--- a/web/html/home.html
+++ b/web/html/home.html
@@ -282,7 +282,7 @@
         });
 
         // Function to go back after delay
-        function goBackAfterDelay(milliseconds) {
+        function goBackAfterDelay(milliseconds, successMessage) {
             var userNavigatedBack = false;  // Flag to track if the user pressed the back button
 
             // Listen for the browser's back button (popstate event)
@@ -292,7 +292,20 @@
 
             setTimeout(function () {
                 if (!userNavigatedBack) {
-                    history.back(); // Go back to the previous state
+                    if (history.length <= 1) {
+                        // Opened as the first page in this tab (e.g. via a target="_blank" link) -
+                        // there's no previous screen to go back to, so close the tab instead.
+                        // If a success message was given, show it as a toast first since the
+                        // tab closing would otherwise give no save feedback.
+                        if (successMessage) {
+                            showToast(successMessage, 'success');
+                            setTimeout(() => window.close(), 800);
+                        } else {
+                            window.close();
+                        }
+                    } else {
+                        history.back(); // Go back to the previous state
+                    }
                 }
             }, milliseconds);
         }

--- a/web/html/problem_test_association_modal.html
+++ b/web/html/problem_test_association_modal.html
@@ -27,7 +27,9 @@
                         <td class="font-mono">{{.ProblemCode}}</td>
                         <td class="font-mono">
                             {{if .Tests}}
-                                {{range $i, $t := .Tests}}{{if $i}}, {{end}}{{$t.TestCode}}{{end}}
+                                {{range $i, $t := .Tests}}{{if $i}}, {{end}}<a
+                                    href="/tests/edit-test?id={{$t.TestID}}" target="_blank" rel="noopener"
+                                    class="text-accent hover:text-accent-hover underline">{{$t.TestCode}}</a>{{end}}
                             {{else}}
                                 <span class="text-ink-muted italic font-sans">No tests found</span>
                             {{end}}


### PR DESCRIPTION
## 🎯 Summary
- 🧩 Test IDs shown in the "Problem Test Associations" dialog are now clickable links that open the test's edit screen in a new tab — so you can remove associated problem from a test before moving it, without losing your place in the dialog
- 🎨 Test code links now have a persistent underline, making them clearly identifiable as links
- 🐛 Fixed a bug where saving a test opened this way (with no back history in its tab) would silently do nothing — `goBackAfterDelay()` now closes the tab and shows a "Saved successfully" toast when there's nowhere to go back to, and falls back to the previous in-app behavior otherwise

## ✅ Test plan
- [x] Open the "Problem Test Associations" dialog for a problem associated with one or more tests — Confirm the test code link is underlined.
- [x] Click a test code — confirm it opens `/tests/edit-test` in a new tab
- [x] Edit and save the test in that new tab — confirm a "Test updated successfully" toast appears and the tab closes
- [x] Edit and save a test reached the normal way (same tab) — confirm it still navigates back as before, with no toast