### PR TITLE
⚡ Fix slow problem-adding in tests + 🧮 Instructions Math button fix

### DIFF
--- a/web/html/add_problem.html
+++ b/web/html/add_problem.html
@@ -1318,34 +1318,7 @@
             });
         }
 
-        // editor.js may still be loading when this inline script runs (common on HTMX body swap)
-        function bootRichTextEditors() {
-            const form = document.querySelector('form.card');
-            if (!form?.querySelector('.container')) return false;
-            if (!window.initializeRichTextEditors) return false;
-            window.initializeRichTextEditors(form);
-            return true;
-        }
-
-        function scheduleEditorBoot() {
-            const boot = () => {
-                if (bootRichTextEditors()) return;
-                const editorScript = document.querySelector('script[src*="editor.js"]');
-                if (editorScript) {
-                    const run = () => { bootRichTextEditors(); };
-                    if (window.initializeRichTextEditors) {
-                        run();
-                    } else {
-                        editorScript.addEventListener('load', run, { once: true });
-                    }
-                } else {
-                    requestAnimationFrame(scheduleEditorBoot);
-                }
-            };
-
-            boot();
-        }
-        scheduleEditorBoot();
+        scheduleEditorBoot(document.querySelector('form.card'));
     })();
 </script>
 {{ end }}

--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -363,7 +363,7 @@
                     <th class="p-2 text-center">Action</th>
                 </tr>
             </thead>
-            <tbody id="questions-table-body" name="questions-table-body">
+            <tbody id="questions-table-body" name="questions-table-body" data-mathjax-manual="true">
                 <!-- if this is for edit/copy test -->
                 {{if .Problems}}
                     {{ $sr := 0 }}

--- a/web/html/home.html
+++ b/web/html/home.html
@@ -15,18 +15,86 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
     <script src="https://unpkg.com/mathlive"></script>
     <script>
