### PR TITLE
🔀 Reorder left-panel columns + 🧮 fix blank scrollbar for maths problems

### DIFF
--- a/web/html/add_test.html
+++ b/web/html/add_test.html
@@ -107,10 +107,10 @@
 
                 <table class="app-table mt-3 border border-border rounded-lg overflow-hidden">
                     <thead>
-                        <tr>
-                            <th>Code</th>
-                            <th>Question</th>
-                            <th>Action</th>
+                        <tr class="bg-bg-card-alt">
+                            <th class="px-2!">Action</th>
+                            <th class="px-2!">Code</th>
+                            <th class="px-2!">Question</th>
                         </tr>
                     </thead>
                     <tbody id="question-bank" hx-ext="addSelectedIds" hx-get="/api/topic/problems?include_paragraph_siblings=true"

--- a/web/html/add_test_searched.html
+++ b/web/html/add_test_searched.html
@@ -3,12 +3,12 @@
 		<h3 class="text-base font-semibold">Selected Test</h3>
 		<div class="text-sm text-ink-muted">{{.TestPtr.Code}} — {{ (index .TestPtr.Name 0).Resource }}</div>
 	</div>
-	<table class="mt-2 w-full border text-left">
+	<table class="mt-2 w-full border text-left overflow-hidden">
 		<thead>
 			<tr class="bg-bg-card-alt">
+				<th class="p-2">Action</th>
 				<th class="p-2">Code</th>
 				<th class="p-2">Question</th>
-				<th class="p-2">Action</th>
 			</tr>
 		</thead>
 		<tbody data-mathjax="true">

--- a/web/html/src_problem_row.html
+++ b/web/html/src_problem_row.html
@@ -1,15 +1,15 @@
 {{ define "src_problem_row" }}
 {{ range . }}
 <tr class="border-b">
-    <td class="p-2 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" 
-        hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body" hx-push-url="true">{{.Code}}
-    </a></td>
-    <td class="p-2">{{(.GetLangVersion "en").MetaData.Question}}</td>
-    <td class="p-2 text-center"><button class="px-2 bg-success text-white rounded-sm" data-id="{{.ID}}"
+    <td class="px-2! py-2 text-center"><button class="px-2 bg-success text-white rounded-sm" data-id="{{.ID}}"
             data-subject="{{.Subject.ID}}" data-subtype="{{.Subtype}}" data-difficulty="{{.DifficultyLevel}}"
             data-curriculum="{{.CurriculumID}}" data-subject-parent="{{if .Subject.ParentID}}{{.Subject.ParentID}}{{end}}" 
             hx-on:click="addQuestionToTest(this)">+</button>
     </td>
+    <td class="px-2! py-2 text-accent hover:text-accent-hover hover:underline font-medium"><a href="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}"
+        hx-get="/problem?id={{.ID}}&curriculum_id={{.CurriculumID}}" hx-target="body" hx-push-url="true">{{.Code}}
+    </a></td>
+    <td class="px-2! py-2">{{(.GetLangVersion "en").MetaData.Question}}</td>
 </tr>
 
 <script>


### PR DESCRIPTION
## Summary

- 🔀 **Reordered columns** to Action, Code, Question (was Code, Question, Action) in both the Question Bank and Search Tests tabs' tables on the Add/Edit Test screen — shared row markup lives in `src_problem_row.html`, plus each table's own `<thead>`. 
[**Reference**: Issue no. `45` in [New CMS Problems list](https://docs.google.com/document/d/19oqumbDgXbyU_shhzutPz-FFUuVd6j0D)]

- 🧮 **Fixed a horizontal scrollbar that revealed nothing when scrolled**, specific to maths problems in the Search Tests tab. Root cause: MathJax renders a hidden, screen-reader-only MathML copy of every equation (`mjx-assistive-mml`) with `width: auto` — sized to the full equation, just visually clipped to 1px via `clip: rect(...)`. Since the table never clipped its own overflow, that invisible-but-wide box's scrollable overflow escaped the table and inflated the panel's scrollbar. Added `overflow-hidden` to that table (matching the Question Bank table, which already had it) so the invisible overflow stops at the table's own edge.

- 📐 **Fixed a column-spacing mismatch**: Question Bank's cells were rendering with `.app-table`'s `px-6`/`py-3`/`py-4` padding instead of the shared row template's intended spacing, since `.app-table th`/`.app-table td` (a class+element selector) outranks a plain class by CSS specificity. Overrode just the horizontal padding with `px-2!` (leaving `.app-table`'s own vertical rhythm untouched) so column spacing now matches the Search Tests tab, without removing the `app-table` class.

## Test plan

- [x] Open Add/Edit Test → Question Bank tab: confirm column order is Action, Code, Question, and horizontal spacing matches the Search Tests tab
- [x] Open Add/Edit Test → Search Tests tab: confirm column order is Action, Code, Question
- [x] Switch to Search Tests tab, search for and select a test with maths problems: confirm no phantom horizontal scrollbar (or that scrolling always reveals real content, never blank space)
- [x] Confirm Question Bank's vertical row spacing is unchanged from before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)