### PR TITLE
⚡ Stop fetching all topics to load chapters and topic lists

### DIFF
--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -90,39 +90,6 @@ func getChapterName(ch models.Chapter, lang string) string {
 	return ch.GetNameByLang(lang)
 }
 
-func (h *ChaptersHandler) getTopics(responseWriter http.ResponseWriter, chapterPtrs []*models.Chapter) {
-	topics, err := h.topicsService.GetList(handlerutils.TopicsEndPoint+"?limit=5000", handlerutils.TopicsKey, false, false)
-	if err != nil {
-		http.Error(responseWriter, fmt.Sprintf("Error fetching topics: %v", err), http.StatusInternalServerError)
-	} else {
-		*topics = funk.Filter(*topics, func(t *models.Topic) bool {
-			return t.StatusID != constants.StatusArchived
-		}).([]*models.Topic)
-
-		associateTopicsWithChapters(chapterPtrs, *topics)
-	}
-}
-
-func associateTopicsWithChapters(chapterPtrs []*models.Chapter, topicPtrs []*models.Topic) {
-	// Create a map to quickly lookup chapters by their ID
-	chapterPtrsMap := make(map[int16]*models.Chapter)
-
-	// Fill the map with the address of each chapter
-	for _, chapterPtr := range chapterPtrs {
-		chapterPtrsMap[chapterPtr.ID] = chapterPtr
-		// clear topics data, because it will be refilled in next step based on latest data
-		chapterPtr.Topics = chapterPtr.Topics[:0]
-	}
-
-	// Loop through each topic and assign it to the corresponding chapter
-	for _, topicPtr := range topicPtrs {
-		if chapterPtr, exists := chapterPtrsMap[topicPtr.ChapterID]; exists &&
-			topicPtr.HasCurriculumID(chapterPtr.CurriculumID) {
-			chapterPtr.Topics = append(chapterPtr.Topics, topicPtr)
-		}
-	}
-}
-
 func (h *ChaptersHandler) EditChapter(responseWriter http.ResponseWriter, request *http.Request) {
 	selectedChapterPtr, code, err := h.getChapter(request)
 	if err != nil {
@@ -359,7 +326,16 @@ func (h *ChaptersHandler) GetTopics(responseWriter http.ResponseWriter, request 
 	if curriculumId != 0 {
 		localChapter.CurriculumID = curriculumId
 	}
-	h.getTopics(responseWriter, []*models.Chapter{&localChapter})
+
+	queryParams := fmt.Sprintf("?chapter_id=%d", localChapter.ID)
+	topics, err := h.topicsService.GetList(handlerutils.TopicsEndPoint+queryParams, handlerutils.TopicsKey, false, true)
+	if err != nil {
+		http.Error(responseWriter, fmt.Sprintf("Error fetching topics: %v", err), http.StatusInternalServerError)
+		return
+	}
+	localChapter.Topics = funk.Filter(*topics, func(t *models.Topic) bool {
+		return t.StatusID != constants.StatusArchived && t.HasCurriculumID(localChapter.CurriculumID)
+	}).([]*models.Topic)
 
 	sortColumn := urlVals.Get("sortColumn")
 	sortOrder := urlVals.Get("sortOrder")

--- a/internal/handlers/chapter_handler.go
+++ b/internal/handlers/chapter_handler.go
@@ -70,8 +70,6 @@ func (h *ChaptersHandler) GetChapters(responseWriter http.ResponseWriter, reques
 		chapterPtr.CurriculumID = curriculumId
 	}
 
-	h.getTopics(responseWriter, *chapters)
-
 	sortColumn := urlVals.Get("sortColumn")
 	sortOrder := urlVals.Get("sortOrder")
 	sortChapters(*chapters, sortColumn, sortOrder)
@@ -246,7 +244,7 @@ func sortChapters(chapterPtrs []*models.Chapter, sortColumn string, sortOrder st
 		case "2":
 			sortResult = strings.Compare(c1.GetNameByLang("en"), c2.GetNameByLang("en"))
 		case "3":
-			sortResult = int(c1.TopicCount() - c2.TopicCount())
+			sortResult = int(c1.TopicCount - c2.TopicCount)
 		default:
 			sortResult = 0
 		}

--- a/internal/models/chapter.go
+++ b/internal/models/chapter.go
@@ -8,6 +8,7 @@ type Chapter struct {
 	GradeID      int8          `json:"grade_id,omitempty"`
 	SubjectID    int8          `json:"subject_id"`
 	StatusID     int8          `json:"cms_status_id,omitempty"`
+	TopicCount int `json:"topic_count"`
 	/**
 	 * []*Topic is used instead of []Topic so that updates applied in centrally cached Topic objects
 	 * are also visible inside these Topic objects
@@ -28,10 +29,6 @@ func NewChapter(code string, name string, curriculum_id int16, grade_id int8, su
 		GradeID:      grade_id,
 		SubjectID:    subject_id,
 	}
-}
-
-func (chapter Chapter) TopicCount() int8 {
-	return int8(len(chapter.Topics))
 }
 
 func (chapterPtr *Chapter) BuildMap(code string, name string) map[string]any {


### PR DESCRIPTION
## 🎯 Summary
- 🚀 `GetChapters` no longer fetches the full topic list (`limit=5000`) just to count topics per chapter — it now reads a `topic_count` field the db-service API already returns per chapter ([avantifellows/db-service#633](https://github.com/avantifellows/db-service))
- 🔍 The `/api/topics` handler for a chapter's topic list also stops downloading all topics and filtering in memory — it now queries the topic API with a `chapter_id` filter directly, mirroring how `GetChapters` already filters remotely
- 🛑 `/api/topics` also now returns early when the fetch fails, instead of continuing on to render the template after already writing an error response

## ✅ Test plan
- [x] Load the chapters list — confirm topic counts per chapter still display correctly
- [x] Open a chapter and load its topics tab — confirm the topic list still loads correctly
- [x] Force the topics fetch to fail (e.g. bad chapter id) — confirm an error is shown and the template isn't rendered on top of it