+        /**
+         * editor.js (which defines window.initializeRichTextEditors) is loaded per-screen, not
+         * from this base template - on an htmx body swap, its re-inserted <script src> tag loads
+         * asynchronously, so a screen's own inline init script can run before it's ready. This
+         * queue lives here (in the base template, always loaded before any per-screen script)
+         * so scheduleEditorBoot() is always safely callable, and queues the boot request instead
+         * of throwing if editor.js hasn't finished loading yet - editor.js flushes the queue
+         * itself once window.initializeRichTextEditors is defined. Classic async-script-ready-
+         * queue pattern (same idea as window.dataLayer.push in GTM's snippet).
+         */
+        window._editorBootQueue = [];
+        window.scheduleEditorBoot = function (root) {
+            function tryBoot() {
+                if (!root?.querySelector('.container')) return false;
+                if (!window.initializeRichTextEditors) return false;
+                window.initializeRichTextEditors(root);
+                return true;
+            }
+            if (tryBoot()) return;
+            if (window.initializeRichTextEditors) {
+                // editor.js is loaded, but this root's .container isn't in the DOM yet - retry next frame
+                requestAnimationFrame(() => window.scheduleEditorBoot(root));
+            } else {
+                // editor.js hasn't finished loading yet - queue for when it flushes
+                window._editorBootQueue.push(tryBoot);
+            }
+        };
+        window.flushEditorBootQueue = function () {
+            const pending = window._editorBootQueue;
+            window._editorBootQueue = [];
+            pending.forEach((tryBoot) => tryBoot());
+        };
+
         window.MathJax = {
             options: {
                 renderActions: {
                     addSourceTex: [
-                        151,
+                        /**
+                         * Must run AFTER MathJax's own "update" stage (STATE.INSERTED = 200),
+                         * which is what actually swaps the constructed <mjx-container> output
+                         * into the live document (the earlier "typeset" stage, STATE.TYPESET =
+                         * 150, only builds that output detached from the document). Below 200,
+                         * math.typesetRoot exists but isn't attached to the document yet, so
+                         * .closest('.container') always returns null regardless of whether the
+                         * math is really inside an editor or not.
+                         */
+                        201,
                         (doc) => {
+                            /**
+                             * The problem this whole feature fixes: legacy problems had rendered
+                             * MathJax markup (mjx-container) stored instead of \( \) LaTeX, so their
+                             * equations weren't editable on the edit-problem screen. The primary fix
+                             * is the MathML walker in getLatexFromMathJaxContainer() (editor-math.js),
+                             * which reconstructs LaTeX from a math node's assistive MathML - but
+                             * that's a lossy approximation. data-tex is an exact fallback checked
+                             * before the walker, stamped opportunistically (not just on .editor
+                             * content, but also on the .output preview - see renderMath() in
+                             * editor-math.js) since preview-rendered markup can end up back in the
+                             * editor later; having the exact source cached avoids ever needing the
+                             * lossy reconstruction for it. getLatexFromMathJaxContainer() is only
+                             * ever called for math inside a rich-text editor instance (.container,
+                             * which wraps both .editor and .output) - never for read-only display
+                             * areas (Question Bank, Questions Table, problem preview, etc) - so
+                             * data-tex is only useful there; tagging math anywhere else would be
+                             * pointless.
+                             *
+                             * This loop itself still runs over doc.math - every math item ever
+                             * typeset on the whole page across all typesetPromise() calls, not
+                             * just the ones from the call that triggered this one. E.g. on
+                             * add_test.html, which has no editor of its own, adding one problem
+                             * would still walk and re-tag every equation already sitting in the
+                             * left Question Bank and the right Questions Table, every single
+                             * time, without the closest('.container') check below.
+                             */
                             for (const math of doc.math) {
-                                doc.adaptor.setAttribute(math.typesetRoot, 'data-tex', math.math);
+                                const root = math.typesetRoot;
+                                if (!root.closest('.container')) continue;
+                                if (doc.adaptor.getAttribute(root, 'data-tex') === math.math) continue;
+                                doc.adaptor.setAttribute(root, 'data-tex', math.math);
                             }
-                        },
-                        (math, doc) => {
-                            doc.adaptor.setAttribute(math.typesetRoot, 'data-tex', math.math);
                         },
                     ],
                 },
@@ -279,6 +347,31 @@
             }
 
             document.body.addEventListener("htmx:afterSettle", debounceUpdate);
+
+            /**
+             * This app never does a real page reload - navigation is htmx swapping
+             * document.body's content, so window.MathJax (and its internal doc.math list of
+             * every equation ever typeset) is a singleton that lives for the whole tab's
+             * session, not per screen. A body-targeted swap means the whole screen is being
+             * replaced, so clear MathJax's tracking before the old content (and its math) is
+             * removed - otherwise doc.math grows for as long as the tab stays open, and every
+             * later typesetPromise() call keeps paying the cost of walking all of it.
+             *
+             * Two separate hooks are needed: htmx:beforeSwap only fires for a fresh,
+             * request-driven navigation (clicking a link/button). Browser back/forward
+             * restores a screen from htmx's history cache instead, which is a completely
+             * different code path that never fires beforeSwap - htmx:historyRestore is the
+             * event for that one.
+             */
+            document.body.addEventListener("htmx:beforeSwap", (event) => {
+                if (event.detail.target === document.body) {
+                    window.MathJax?.typesetClear?.();
+                }
+            });
+
+            document.addEventListener("htmx:historyRestore", () => {
+                window.MathJax?.typesetClear?.();
+            });
         });
 
         // Function to go back after delay
