### PR TITLE
🐛 Fix loading spinners broken by the Tailwind v4 upgrade

### DIFF
--- a/input.css
+++ b/input.css
@@ -348,8 +348,18 @@
   }
   #searched-test-results { display: block; }
   #searched-test-results.htmx-request { display: none; }
-  #move-problems-form.htmx-request .btn-text { display: none; }
-  #move-problems-form.htmx-request .btn-loader { display: inline; }
+  #move-problems-form .btn-loader,
+  #move-resources-form .btn-loader {
+    display: none;
+  }
+  #move-problems-form.htmx-request .btn-text,
+  #move-resources-form.htmx-request .btn-text {
+    display: none;
+  }
+  #move-problems-form.htmx-request .btn-loader,
+  #move-resources-form.htmx-request .btn-loader {
+    display: inline;
+  }
 }
 
 /* -----------------------------------------------------------------------------

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -121,7 +121,7 @@
                         <!-- Rows will be dynamically inserted here -->
                     </tbody>
                 </table>
-                <div id="question-bank-loader" class="hidden flex justify-center py-4">
+                <div id="question-bank-loader" class="justify-center py-4">
                     <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
                 </div>                
             </div>
@@ -147,7 +147,7 @@
                             </button>
 
                             <!-- loader -->
-                            <div id="search-btn-loader" class="hidden absolute inset-0 flex items-center justify-center">
+                            <div id="search-btn-loader" class="absolute inset-0 items-center justify-center">
                                 <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
                             </div>
                         </div>
@@ -158,7 +158,7 @@
                          class="hidden absolute left-0 mt-1 border rounded-sm bg-bg-card shadow-sm z-10 w-full">
                     </div>
                 </div>         
-                <div id="searched-test-loader" class="hidden flex justify-center py-4">
+                <div id="searched-test-loader" class="justify-center py-4">
                     <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
                 </div>                                   
                 <div id="searched-test-results" class="mt-4">

--- a/web/html/move_problems_modal.html
+++ b/web/html/move_problems_modal.html
@@ -72,7 +72,7 @@
                     <!-- Normal text -->
                     <span class="btn-text">Move</span>
                     <!-- Loader -->
-                    <span class="btn-loader hidden">Moving…</span>
+                    <span class="btn-loader">Moving…</span>
                 </button>
             </div>
 

--- a/web/html/move_resources_modal.html
+++ b/web/html/move_resources_modal.html
@@ -55,7 +55,7 @@
                 <button id="move-resource-btn" type="submit" disabled
                     class="btn-primary disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-bg-card-alt disabled:text-ink-muted">
                     <span class="btn-text">Move</span>
-                    <span class="btn-loader hidden">Moving…</span>
+                    <span class="btn-loader">Moving…</span>
                 </button>
             </div>
         </form>

--- a/web/html/topic_problems.html
+++ b/web/html/topic_problems.html
@@ -50,7 +50,7 @@
             </tbody>
         </table>
     </div>
-    <div id="topic-problems-loader" class="flex justify-center py-4">
+    <div id="topic-problems-loader" class="justify-center py-4">
         <div class="w-6 h-6 border-4 border-border border-t-accent rounded-full animate-spin"></div>
     </div>
 </div>
@@ -68,6 +68,7 @@
         const subject = document.getElementById('subject-dropdown').value;
         if (!curriculum || !subject) return false;
         htmx.ajax('GET', `/api/topic/problems?topic-dropdown=${topicId}&curriculum-dropdown=${curriculum}&subject-dropdown=${subject}`, {
+            source: '#problemTableBody',
             target: '#problemTableBody',
             swap: 'innerHTML',
         });


### PR DESCRIPTION
## 🎯 Summary

Several htmx loading spinners across the app silently stopped working after the Tailwind v4 migration (`dd9fc7f`) — they either never appeared or, in one case, never disappeared. 🔍

## 🧵 Root cause

- ⚙️ v3 → v4 changed `input.css` from `@tailwind base/components/utilities` to `@import "tailwindcss"`, which declares **real native CSS cascade layers** (`@layer theme, base, components, utilities`).
- 📐 With native layers, **layer order beats selector specificity**. `utilities` is declared last, so any Tailwind utility class (e.g. `hidden`, `flex`) always wins over our `@layer components` htmx-request toggle rules — even though those rules use higher-specificity ID selectors.
- 🕰️ Under v3 there were no real cascade layers, so the higher-specificity ID selector legitimately won. The bug was invisible until now.

## 🛠️ Fixes

- 🔧 Removed the conflicting `hidden`/`flex` utility classes from loader elements that also relied on the `@layer components` toggle rule:
  - Search Tests: search button spinner, searched-test spinner, question-bank spinner (`add_test.html`)
  - Topic detail: topic-problems spinner (`topic_problems.html`)
  - Move Problems / Move Resources modal buttons (`.btn-loader`)
- ➕ Added the missing `#move-resources-form` toggle rule in `input.css` — it only ever existed for `#move-problems-form`, so that modal's spinner had **no** CSS path at all.
- 🧩 Separately found: the topic-problems tab's initial load uses a manual `htmx.ajax()` call with no `source`. Per htmx's own source, that makes indicator resolution fall back to `document.body` instead of the tbody carrying `hx-indicator`, so **no** indicator ever activated for that call. Added `source: '#problemTableBody'` so it resolves like a normal attribute-driven request.

## ✅ Verification

Live-tested against the running dev server with a throwaway Playwright script (not committed): logged in via the `DEV_LOGIN_EMAIL` bypass, opened a real topic's Problems tab, artificially delayed the `/api/topic/problems` response by 1.5s, and polled the loader's computed style.

- ❌ Before: `display: none` for the entire delay (spinner never showed).
- ✅ After: `htmx-request` class present + `display: flex` for the full delay, reverting to `none` once the response landed.

`npm run build:css` was rerun locally to regenerate `output.css` (gitignored, not part of this diff).

## 🧪 Test plan

- [x] Add/Edit Test screen → Search Tests tab → click Search → confirm spinner shows in place of the button, then results appear
- [x] Add/Edit Test screen → Question Bank tab → select a topic → confirm spinner shows while problems load
- [x] Topic detail → Problems tab → confirm spinner shows briefly on initial load
- [x] Topic detail → Problems tab → move a problem to another topic → confirm spinner still shows on refresh
- [x] Move Problems modal → confirm "Moving…" text/spinner shows on submit
- [x] Move Resources modal → confirm "Moving…" text/spinner shows on submit