### PR TITLE
✨🖼️ Rich Text Editor: Image center alignment toolbar option and image dimension display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ terraform/terraform.prod.tfvars
 
 # Local working notes (not for the repo)
 TODO.md
+
+# Screenshots captured while verifying changes — kept locally so they can be
+# attached to a PR, not committed to the repo.
+/verification-screenshots/

--- a/input.css
+++ b/input.css
@@ -284,6 +284,22 @@
     box-sizing: border-box;
     pointer-events: all;
   }
+  .img-resize-dims {
+    display: none;
+    position: absolute;
+    bottom: 6px;
+    right: 6px;
+    padding: 2px 6px;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    white-space: nowrap;
+    color: var(--color-bg-card);
+    background: var(--color-ink);
+    border-radius: 4px;
+    pointer-events: none;
+  }
+  .img-resize-dims.active { display: block; }
+
   .img-resize-nw { top: -5px; left: -5px;   cursor: nw-resize; }
   .img-resize-ne { top: -5px; right: -5px;  cursor: ne-resize; }
   .img-resize-se { bottom: -5px; right: -5px; cursor: se-resize; }

--- a/input.css
+++ b/input.css
@@ -219,6 +219,16 @@
     margin: 0.5em 0;
     float: none;
   }
+  .editor p.editor-img-center,
+  .output p.editor-img-center {
+    margin: 0.5em 0;
+  }
+  .editor p.editor-img-center > img,
+  .output p.editor-img-center > img {
+    display: block;
+    margin: 0.5em auto;
+    float: none;
+  }
 
   /* --- Image editing toolbar (appears above selected image) ----------- */
   .img-edit-toolbar {

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -255,6 +255,7 @@
             <div class="img-resize-handle img-resize-ne" data-dir="ne"></div>
             <div class="img-resize-handle img-resize-se" data-dir="se"></div>
             <div class="img-resize-handle img-resize-sw" data-dir="sw"></div>
+            <div class="img-resize-dims"></div>
         </div>
 
     </div>

--- a/web/html/editor.html
+++ b/web/html/editor.html
@@ -238,6 +238,7 @@
         <!-- Image editing UI (positioned over the editor by JS) -->
         <div class="img-edit-toolbar" role="toolbar" aria-label="Image options">
             <button type="button" data-img-align="left" title="Align Left"><i class="fas fa-align-left"></i></button>
+            <button type="button" data-img-align="center" title="Align Center"><i class="fas fa-align-center"></i></button>
             <button type="button" data-img-align="inline" title="Inline With Text"><i class="fas fa-text-width"></i></button>
             <button type="button" data-img-align="justify" title="Justify"><i class="fas fa-align-justify"></i></button>
             <button type="button" data-img-align="right" title="Align Right"><i class="fas fa-align-right"></i></button>

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -50,6 +50,7 @@ function insertImage(event, editor) {
 function initImageEditing(editor, editorWrapper) {
     const imgToolbar = editorWrapper.querySelector('.img-edit-toolbar');
     const resizeOverlay = editorWrapper.querySelector('.img-resize-overlay');
+    const resizeDims = resizeOverlay?.querySelector('.img-resize-dims');
     if (!imgToolbar || !resizeOverlay) return;
 
     let selectedImg = null;
@@ -68,6 +69,10 @@ function initImageEditing(editor, editorWrapper) {
         const toolbarTop = top - toolbarH - 4;
         imgToolbar.style.top  = (toolbarTop < 0 ? top + iRect.height + 4 : toolbarTop) + 'px';
         imgToolbar.style.left = (iRect.left - wRect.left) + 'px';
+
+        if (resizeDims) {
+            resizeDims.textContent = `${Math.round(iRect.width)} × ${Math.round(iRect.height)}`;
+        }
     }
 
     function selectImage(img) {
@@ -75,6 +80,7 @@ function initImageEditing(editor, editorWrapper) {
         img.classList.add('img-selected');
         resizeOverlay.classList.add('active');
         imgToolbar.classList.add('active');
+        resizeDims?.classList.add('active');
         positionUI(img);
     }
 
@@ -83,6 +89,7 @@ function initImageEditing(editor, editorWrapper) {
         selectedImg = null;
         resizeOverlay.classList.remove('active');
         imgToolbar.classList.remove('active');
+        resizeDims?.classList.remove('active');
     }
 
     editor.addEventListener('click', (e) => {

--- a/web/static/js/editor-image.js
+++ b/web/static/js/editor-image.js
@@ -178,7 +178,7 @@ function initImageEditing(editor, editorWrapper) {
 }
 
 function getImageBlock(img) {
-    return img.closest('.editor-img-float, .editor-img-row, .editor-img-justify');
+    return img.closest('.editor-img-float, .editor-img-row, .editor-img-justify, .editor-img-center');
 }
 
 /** Unwrap legacy flex span so text flows naturally in the paragraph. */
@@ -195,21 +195,53 @@ function flattenTextSpan(block) {
     block.style.flexDirection = '';
 }
 
+/**
+ * Move img (and everything after it in its current parent) into `block`, then
+ * place `block` as a sibling of that parent — instead of nesting `block` inside
+ * it — so an image sitting amid other paragraph text doesn't produce a <p>
+ * nested inside another <p>.
+ */
+function relocateImageIntoBlock(img, editor, block) {
+    const parent = img.parentElement;
+    if (!parent) {
+        block.appendChild(img);
+        return block;
+    }
+
+    if (parent === editor) {
+        editor.insertBefore(block, img);
+        block.appendChild(img);
+        return block;
+    }
+
+    let node = img;
+    while (node) {
+        const next = node.nextSibling;
+        block.appendChild(node);
+        node = next;
+    }
+
+    parent.after(block);
+    if (parent.childNodes.length === 0 && parent.tagName === 'P') {
+        parent.remove();
+    }
+    return block;
+}
+
 function buildFloatBlock(img, align, editor) {
-    const block = document.createElement('p');
+    /* Reuse an existing image block (float/justify/center) in place rather than
+       wrapping a fresh <p> around it, which would nest paragraphs. */
+    let block = getImageBlock(img);
+    if (block) {
+        flattenTextSpan(block);
+        block.style.margin = '';
+    } else {
+        block = document.createElement('p');
+        relocateImageIntoBlock(img, editor, block);
+    }
+
     block.className = 'editor-img-float';
     block.classList.add(align === 'right' ? 'editor-img-right' : 'editor-img-left');
-
-    const parent = img.parentElement;
-    if (parent && parent !== block) {
-        parent.insertBefore(block, img);
-        block.appendChild(img);
-        if (parent !== editor && parent.childNodes.length === 0 && parent.tagName === 'P') {
-            parent.remove();
-        }
-    } else {
-        block.appendChild(img);
-    }
 
     applyFloatStyles(img, align);
     ensureTextAfterImage(img);
@@ -226,18 +258,7 @@ function ensureImageBlock(img, editor) {
     block = document.createElement('p');
     block.className = 'editor-img-float';
     block.style.margin = '0.5em 0';
-
-    const parent = img.parentElement;
-    if (parent === editor) {
-        editor.insertBefore(block, img);
-        block.appendChild(img);
-    } else if (parent) {
-        parent.insertBefore(block, img);
-        block.appendChild(img);
-        if (parent !== editor && parent.childNodes.length === 0 && parent.tagName === 'P') {
-            parent.remove();
-        }
-    }
+    relocateImageIntoBlock(img, editor, block);
 
     return block;
 }
@@ -297,6 +318,26 @@ function applyImageAlign(img, align, editor) {
     if (align === 'inline') {
         applyInlineImage(img);
         placeCaretAfterImage(img);
+        return;
+    }
+
+    if (align === 'center') {
+        clearInlineImageStyles(img);
+        let block = getImageBlock(img);
+        flattenTextSpan(block || img.parentElement);
+
+        if (!block || !block.classList.contains('editor-img-center')) {
+            block = ensureImageBlock(img, editor);
+            block.className = 'editor-img-center';
+            block.style.margin = '0.5em 0';
+        }
+
+        img.style.float = 'none';
+        img.style.display = 'block';
+        img.style.margin = '0.5em auto';
+        if (!img.style.width) {
+            applyImageSize(img, 100);
+        }
         return;
     }
 


### PR DESCRIPTION
## 🎯 What's changed

- 🎯 Added a **Center** alignment option for images in the rich text editor toolbar (alongside left/right/inline/justify)
- 📐 Selecting an image now shows a live **width × height** badge inside its bottom-right corner immediately — and it keeps updating as you resize
- 🐛 Fixed a latent bug where switching an image between block-level alignments (or aligning an image sitting inline within surrounding text) could nest a `<p>` inside another `<p>`, silently corrupting the saved HTML on re-parse

## 🖼️ Screenshots

**Dimension badge shown immediately on selection:**
![Image dimension shown on select](https://github.com/user-attachments/assets/98578358-9e04-48df-b106-111c015dda14)

## ✅ Test plan

- [x] Selected an image → dimension badge appears immediately, positioned inside the bottom-right corner
- [x] Dragged each resize handle (nw/ne/se/sw) → badge updates live and matches the applied size
- [x] Switched an image between center/justify/left/right/inline repeatedly → no duplicate or nested wrapper elements
- [x] Aligned an image sitting inline within surrounding text for the first time → paragraph splits correctly, no nested `<p>`, no lost text
- [x] Preview pane renders center-aligned images correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)