@@ -312,14 +405,26 @@
                 if ((name === "htmx:afterSwap" || name === "htmx:oobAfterSwap") && window.MathJax) {
                     let targetElement = event.detail.target;
 
+                    /**
+                     * Elements under a [data-mathjax-manual] container (e.g. the growing questions
+                     * table in add_test.html) typeset themselves precisely at the point a row is
+                     * inserted - see addQuestionToTest()/createAfterRequestHandler() in
+                     * src_problem_row.html. Skip them here, otherwise every single row added would
+                     * re-typeset the whole (ever-growing) table via targetElement.parentElement below,
+                     * which gets slower the more rows already exist.
+                     */
+                    if (targetElement.closest("[data-mathjax-manual]")) {
+                        return;
+                    }
+
                     // Check if the target element itself has data-mathjax
                     let hasMathJax = targetElement.hasAttribute("data-mathjax");
-                    
+
                     // Check if any nested elements have data-mathjax
                     if (!hasMathJax) {
                         hasMathJax = targetElement.querySelector('[data-mathjax]') !== null;
                     }
-                    
+
                     // Apply MathJax.typesetPromise() only if at least one element has data-mathjax
                     if (hasMathJax) {
                         /**

--- a/web/html/src_problem_row.html
+++ b/web/html/src_problem_row.html
@@ -97,6 +97,23 @@
                 inheritMarkingScheme(tableBody, newlyInsertedRow);
                 updateTotalMarks();
 
+                // Typeset only the newly inserted row (it's the one marked [data-mathjax-manual]
+                // in add_test.html, so the global mathJaxLoader extension skips it) - re-typesetting
+                // the whole, ever-growing questions table on every single addition is what caused
+                // the slowdown/forced-reflow warnings when adding many problems one by one.
+                //
+                // Deferred a frame: MathJax's own font-metric measurement for the new equation
+                // needs a layout read, which - run synchronously here, right after the DOM writes
+                // above - is exactly what triggers a *forced* reflow console warning, e.g.
+                // "[Violation] Forced reflow while executing JavaScript took 35ms". Running it on
+                // the next frame lets the browser fold that layout work into its normal render
+                // pass instead.
+                if (window.MathJax) {
+                    requestAnimationFrame(() => {
+                        MathJax.typesetPromise([newlyInsertedRow]).catch(console.error);
+                    });
+                }
+
                 initSortableForSections();
                 updateSubjectArrowStates();
 

--- a/web/html/test_instructions_modal.html
+++ b/web/html/test_instructions_modal.html
@@ -30,10 +30,7 @@
 <script src="/web/static/js/editor.js"></script>
 <script>
     (function () {
-        const wrapper = document.getElementById("test-instructions-editor-wrapper");
-        if (window.initializeRichTextEditors && wrapper) {
-            window.initializeRichTextEditors(wrapper);
-        }
+        scheduleEditorBoot(document.getElementById("test-instructions-editor-wrapper"));
     })();
 
     function getCurrentInstructions() {

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -642,3 +642,7 @@ window.initializeRichTextEditors = function (root = document) {
     }
     });
 };
+
+// Process any scheduleEditorBoot() calls that came in while this script was still loading.
+// See window.scheduleEditorBoot in home.html for why the queue itself has to live there.
+window.flushEditorBootQueue?.();


### PR DESCRIPTION
## Summary

- 🐢➡️🚀 **Adding problems to a test was getting progressively slower** the more problems were already added — MathJax was re-typesetting the *entire* (ever-growing) questions table on every single addition instead of just the new row, and a custom render action was re-tagging *every* equation on the page on every typeset call. Both scaled with total problems already added, eventually tripping browser "Forced reflow" console warnings.
- 🧹 Removed that render action's item-level callback — dead code from day one, since nothing in this app ever exercises the per-`MathItem` `rerender()`/`convert()` path that would invoke it.
- 🔄 **MathJax's internal math tracking never reset between screens** — it's a singleton that lives for the whole browser tab (this app never does a real page reload), so it grew across *every* screen visited, not just within one. Now cleared on both forward navigation and browser back/forward.
- 🧮 **Fixed a pre-existing bug**: the Test Instructions editor's toolbar (including the Math button) silently failed to initialize when reached via an htmx navigation, because `editor.js` can finish loading *after* the modal's own init script runs. Extracted the retry-safe boot logic (already used by `add_problem.html`) into a shared, always-callable `scheduleEditorBoot`.

## Test plan

- [x] Open Add/Edit Test, add 15-20+ problems one by one from the Question Bank, and confirm no growing delay / no "Forced reflow" console warnings
- [x] Open Test Instructions modal, insert a math expression via the Math toolbar button, save, reopen — confirm it round-trips correctly as editable LaTeX
- [x] Navigate Tests → Problems → back/forward a few times and confirm no console errors
- [x] Add/Edit Problem screen still boots its rich-text editors correctly (question, options, solution)

## 📄 References

- [New CMS Problems list](https://docs.google.com/document/d/19oqumbDgXbyU_shhzutPz-FFUuVd6j0D) — addresses issues 42 and 43 tracked there

🤖 Generated with [Claude Code](https://claude.com/claude-code)