### PR TITLE
🖼️ Fix problem image rendering and MCQ option alignment

### DIFF
--- a/input.css
+++ b/input.css
@@ -465,3 +465,29 @@ mjx-container[jax="CHTML"] mjx-math {
 mjx-container[jax="CHTML"] mjx-math:has(mjx-mtable) {
   white-space: nowrap !important;
 }
+
+/* -----------------------------------------------------------------------------
+ * Option row overrides (PDF + the single-problem view) — unlayered so they
+ * beat the items-baseline utility (Tailwind's utilities layer always wins
+ * over @layer components, regardless of selector specificity).
+ * --------------------------------------------------------------------------- */
+
+/*
+ * The option row uses items-baseline so multi-line/equation option text
+ * aligns its first line with the label - correct for text, since that's a
+ * genuine text baseline. A default (non-inline) option image is wrapped in
+ * a floated editor-img-float paragraph with no inline content, so it has
+ * no real baseline either - flexbox synthesizes one from the image's
+ * bottom edge, making the label look bottom-aligned. Fix: render default
+ * option images exactly like an explicitly "inline with text" image (same
+ * properties applyInlineImage() sets in editor-image.js): un-float it so
+ * the paragraph has a genuine inline baseline, positioned identically to
+ * the manual case. Scoped to .option-row so the question image above (which
+ * does rely on floating, with text wrapping beside it) is untouched.
+ */
+.option-row p.editor-img-float img {
+  float: none !important;
+  display: inline-block !important;
+  vertical-align: middle !important;
+  margin: 0 !important;
+}

--- a/input.css
+++ b/input.css
@@ -195,24 +195,24 @@
   /* Image — show pointer to hint it's clickable */
   .editor img { cursor: pointer; }
 
-  /* Floated image: text beside, then full width below image (clearfix on paragraph) */
-  .editor p.editor-img-float,
-  .output p.editor-img-float {
+  /*
+   * Floated image: text beside, then full width below image (clearfix on paragraph).
+   * Not scoped to .editor/.output - this stored HTML also renders on read-only
+   * screens (e.g. the single problem view) that don't wrap content in either class.
+   */
+  p.editor-img-float {
     margin: 0.5em 0;
     overflow: visible;
   }
-  .editor p.editor-img-float::after,
-  .output p.editor-img-float::after {
+  p.editor-img-float::after {
     content: '';
     display: table;
     clear: both;
   }
-  .editor p.editor-img-justify,
-  .output p.editor-img-justify {
+  p.editor-img-justify {
     margin: 0.5em 0;
   }
-  .editor p.editor-img-justify > img,
-  .output p.editor-img-justify > img {
+  p.editor-img-justify > img {
     display: block;
     width: 100%;
     max-width: 100%;

--- a/web/html/problem.html
+++ b/web/html/problem.html
@@ -38,9 +38,9 @@
     <div class="card card-pad" data-mathjax="true">
         {{ if and (eq .ProblemPtr.Subtype "comprehension") .ProblemPtr.Paragraph }}
         <h2 class="section-title">Paragraph</h2>
-        <p class="mt-2 text-ink">
+        <div class="mt-2 text-ink">
             {{ .ProblemPtr.Paragraph.Body }}
-        </p>
+        </div>
         {{ end }}
         <h2 class="section-title{{ if and (eq .ProblemPtr.Subtype "comprehension") .ProblemPtr.Paragraph }} mt-6{{ end }}">Statement / Text</h2>
         {{ range .ProblemPtr.LangVersions }}
@@ -66,9 +66,12 @@
             <h2 class="section-title mt-6">Options</h2>
             <div class="mt-2 rounded-lg border border-border overflow-hidden">
                 {{ range $index, $option := .MetaData.Options }}
-                <div class="flex items-center border-b border-border/40 p-4 last:border-b-0 bg-bg-card">
+                <!-- items-baseline + option-row: aligns the label with the option's first
+                     text line, or with a default (non-inline) image's vertical center via
+                     the .option-row rule in input.css. -->
+                <div class="flex items-baseline option-row border-b border-border/40 p-4 last:border-b-0 bg-bg-card">
                     <span class="mr-6 font-mono font-bold text-accent w-6">{{ printf "%c" (add 65 $index) }}</span>
-                    <p class="text-ink">{{ $option }}</p>
+                    <div class="text-ink">{{ $option }}</div>
                 </div>
                 {{ end }}
             </div>

--- a/web/html/test_pdf_shared.html
+++ b/web/html/test_pdf_shared.html
@@ -118,9 +118,16 @@ window.MathJax = {
             {{ $gridClass = "grid-cols-4" }}
         {{ end }}
 
-        <div class="grid gap-x-4 gap-y-2 {{ $gridClass }}">
+        <!-- items-baseline: without it, sibling options in the same grid row (e.g. A & B)
+             can render at different heights, since each option's own baseline depends on
+             its own content (see .option-row rule in input.css) - this syncs them to a
+             shared baseline per row. -->
+        <div class="grid items-baseline gap-x-4 gap-y-2 {{ $gridClass }}">
             {{ range $index, $option := $enLV.MetaData.Options }}
-            <div class="flex items-start">
+            <!-- items-baseline + option-row: aligns the label with the option's first text
+                 line, or with a default (non-inline) image's vertical center via the
+                 .option-row rule in input.css - see that rule for why. -->
+            <div class="flex items-baseline option-row">
                 <div class="font-semibold mr-2">{{ index labels $index }}</div>
                 <div class="flex-1">
                     <div class="whitespace-pre-wrap !text-ink [&_*]:!text-ink">{{ $option }}</div>


### PR DESCRIPTION
## 🎯 Summary
- 🧹 Single problem screen showing textual question and skills section on right hand side of question image instead of showing below it - The clearfix that makes a paragraph contain a floated image was scoped to `.editor`/`.output` only, so stored problem HTML rendered without either ancestor class (e.g. the single problem view) let the image's float bleed into the next block instead of clearing below it
- 🎯 A default (non-inline) option image had no real text baseline, so the label rendered bottom-aligned (with items-baseline & top aligned with items-start) against it instead of centered like a manually "inline with text" image — it's now rendered with the same inline/`vertical-align:middle` styles so it gets a genuine baseline [Issue no. 40A in [New CMS Problems list](https://docs.google.com/document/d/19oqumbDgXbyU_shhzutPz-FFUuVd6j0D)]
- 📐 Sibling options sharing a PDF grid row (e.g. A & B) could end up at different heights since each one's baseline depended on its own content — the grid now syncs them to a shared per-row baseline [Issue no. 40 in [New CMS Problems list](https://docs.google.com/document/d/19oqumbDgXbyU_shhzutPz-FFUuVd6j0D)]
- 🩹 The single-problem view's paragraph and option wrappers changed from `<p>` to `<div>`: that stored HTML can contain its own block content (e.g. a floated image's `<p class="editor-img-float">`), and nesting a `<p>` inside a `<p>` is invalid HTML — the browser was auto-closing the outer tag early, scattering an option's image and surrounding text into stray siblings that laid out side-by-side instead of stacking

## ✅ Test plan
- [x] View a problem (single-problem screen) whose statement/paragraph has a floated image followed by text — confirm the text renders below the image, not beside it
- [x] View a problem with an MCQ option that has an image only — confirm the label centers against the image, matching how a manually "inline with text" image already looks
- [x] View/generate a PDF for a test with two-column MCQ options where one option's image is a different height than its row sibling — confirm both labels land at the same height
- [x] View a problem with an option containing text before/after an image — confirm the text stacks above/below the image instead of appearing beside it